### PR TITLE
Add support for MUMPS and ToleranceSettings

### DIFF
--- a/doc/sphinx/source/compiling.rst
+++ b/doc/sphinx/source/compiling.rst
@@ -45,3 +45,15 @@ where ``NTHREADS`` is the number of CPU threads available on your computer.
 will go).
 
 
+Building PETSc with MUMPS
+-------------------------
+By far the easiest way of adding MUMPS support to PETSc is by configuring PETSc
+with the flags ``--download-mumps`` and ``--download-scalapack`` (ScaLAPACK is
+a dependency of MUMPS). Thus, you should configure PETSc in a manner similar to
+the following::
+
+    $ ./configure --download-mumps --download-scalapack
+
+If you run into the Fortran error ``Rank mismatch between actual argument at
+(1) and actual argument at (2) (scalar and rank-1)``, add the flag
+``--FFLAGS=-fallow-argument-mismatch`` to the configure line above.

--- a/examples/tolerance/generate.py
+++ b/examples/tolerance/generate.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+#
+# This example shows how to set up a simple CODE-like runaway
+# scenario in DREAM. The simulation uses a constant temperature,
+# density and electric field, and generates a runaway current
+# through the electric field acceleration, demonstrating Dreicer generation.
+# We tweak the convergence tolerance settings for illustration purposes.
+#
+# Run as
+#
+#   $ ./basic.py
+#   $ ../../build/iface/dreami dream_settings.h5
+#
+# ###################################################################
+
+import numpy as np
+import sys
+
+sys.path.append('../../py/')
+
+from DREAM.DREAMSettings import DREAMSettings
+import DREAM.Settings.Equations.HotElectronDistribution as FHot
+import DREAM.Settings.Equations.IonSpecies as Ions
+import DREAM.Settings.Equations.RunawayElectrons as Runaways
+import DREAM.Settings.Solver as Solver
+
+ds = DREAMSettings()
+
+# Physical parameters
+E = 6       # Electric field strength (V/m)
+n = 5e19    # Electron density (m^-3)
+T = 100     # Temperature (eV)
+
+# Grid parameters
+pMax = 1    # maximum momentum in units of m_e*c
+Np   = 300  # number of momentum grid points
+Nxi  = 50   # number of pitch grid points
+tMax = 2e-4 # simulation time in seconds
+Nt   = 20   # number of time steps
+
+# Set E_field
+ds.eqsys.E_field.setPrescribedData(E)
+
+# Set temperature
+ds.eqsys.T_cold.setPrescribedData(T)
+
+# Set ions
+ds.eqsys.n_i.addIon(name='D', Z=1, iontype=Ions.IONS_PRESCRIBED_FULLY_IONIZED, n=n)
+
+# Disable avalanche generation
+ds.eqsys.n_re.avalanche = Runaways.AVALANCHE_MODE_NEGLECT
+
+# Hot-tail grid settings
+ds.hottailgrid.setNxi(Nxi)
+ds.hottailgrid.setNp(Np)
+ds.hottailgrid.setPmax(pMax)
+
+# Set initial hot electron Maxwellian
+ds.eqsys.f_hot.setInitialProfiles(n0=n, T0=T)
+
+# Disable runaway grid
+ds.runawaygrid.setEnabled(False)
+
+# Set up radial grid
+ds.radialgrid.setB0(5)
+ds.radialgrid.setMinorRadius(0.22)
+ds.radialgrid.setNr(1)
+
+# Set solver type
+#ds.solver.setType(Solver.LINEAR_IMPLICIT) # semi-implicit time stepping
+#ds.solver.setLinearSolver(Solver.LINEAR_SOLVER_MUMPS)
+ds.solver.setType(Solver.NONLINEAR)
+ds.solver.tolerance.set('n_re', abstol=1e5, reltol=1e-8)
+#ds.solver.setVerbose(True)
+
+# include otherquantities to save to output
+ds.other.include('fluid')
+
+# Set time stepper
+ds.timestep.setTmax(tMax)
+ds.timestep.setNt(Nt)
+
+ds.output.setTiming(stdout=True, file=True)
+ds.output.setFilename('output.h5')
+
+# Save settings to HDF5 file
+ds.save('dream_settings.h5')
+

--- a/fvm/CMakeLists.txt
+++ b/fvm/CMakeLists.txt
@@ -12,6 +12,7 @@ set(fvm_core
     "${PROJECT_SOURCE_DIR}/fvm/QuantityData.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Solvers/MILU.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Solvers/MIKSP.cpp"
+    "${PROJECT_SOURCE_DIR}/fvm/Solvers/MIMUMPS.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/TimeKeeper.cpp"
 )
 set(fvm_core_headers
@@ -21,6 +22,7 @@ set(fvm_core_headers
     "${PROJECT_SOURCE_DIR}/include/FVM/MatrixInverter.hpp"
     "${PROJECT_SOURCE_DIR}/include/FVM/Solvers/MILU.hpp"
     "${PROJECT_SOURCE_DIR}/include/FVM/Solvers/MIKSP.hpp"
+    "${PROJECT_SOURCE_DIR}/include/FVM/Solvers/MIMUMPS.hpp"
     "${PROJECT_SOURCE_DIR}/include/FVM/Grid/fluxGridType.enum.hpp"
 )
 set(fvm_equation

--- a/fvm/Matrix.cpp
+++ b/fvm/Matrix.cpp
@@ -58,9 +58,9 @@ void Matrix::Construct(
     this->n = n;
 
     MatCreate(PETSC_COMM_WORLD, &(this->petsc_mat));
+    //MatSetType(this->petsc_mat, MATSEQAIJ);
+    MatSetType(this->petsc_mat, MATAIJ);
     MatSetSizes(this->petsc_mat, PETSC_DECIDE, PETSC_DECIDE, m, n);
-
-    MatSetType(this->petsc_mat, MATSEQAIJ);
 
     if ((ierr=MatSeqAIJSetPreallocation(this->petsc_mat, nnz, nnzl)))
         throw MatrixException("Failed to allocate memory for PETSc matrix. Error code: %d", ierr);

--- a/fvm/NormEvaluator.cpp
+++ b/fvm/NormEvaluator.cpp
@@ -14,7 +14,7 @@ using namespace DREAM::FVM;
 /**
  * Constructor.
  */
-NormEvaluator::NormEvaluator(UnknownQuantityHandler *uqh, vector<len_t> &nontrivials)
+NormEvaluator::NormEvaluator(UnknownQuantityHandler *uqh, const vector<len_t> &nontrivials)
     : unknowns(uqh), nontrivials(nontrivials) {
 
     this->nNontrivials = nontrivials.size();

--- a/fvm/UnknownQuantityHandler.cpp
+++ b/fvm/UnknownQuantityHandler.cpp
@@ -34,7 +34,7 @@ UnknownQuantityHandler::~UnknownQuantityHandler() {
  *                      (these are usually the "non-trivial" unknowns that
  *                      appear in the equation system to solve.
  */
-const real_t *UnknownQuantityHandler::GetLongVector(vector<len_t>& nontrivial_unknowns, real_t *vec) {
+const real_t *UnknownQuantityHandler::GetLongVector(const vector<len_t>& nontrivial_unknowns, real_t *vec) {
     return GetLongVector(nontrivial_unknowns.size(), nontrivial_unknowns.data(), vec);
 }
 const real_t *UnknownQuantityHandler::GetLongVector(const len_t n, const len_t *iuqn, real_t *vec) {
@@ -90,7 +90,7 @@ const real_t *UnknownQuantityHandler::GetLongVectorAll(real_t *vec) {
  * 'GetLongVector()'. Put differently: return the combined number of
  * elements in the unknowns specified to this routine.
  */
-const len_t UnknownQuantityHandler::GetLongVectorSize(vector<len_t>& nontrivial_unknowns) {
+const len_t UnknownQuantityHandler::GetLongVectorSize(const vector<len_t>& nontrivial_unknowns) {
     return GetLongVectorSize(nontrivial_unknowns.size(), nontrivial_unknowns.data());
 }
 const len_t UnknownQuantityHandler::GetLongVectorSize(const len_t n, const len_t *iuqn) {
@@ -169,6 +169,21 @@ len_t UnknownQuantityHandler::GetUnknownID(const string& name) {
         "No unknown quantity with name '%s' exists in the equation system.",
         name.c_str()
     );
+}
+
+/**
+ * Checks whether an unknown quantity with the given name
+ * exists in this UnknownQuantityHandler.
+ *
+ * name: Name of unknown to look for.
+ */
+bool UnknownQuantityHandler::HasUnknown(const string& name) {
+    for (auto it = unknowns.begin(); it != unknowns.end(); it++) {
+        if ((*it)->GetName() == name)
+            return true;
+    }
+
+    return false;
 }
 
 /**

--- a/include/DREAM/ConvergenceChecker.hpp
+++ b/include/DREAM/ConvergenceChecker.hpp
@@ -25,7 +25,7 @@ namespace DREAM {
 
     public:
         ConvergenceChecker(
-            FVM::UnknownQuantityHandler*, std::vector<len_t>&,
+            FVM::UnknownQuantityHandler*, const std::vector<len_t>&,
             const real_t reltol=1e-6
         );
         virtual ~ConvergenceChecker();
@@ -42,6 +42,7 @@ namespace DREAM {
         const real_t *GetErrorNorms() { return this->dx_2norm; }
         const real_t GetErrorScale(const len_t);
 
+        void SetAbsoluteTolerance(const len_t, const real_t);
         void SetRelativeTolerance(const real_t);
         void SetRelativeTolerance(const len_t, const real_t);
     };

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -81,8 +81,7 @@ enum solver_type {
 // and nonlinear solvers)
 enum linear_solver {
     LINEAR_SOLVER_LU=1,
-    LINEAR_SOLVER_GMRES=2,
-    LINEAR_SOLVER_MUMPS=3
+    LINEAR_SOLVER_MUMPS=2
 };
 
 /////////////////////////////////////

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -81,7 +81,8 @@ enum solver_type {
 // and nonlinear solvers)
 enum linear_solver {
     LINEAR_SOLVER_LU=1,
-    LINEAR_SOLVER_GMRES=2
+    LINEAR_SOLVER_GMRES=2,
+    LINEAR_SOLVER_MUMPS=3
 };
 
 /////////////////////////////////////

--- a/include/DREAM/Settings/SimulationGenerator.hpp
+++ b/include/DREAM/Settings/SimulationGenerator.hpp
@@ -2,6 +2,7 @@
 #define _DREAM_PROCESS_SETTINGS_HPP
 
 #include "DREAM/ADAS.hpp"
+#include "DREAM/ConvergenceChecker.hpp"
 #include "DREAM/EquationSystem.hpp"
 #include "DREAM/Equations/RunawayFluid.hpp"
 #include "DREAM/IonInterpolator1D.hpp"
@@ -78,6 +79,9 @@ namespace DREAM {
         static void DefineOptions_RunawayGrid(Settings*);
         static void DefineOptions_Solver(Settings*);
         static void DefineOptions_TimeStepper(Settings*);
+
+        static void DefineToleranceSettings(const std::string&, Settings*, const std::string& name="tolerance");
+        static ConvergenceChecker *LoadToleranceSettings(const std::string&, Settings*, FVM::UnknownQuantityHandler*, const std::vector<len_t>&, const std::string& name="tolerance");
 
         static ADAS *LoadADAS(Settings*);
         static NIST *LoadNIST(Settings*);

--- a/include/DREAM/Solver/Solver.hpp
+++ b/include/DREAM/Solver/Solver.hpp
@@ -6,6 +6,7 @@
  */
 
 #include <vector>
+#include "DREAM/ConvergenceChecker.hpp"
 #include "DREAM/Equations/CollisionQuantityHandler.hpp"
 #include "DREAM/Equations/RunawayFluid.hpp"
 #include "DREAM/UnknownQuantityEquation.hpp"
@@ -34,6 +35,9 @@ namespace DREAM {
         CollisionQuantityHandler *cqh_hottail, *cqh_runaway;
         RunawayFluid *REFluid;
 
+        // Convergence checker for linear solver (GMRES primarily)
+        ConvergenceChecker *convChecker=nullptr;
+
         /*FVM::DurationTimer
             timerTot, timerCqh, timerREFluid, timerRebuildTerms;*/
         FVM::TimeKeeper *solver_timeKeeper;
@@ -54,6 +58,7 @@ namespace DREAM {
 
         //virtual const real_t *GetSolution() const = 0;
         virtual void Initialize(const len_t, std::vector<len_t>&);
+        std::vector<len_t> GetNonTrivials() { return this->nontrivial_unknowns; }
 
         virtual void SetCollisionHandlers(
             CollisionQuantityHandler *cqh_hottail,
@@ -71,6 +76,8 @@ namespace DREAM {
         void PrintTimings_rebuild();
         virtual void SaveTimings(SFile*, const std::string& path="") = 0;
         void SaveTimings_rebuild(SFile*, const std::string& path="");
+
+        void SetConvergenceChecker(ConvergenceChecker*);
     };
 
     class SolverException : public DREAM::FVM::FVMException {

--- a/include/DREAM/Solver/SolverNonLinear.hpp
+++ b/include/DREAM/Solver/SolverNonLinear.hpp
@@ -20,8 +20,6 @@ namespace DREAM {
 		FVM::MatrixInverter *inverter = nullptr;
 		Vec petsc_F, petsc_dx;
 
-        ConvergenceChecker *convChecker=nullptr;
-
         enum OptionConstants::linear_solver linearSolver = OptionConstants::LINEAR_SOLVER_LU;
 
 		int_t maxiter=100;

--- a/include/DREAM/TimeStepper/TimeStepperAdaptive.hpp
+++ b/include/DREAM/TimeStepper/TimeStepperAdaptive.hpp
@@ -87,7 +87,7 @@ namespace DREAM {
     public:
         TimeStepperAdaptive(
             const real_t tMax, const real_t dt0, FVM::UnknownQuantityHandler*,
-            std::vector<len_t>&, const real_t reltol=1e-6, int_t checkEvery=0,
+            std::vector<len_t>&, ConvergenceChecker*, int_t checkEvery=0,
             bool verbose=false, bool constantStep=false
         );
         ~TimeStepperAdaptive();

--- a/include/FVM/NormEvaluator.hpp
+++ b/include/FVM/NormEvaluator.hpp
@@ -9,7 +9,7 @@ namespace DREAM::FVM {
     class NormEvaluator {
     protected:
         UnknownQuantityHandler *unknowns;
-        std::vector<len_t> nontrivials;
+        const std::vector<len_t> nontrivials;
 
         // Vector for storing nontrivial-wise norms. Has
         // as many elements as there are non-trivial unknowns
@@ -17,7 +17,7 @@ namespace DREAM::FVM {
         len_t nNontrivials;
 
     public:
-        NormEvaluator(UnknownQuantityHandler*, std::vector<len_t>&);
+        NormEvaluator(UnknownQuantityHandler*, const std::vector<len_t>&);
         virtual ~NormEvaluator();
 
         const real_t *Norm2(const real_t*);

--- a/include/FVM/Solvers/MIKSP.hpp
+++ b/include/FVM/Solvers/MIKSP.hpp
@@ -18,6 +18,11 @@ namespace DREAM::FVM {
         ~MIKSP();
 
 		virtual void Invert(Matrix*, Vec*, Vec*) override;
+
+        void SetConvergenceTest(
+            PetscErrorCode (*)(KSP, PetscInt, PetscReal, KSPConvergedReason*, void*),
+            void*
+        );
 	};
 }
 

--- a/include/FVM/Solvers/MIMUMPS.hpp
+++ b/include/FVM/Solvers/MIMUMPS.hpp
@@ -1,0 +1,24 @@
+#ifndef _DREAM_FVM_MATRIX_INVERTER_MUMPS_HPP
+#define _DREAM_FVM_MATRIX_INVERTER_MUMPS_HPP
+
+#include <petscksp.h>
+#include "FVM/config.h"
+#include "FVM/MatrixInverter.hpp"
+
+namespace DREAM::FVM {
+	class MIMUMPS : public MatrixInverter {
+    private:
+        KSP ksp;
+        Vec x;
+
+        PetscScalar *x_data;
+        len_t xn;
+	public:
+		MIMUMPS(const len_t);
+        ~MIMUMPS();
+
+		virtual void Invert(Matrix*, Vec*, Vec*) override;
+	};
+}
+
+#endif/*_DREAM_FVM_MATRIX_INVERTER_MUMPS_HPP*/

--- a/include/FVM/UnknownQuantityHandler.hpp
+++ b/include/FVM/UnknownQuantityHandler.hpp
@@ -23,9 +23,9 @@ namespace DREAM::FVM {
         len_t GetNUnknowns() const { return this->unknowns.size(); }
         len_t Size() const { return GetNUnknowns(); }
 
-        const real_t *GetLongVector(std::vector<len_t>& nontrivials, real_t *vec=nullptr);
+        const real_t *GetLongVector(const std::vector<len_t>& nontrivials, real_t *vec=nullptr);
         const real_t *GetLongVector(const len_t, const len_t*, real_t *vec=nullptr);
-        const len_t GetLongVectorSize(std::vector<len_t>& nontrivials);
+        const len_t GetLongVectorSize(const std::vector<len_t>& nontrivials);
         const len_t GetLongVectorSize(const len_t, const len_t*);
 
         const real_t *GetLongVectorAll(real_t *vec=nullptr);
@@ -39,6 +39,7 @@ namespace DREAM::FVM {
 
         bool HasChanged(const len_t id) const { return unknowns[id]->HasChanged(); }
         bool HasInitialValue(const len_t id) const { return unknowns[id]->HasInitialValue(); }
+        bool HasUnknown(const std::string&);
         len_t InsertUnknown(const std::string&, const std::string&, Grid*, const len_t nMultiples=1);
 
         void Store(std::vector<len_t>&, Vec&, bool mayBeConstant=false);

--- a/py/DREAM/Settings/EquationSystem.py
+++ b/py/DREAM/Settings/EquationSystem.py
@@ -14,6 +14,16 @@ from .Equations.RunawayElectrons import RunawayElectrons
 from .Equations.EquationException import EquationException
 
 
+# List of names of unknown quantities in DREAM. This list can be
+# used across the interface to validate names of unknowns.
+UNKNOWNS = [
+    'E_field', 'f_hot', 'f_re', 'n_i', 'I_p', 'I_wall',
+    'j_hot', 'j_ohm', 'j_re', 'j_tot', 'n_cold', 'n_hot',
+    'n_re', 'n_tot', 'psi_p', 'psi_wall', 'psi_edge',
+    'T_cold', 'V_loop_w', 'W_cold'
+]
+
+
 class EquationSystem:
     
     def __init__(self, settings):

--- a/py/DREAM/Settings/Solver.py
+++ b/py/DREAM/Settings/Solver.py
@@ -12,6 +12,7 @@ NONLINEAR_SNES  = 3
 
 LINEAR_SOLVER_LU    = 1
 LINEAR_SOLVER_GMRES = 2
+LINEAR_SOLVER_MUMPS = 3
 
 
 class Solver:
@@ -138,7 +139,8 @@ class Solver:
         Verifies the settings for the linear solver (which is used
         by both the 'LINEAR_IMPLICIT' and 'NONLINEAR' solvers).
         """
-        if (self.linsolv != LINEAR_SOLVER_LU) and (self.linsolv != LINEAR_SOLVER_GMRES):
+        solv = [LINEAR_SOLVER_LU, LINEAR_SOLVER_GMRES, LINEAR_SOLVER_MUMPS]
+        if self.linsolv not in solv:
             raise DREAMException("Solver: Unrecognized linear solver type: {}.".format(self.linsolv))
 
 

--- a/py/DREAM/Settings/ToleranceSettings.py
+++ b/py/DREAM/Settings/ToleranceSettings.py
@@ -1,0 +1,144 @@
+# Settings for tolerances of computed quantities
+
+import numpy as np
+from .. DREAMException import DREAMException
+from . import EquationSystem
+
+
+class ToleranceSettings:
+    
+    def __init__(self):
+        """
+        Constructor.
+        """
+        # General absolute and relative tolerances (applied to
+        # unknowns without explicit tolerances)
+        self.reltol = 1e-6
+        self.overrides = []
+
+
+    def disable(self, unknown):
+        """
+        Disable tolerance checking for the given unknowns. If 'unknown'
+        is ``None``, tolerance checking is disabled for all unknowns.
+        This can be reset for each unknown by explicitly calling
+        :automethod:`set` for them.
+        """
+        if unknown is None:
+            self.disable(EquationSystem.UNKNOWNS)
+        elif type(unknown) == str:
+            self.set(unknown, abstol=0, reltol=0)
+        elif type(unknown) == list:
+            for u in unknown:
+                self.set(u, abstol=0, reltol=0)
+        else:
+            raise DREAMException("Unrecognized type of parameter 'unknown': {}.".format(type(unknown)))
+
+
+    def fromdict(self, data):
+        """
+        Load tolerance settings from a dictionary.
+        """
+        if 'reltol' in data:
+            self.reltol = data['reltol']
+
+        overrides = []
+
+        if 'names' in data:
+            if 'abstols' not in data:
+                raise DREAMException("'names' setting present, but no 'abstols' setting found.")
+            if 'reltols' not in data:
+                raise DREAMException("'names' setting present, but no 'reltols' setting found.")
+                
+            names = data['names'].split(';')[:-1]
+            for i in range(len(l)):
+                atol = data['abstol'][i]
+                rtol = data['reltol'][i]
+
+                l = {'name': names[i], 'abstol': float(atol), 'reltol': float(rtol)}
+                overrides.append(l)
+
+            self.overrides = overrides
+
+    
+    def getIndex(self, unknown):
+        """
+        Returns the index into the 'overrides' list for the
+        given unknown. If the returned value is '-1', no
+        override exists for the quantity and the general
+        absolute and relative tolerances are used instead.
+        """
+        for i in range(0, len(self.overrides)):
+            if self.overrides[i]['name'] == unknown:
+                return i
+        
+        return -1
+
+
+    def set(self, unknown=None, abstol=0, reltol=1e-6):
+        """
+        Set the absolute and relative tolerance of one or more unknown
+        quantities.
+
+        :param unknown: A string or list of strings specifying the name(s) of the quantity/ies to set the tolerances for. If 'None', the tolerances are applied to all unknowns.
+        :param float abstol: Absolut tolerance to set for unknown.
+        :param float reltol: Relative tolerance to set for unknown.
+        """
+        if unknown is None:
+            self.reltol = float(reltol)
+            self.overrides = []
+        elif type(unknown) == str:
+            t = self.getIndex(unknown)
+            l = {'name': unknown, 'abstol': float(abstol), 'reltol': float(reltol)}
+
+            # Append to list or overwrite existing element?
+            if t < 0:
+                self.overrides.append(l)
+            else:
+                self.overrides[i] = l
+        elif type(unknown) == list:
+            for u in unknown:
+                self.set(u, abstol=abstol, reltol=reltol)
+        else:
+            raise DREAMException("ToleranceSettings.set(): Unrecognized type of parameter 'unknown': {}.:".format(type(unknown)))
+
+
+    def todict(self):
+        """
+        Convert this object to a dict.
+        """
+        data = {'reltol': self.reltol}
+
+        if len(self.overrides) > 0:
+            data['names'] = ''
+            data['abstols'] = []
+            data['reltols'] = []
+            for u in self.overrides:
+                data['names'] += '{};'.format(u['name'])
+                data['abstols'].append(u['abstol'])
+                data['reltols'].append(u['reltol'])
+
+        return data
+
+
+    def verifySettings(self):
+        """
+        Verify that these settings are consistent.
+        """
+        if type(self.reltol) is not float:
+            raise DREAMException("Invalid type of general relative tolerance: {}. Expected float.".format(type(self.reltol)))
+
+
+        for i in range(len(self.overrides)):
+            u = self.overrides[i]
+            if ('name' not in u) or ('abstol' not in u) or ('reltol' not in u):
+                raise DREAMException("Incomplete override at index {}.".format(i))
+            elif type(u['abstol']) is not float:
+                raise DREAMException("Invalid type of absolute tolerance for unknown '{}': {}. Expected float.".format(u['name'], type(u['abstol'])))
+            elif type(u['reltol']) is not float:
+                raise DREAMException("Invalid type of relative tolerance for unknown '{}': {}. Expected float.".format(u['name'], type(u['reltol'])))
+
+            if u['name'] not in EquationSystem.UNKNOWNS:
+                print("WARNING: No unknown quantity with name '{}' is available in DREAM. Tolerance setting will be ignored...".format(u['name']))
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,7 @@ set(dream_settings
     "${PROJECT_SOURCE_DIR}/src/Settings/SFile.cpp"
     "${PROJECT_SOURCE_DIR}/src/Settings/Solver.cpp"
     "${PROJECT_SOURCE_DIR}/src/Settings/TimeStepper.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Settings/Tolerances.cpp"
 )
 set(dream_headers
     "${PROJECT_SOURCE_DIR}/include/DREAM/IO.hpp"

--- a/src/Settings/Solver.cpp
+++ b/src/Settings/Solver.cpp
@@ -31,6 +31,8 @@ void SimulationGenerator::DefineOptions_Solver(Settings *s) {
     s->DefineSetting(MODULENAME "/maxiter", "Maximum number of nonlinear iterations allowed", (int_t)100);
     s->DefineSetting(MODULENAME "/reltol", "Relative tolerance for nonlinear solver", (real_t)1e-6);
     s->DefineSetting(MODULENAME "/verbose", "If true, generates extra output during nonlinear solve", (bool)false);
+
+    DefineToleranceSettings(MODULENAME, s);
 }
 
 /**
@@ -67,6 +69,12 @@ void SimulationGenerator::ConstructSolver(EquationSystem *eqsys, Settings *s) {
         eqsys->GetRunawayCollisionHandler(),
         eqsys->GetREFluid()
     );
+
+    ConvergenceChecker *cc = LoadToleranceSettings(
+        MODULENAME, s, u, solver->GetNonTrivials()
+    );
+
+    solver->SetConvergenceChecker(cc);
 }
 
 

--- a/src/Settings/TimeStepper.cpp
+++ b/src/Settings/TimeStepper.cpp
@@ -28,8 +28,10 @@ void SimulationGenerator::DefineOptions_TimeStepper(Settings *s) {
     s->DefineSetting(MODULENAME "/tmax", "Maximum simulation time", (real_t)0.0);
     s->DefineSetting(MODULENAME "/dt", "Length of each time step", (real_t)0.0);
     s->DefineSetting(MODULENAME "/nt", "Number of time steps to take", (int_t)0);
-    s->DefineSetting(MODULENAME "/reltol", "Relative tolerance to use for time stepper", (real_t)1e-6);
     s->DefineSetting(MODULENAME "/verbose", "If true, generates excessive output", (bool)false);
+
+    // Tolerance settings for adaptive time stepper
+    DefineToleranceSettings(MODULENAME, s);
 }
 
 /**
@@ -114,7 +116,6 @@ TimeStepperAdaptive *SimulationGenerator::ConstructTimeStepper_adaptive(
 ) {
     int_t checkevery = s->GetInteger(MODULENAME "/checkevery");
     real_t tmax = s->GetReal(MODULENAME "/tmax");
-    real_t reltol = s->GetReal(MODULENAME "/reltol");
     real_t dt = s->GetReal(MODULENAME "/dt");
     bool verbose = s->GetBool(MODULENAME "/verbose");
     bool conststep = s->GetBool(MODULENAME "/constantstep");
@@ -122,5 +123,10 @@ TimeStepperAdaptive *SimulationGenerator::ConstructTimeStepper_adaptive(
     if (dt == 0)
         dt = 1;
 
-    return new TimeStepperAdaptive(tmax, dt, u, *nontrivials, reltol, checkevery, verbose, conststep);
+    ConvergenceChecker *cc = LoadToleranceSettings(
+        MODULENAME, s, u, *nontrivials
+    );
+
+    return new TimeStepperAdaptive(tmax, dt, u, *nontrivials, cc, checkevery, verbose, conststep);
 }
+

--- a/src/Settings/Tolerances.cpp
+++ b/src/Settings/Tolerances.cpp
@@ -1,0 +1,82 @@
+/**
+ * Load tolerance settings.
+ */
+
+#include "DREAM/IO.hpp"
+#include "DREAM/Settings/SimulationGenerator.hpp"
+
+
+using namespace DREAM;
+using namespace std;
+
+
+/**
+ * Define options for tolerance settings.
+ *
+ * modname: Name of module to place the settings in.
+ * s:       Settings object to define options in.
+ * name:    Name of tolerance settings object to use.
+ */
+void SimulationGenerator::DefineToleranceSettings(
+    const string& modname, Settings *s,
+    const string& name
+) {
+    const string n = modname + "/" + name;
+
+    s->DefineSetting(n + "/reltol",  "General relative tolerance to apply.", (real_t)1e-6);
+    s->DefineSetting(n + "/names",   "Names of unknowns to override tolerances for", (const string)"");
+    s->DefineSetting(n + "/abstols", "List of absolute tolerances to apply to the unknowns in 'names'.", 0, (real_t*)nullptr);
+    s->DefineSetting(n + "/reltols", "List of relative tolerances to apply to the unknowns in 'names'.", 0, (real_t*)nullptr);
+}
+
+/**
+ * Load tolerance settings for the specified module.
+ * 
+ * modname:     Name of module to place the settings in.
+ * s:           Settings object to define options in.
+ * uqh:         Unknown quantity handler.
+ * nontrivials: List of IDs of the non-trivial unknowns of the equation system.
+ * name:        Name of tolerance settings object to use.
+ */
+ConvergenceChecker *SimulationGenerator::LoadToleranceSettings(
+    const string& modname, Settings *s,
+    FVM::UnknownQuantityHandler *uqh, const vector<len_t>& nontrivials,
+    const string& name
+) {
+    const string n = modname + "/" + name;
+
+    len_t nabstols, nreltols;
+
+    real_t reltol = s->GetReal(n + "/reltol");
+    vector<string> uqtyNames = s->GetStringList(n + "/names");
+    const real_t *abstols = s->GetRealArray(n + "/abstols", 1, &nabstols);
+    const real_t *reltols = s->GetRealArray(n + "/reltols", 1, &nreltols);
+
+    ConvergenceChecker *cc = new ConvergenceChecker(
+        uqh, nontrivials, reltol
+    );
+
+    // Set tolerances...
+    for (len_t i = 0; i < uqtyNames.size(); i++) {
+        // Ignore non-existent unknowns...
+        // (These settings may be remnants from previous settings
+        //  objects, and so instead of stopping the simulation we
+        //  simply ignore it and emit a warning in case it's a typo)
+        if (!uqh->HasUnknown(uqtyNames[i])) {
+            DREAM::IO::PrintWarning(
+                "%s: No unknown quantity with name '%s' in equation system. "
+                "Ignoring tolerance settings...",
+                n.c_str(), uqtyNames[i].c_str()
+            );
+            continue;
+        }
+
+        len_t id = uqh->GetUnknownID(uqtyNames[i]);
+
+        cc->SetAbsoluteTolerance(id, abstols[i]);
+        cc->SetRelativeTolerance(id, reltols[i]);
+    }
+
+    return cc;
+}
+

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -289,3 +289,13 @@ void Solver::PrintTimings_rebuild() {
 void Solver::SaveTimings_rebuild(SFile *sf, const std::string& path) {
     this->solver_timeKeeper->SaveTimings(sf, path);
 }
+
+/**
+ * Set the convergence checker to use for the linear solver.
+ */
+void Solver::SetConvergenceChecker(ConvergenceChecker *cc) {
+    if (this->convChecker != nullptr)
+        delete this->convChecker;
+
+    this->convChecker = cc;
+}

--- a/src/Solver/Solver.cpp
+++ b/src/Solver/Solver.cpp
@@ -36,6 +36,7 @@ Solver::Solver(
  */
 Solver::~Solver() {
     delete this->solver_timeKeeper;
+    delete this->convChecker;
 }
 
 /**

--- a/src/Solver/SolverLinearlyImplicit.cpp
+++ b/src/Solver/SolverLinearlyImplicit.cpp
@@ -32,6 +32,7 @@
 #include "DREAM/Solver/SolverLinearlyImplicit.hpp"
 #include "FVM/Solvers/MILU.hpp"
 #include "FVM/Solvers/MIKSP.hpp"
+#include "FVM/Solvers/MIMUMPS.hpp"
 
 
 using namespace DREAM;
@@ -77,6 +78,8 @@ void SolverLinearlyImplicit::initialize_internal(
         this->inverter = new FVM::MILU(size);
     else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_GMRES)
         this->inverter = new FVM::MIKSP(size);
+    else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_MUMPS)
+        this->inverter = new FVM::MIMUMPS(size);
     else
         throw SolverException(
             "Unrecognized linear solver specified: %d.", this->linearSolver

--- a/src/Solver/SolverLinearlyImplicit.cpp
+++ b/src/Solver/SolverLinearlyImplicit.cpp
@@ -76,8 +76,6 @@ void SolverLinearlyImplicit::initialize_internal(
     // Select linear solver
     if (this->linearSolver == OptionConstants::LINEAR_SOLVER_LU)
         this->inverter = new FVM::MILU(size);
-    else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_GMRES)
-        this->inverter = new FVM::MIKSP(size);
     else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_MUMPS)
         this->inverter = new FVM::MIMUMPS(size);
     else

--- a/src/Solver/SolverNonLinear.cpp
+++ b/src/Solver/SolverNonLinear.cpp
@@ -9,6 +9,7 @@
 #include "DREAM/Solver/SolverNonLinear.hpp"
 #include "FVM/Solvers/MILU.hpp"
 #include "FVM/Solvers/MIKSP.hpp"
+#include "FVM/Solvers/MIMUMPS.hpp"
 
 
 using namespace DREAM;
@@ -80,6 +81,8 @@ void SolverNonLinear::Allocate() {
         this->inverter = new FVM::MILU(N);
     else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_GMRES)
         this->inverter = new FVM::MIKSP(N);
+    else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_MUMPS)
+        this->inverter = new FVM::MIMUMPS(N);
     else
         throw SolverException(
             "Unrecognized linear solver specified: %d.", this->linearSolver

--- a/src/Solver/SolverNonLinear.cpp
+++ b/src/Solver/SolverNonLinear.cpp
@@ -79,8 +79,6 @@ void SolverNonLinear::Allocate() {
     // Select linear solver
     if (this->linearSolver == OptionConstants::LINEAR_SOLVER_LU)
         this->inverter = new FVM::MILU(N);
-    else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_GMRES)
-        this->inverter = new FVM::MIKSP(N);
     else if (this->linearSolver == OptionConstants::LINEAR_SOLVER_MUMPS)
         this->inverter = new FVM::MIMUMPS(N);
     else
@@ -135,7 +133,10 @@ void SolverNonLinear::initialize_internal(
 ) {
 	this->Allocate();
 
-    this->convChecker = new ConvergenceChecker(unknowns, this->nontrivial_unknowns, this->reltol);
+    if (this->convChecker == nullptr)
+        this->SetConvergenceChecker(
+            new ConvergenceChecker(unknowns, this->nontrivial_unknowns, this->reltol)
+        );
 }
 
 /**

--- a/tests/physics/ts_adaptive/ts_adaptive.py
+++ b/tests/physics/ts_adaptive/ts_adaptive.py
@@ -70,8 +70,8 @@ def genSettings(adaptive=False):
     ds.eqsys.f_hot.setBoundaryCondition(bc=FHot.BC_F_0)
 
     ds.solver.setType(Solver.NONLINEAR)
-    ds.solver.setLinearSolver(linsolv=Solver.LINEAR_SOLVER_GMRES)
-    ds.solver.setTolerance(reltol=0.01)
+    ds.solver.setLinearSolver(linsolv=Solver.LINEAR_SOLVER_LU)
+    ds.solver.tolerance.set(reltol=1e-6)
 
     return ds
 


### PR DESCRIPTION
This branch adds support for using MUMPS as the linear solver (in both the *linearly implicit* and *nonlinear* solvers). This branch also implements a general ``ToleranceSettings`` interface (fixing issue #37) which allows us to set custom relative and absolute tolerances for all unknowns in the ``Solver`` and ``TimeStepper`` (separately). Tolerance checks can also be disabled on selected unknowns, which allows, for example, the adaptive time stepper to only seek good convergence in a particular unknown.