### PR TITLE
Screening

### DIFF
--- a/examples/runaway_partiallyIonized/generate.py
+++ b/examples/runaway_partiallyIonized/generate.py
@@ -58,11 +58,12 @@ ds.hottailgrid.setPmax(pMax)
 # Set initial hot electron Maxwellian
 nFree, rn0 = ds.eqsys.n_i.getFreeElectronDensity()
 # nFree gives a 1-element array, but DREAM either needs a scalar or something on the same size as the radial grid
-ds.eqsys.f_hot.setInitialProfiles(n0=nFree[0], T0=T) 
+ds.eqsys.f_hot.setInitialProfiles(n0=nFree, rn0=rn0, T0=T) 
 
 # Set boundary condition type at pMax
 #ds.eqsys.f_hot.setBoundaryCondition(FHot.BC_PHI_CONST) # extrapolate flux to boundary
 ds.eqsys.f_hot.setBoundaryCondition(FHot.BC_F_0) # F=0 outside the boundary
+ds.eqsys.f_hot.setAdvectionInterpolationMethod(FHot.AD_INTERP_TCDF) # needs a non-linear solver!
 
 # Disable runaway grid
 ds.runawaygrid.setEnabled(False)
@@ -73,7 +74,7 @@ ds.radialgrid.setMinorRadius(0.22)
 ds.radialgrid.setNr(1)
 
 # Set solver type
-ds.solver.setType(Solver.LINEAR_IMPLICIT) # semi-implicit time stepping
+ds.solver.setType(Solver.NONLINEAR) # semi-implicit time stepping
 
 # include otherquantities to save to output
 ds.other.include('fluid')

--- a/examples/runaway_partiallyIonized/generate.py
+++ b/examples/runaway_partiallyIonized/generate.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+#
+# This example shows how to set up a simple CODE-like runaway
+# scenario in DREAM, similar to the runaway example but including
+# singly ionized argon
+#
+# Run as
+#
+#   $ ./generate.py
+#   $ ../../build/iface/dreami dream_settings.h5
+#
+# ###################################################################
+
+import numpy as np
+import sys
+
+sys.path.append('../../py/')
+
+import DREAM
+from DREAM.DREAMSettings import DREAMSettings
+import DREAM.Settings.Equations.HotElectronDistribution as FHot
+import DREAM.Settings.Equations.IonSpecies as Ions
+import DREAM.Settings.Equations.RunawayElectrons as Runaways
+import DREAM.Settings.Solver as Solver
+
+ds = DREAMSettings()
+
+# Physical parameters
+E = 6       # Electric field strength (V/m)
+n = 5e19    # Electron density (m^-3)
+T = 20      # Temperature (eV)
+
+# Grid parameters
+pMax = 1    # maximum momentum in units of m_e*c
+Np   = 300  # number of momentum grid points
+Nxi  = 10   # number of pitch grid points
+tMax = 2e-4 # simulation time in seconds
+Nt   = 20   # number of time steps
+
+# Set E_field
+ds.eqsys.E_field.setPrescribedData(E)
+
+# Set temperature
+ds.eqsys.T_cold.setPrescribedData(T)
+
+# Set ions
+ds.eqsys.n_i.addIon(name='D', Z=1, iontype=Ions.IONS_PRESCRIBED_FULLY_IONIZED, n=n)
+ds.eqsys.n_i.addIon(name='Ar', Z=18, iontype=Ions.IONS_PRESCRIBED, Z0=1, n=n)
+
+# Disable avalanche generation
+ds.eqsys.n_re.avalanche = Runaways.AVALANCHE_MODE_NEGLECT
+
+# Hot-tail grid settings
+ds.hottailgrid.setNxi(Nxi)
+ds.hottailgrid.setNp(Np)
+ds.hottailgrid.setPmax(pMax)
+
+# Set initial hot electron Maxwellian
+nFree, rn0 = ds.eqsys.n_i.getFreeElectronDensity()
+# nFree gives a 1-element array, but DREAM either needs a scalar or something on the same size as the radial grid
+ds.eqsys.f_hot.setInitialProfiles(n0=nFree[0], T0=T) 
+
+# Set boundary condition type at pMax
+#ds.eqsys.f_hot.setBoundaryCondition(FHot.BC_PHI_CONST) # extrapolate flux to boundary
+ds.eqsys.f_hot.setBoundaryCondition(FHot.BC_F_0) # F=0 outside the boundary
+
+# Disable runaway grid
+ds.runawaygrid.setEnabled(False)
+
+# Set up radial grid
+ds.radialgrid.setB0(5)
+ds.radialgrid.setMinorRadius(0.22)
+ds.radialgrid.setNr(1)
+
+# Set solver type
+ds.solver.setType(Solver.LINEAR_IMPLICIT) # semi-implicit time stepping
+
+# include otherquantities to save to output
+ds.other.include('fluid')
+
+# Set time stepper
+ds.timestep.setTmax(tMax)
+ds.timestep.setNt(Nt)
+
+ds.output.setTiming(stdout=True, file=True)
+ds.output.setFilename('output.h5')
+
+# Save settings to HDF5 file
+ds.save('dream_settings.h5')
+

--- a/include/DREAM/Equations/SlowingDownFrequency.hpp
+++ b/include/DREAM/Equations/SlowingDownFrequency.hpp
@@ -6,15 +6,10 @@ namespace DREAM {
     class SlowingDownFrequency : public CollisionFrequency {
     private:
         gsl_integration_workspace *gsl_ad_w;
-        /* static const len_t  meanExcI_len; // remove!
-        static const real_t meanExcI_data[]; // remove!
-        static const real_t meanExcI_Zs[]; // remove!
-        static const real_t meanExcI_Z0s[]; // remove! 
-        */
 
-        static const len_t  MAX_Z;
-        static const len_t  MAX_NE;
-        static const real_t MEAN_EXCITATION_ENERGY_DATA[18][18]; // @@?? use definie instead?? Hm.. 
+        static const len_t  MAX_Z = 18; // tabulated mean excitation energies up to Z = 18
+        static const len_t  MAX_NE = 14; // tabulated constants for analytic formula up to Ne = 14
+        static const real_t MEAN_EXCITATION_ENERGY_DATA[MAX_Z][MAX_Z];
         static const real_t MEAN_EXCITATION_ENERGY_FUNCTION_D[];
         static const real_t MEAN_EXCITATION_ENERGY_FUNCTION_S_0[];
         static const real_t HIGH_Z_EXCITATION_ENERGY_PER_Z; 
@@ -29,7 +24,7 @@ namespace DREAM {
         virtual real_t evaluateIonTermAtP(len_t /*iz*/, len_t /*Z0*/, real_t /*p*/) override {return 0;}
         virtual real_t evaluateBremsstrahlungTermAtP(len_t iz, len_t Z0, real_t p, OptionConstants::eqterm_bremsstrahlung_mode brems_mode, OptionConstants::collqty_collfreq_type collfreq_type) override;
     protected:
-        virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override;        
+        // virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override;        
     public:
         SlowingDownFrequency(FVM::Grid *g, FVM::UnknownQuantityHandler *u, IonHandler *ih,  
                 CoulombLogarithm *lnLee,CoulombLogarithm *lnLei,
@@ -41,6 +36,7 @@ namespace DREAM {
 
         real_t GetP3NuSAtZero(len_t ir);
         real_t *GetPartialP3NuSAtZero(len_t derivId);
+        virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override; 
     };
 
 }

--- a/include/DREAM/Equations/SlowingDownFrequency.hpp
+++ b/include/DREAM/Equations/SlowingDownFrequency.hpp
@@ -2,15 +2,22 @@
 #define _DREAM_EQUATIONS_SLOWING_DOWN_FREQUENCY_HPP
 
 #include "CollisionFrequency.hpp"
-
 namespace DREAM {
     class SlowingDownFrequency : public CollisionFrequency {
     private:
         gsl_integration_workspace *gsl_ad_w;
-        static const len_t  meanExcI_len;
-        static const real_t meanExcI_data[];
-        static const real_t meanExcI_Zs[];
-        static const real_t meanExcI_Z0s[];
+        /* static const len_t  meanExcI_len; // remove!
+        static const real_t meanExcI_data[]; // remove!
+        static const real_t meanExcI_Zs[]; // remove!
+        static const real_t meanExcI_Z0s[]; // remove! 
+        */
+
+        static const len_t  MAX_Z;
+        static const len_t  MAX_NE;
+        static const real_t MEAN_EXCITATION_ENERGY_DATA[18][18]; // @@?? use definie instead?? Hm.. 
+        static const real_t MEAN_EXCITATION_ENERGY_FUNCTION_D[];
+        static const real_t MEAN_EXCITATION_ENERGY_FUNCTION_S_0[];
+        static const real_t HIGH_Z_EXCITATION_ENERGY_PER_Z; 
         static const real_t HYDROGEN_MEAN_EXCITATION_ENERGY;
         
         void GetPartialContributionNi(real_t preFactor, real_t *hiBethe, real_t hCold, const real_t lnLee, len_t pind,len_t np1, real_t *&partQty);        
@@ -21,7 +28,7 @@ namespace DREAM {
         virtual real_t evaluateScreenedTermAtP(len_t iz, len_t Z0, real_t p, OptionConstants::collqty_collfreq_mode collfreq_mode) override;
         virtual real_t evaluateIonTermAtP(len_t /*iz*/, len_t /*Z0*/, real_t /*p*/) override {return 0;}
         virtual real_t evaluateBremsstrahlungTermAtP(len_t iz, len_t Z0, real_t p, OptionConstants::eqterm_bremsstrahlung_mode brems_mode, OptionConstants::collqty_collfreq_type collfreq_type) override;
-   protected:
+    protected:
         virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override;        
     public:
         SlowingDownFrequency(FVM::Grid *g, FVM::UnknownQuantityHandler *u, IonHandler *ih,  

--- a/include/DREAM/Equations/SlowingDownFrequency.hpp
+++ b/include/DREAM/Equations/SlowingDownFrequency.hpp
@@ -24,7 +24,7 @@ namespace DREAM {
         virtual real_t evaluateIonTermAtP(len_t /*iz*/, len_t /*Z0*/, real_t /*p*/) override {return 0;}
         virtual real_t evaluateBremsstrahlungTermAtP(len_t iz, len_t Z0, real_t p, OptionConstants::eqterm_bremsstrahlung_mode brems_mode, OptionConstants::collqty_collfreq_type collfreq_type) override;
     protected:
-        // virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override;        
+        virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override;        
     public:
         SlowingDownFrequency(FVM::Grid *g, FVM::UnknownQuantityHandler *u, IonHandler *ih,  
                 CoulombLogarithm *lnLee,CoulombLogarithm *lnLei,
@@ -35,8 +35,7 @@ namespace DREAM {
             {len_t ind = ionIndex[iz][Z0]; return atomicParameter[ind];}
 
         real_t GetP3NuSAtZero(len_t ir);
-        real_t *GetPartialP3NuSAtZero(len_t derivId);
-        virtual real_t GetAtomicParameter(len_t iz, len_t Z0) override; 
+        real_t *GetPartialP3NuSAtZero(len_t derivId); 
     };
 
 }

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -109,6 +109,9 @@ real_t SlowingDownFrequency::GetAtomicParameter(len_t iz, len_t Z0){
     real_t D_N;
     real_t S_N0;
 
+    if (Z == Z0){
+        return NAN;
+    }
     if (Z < MAX_Z){ /* use tabulated data */
         I = MEAN_EXCITATION_ENERGY_DATA[Z-1][Z0]; // or maybe the other way around...
     }else{ /* use the formula instead */

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -48,7 +48,8 @@ const real_t SlowingDownFrequency::MEAN_EXCITATION_ENERGY_DATA[MAX_Z][MAX_Z] = {
 
 const real_t SlowingDownFrequency::MEAN_EXCITATION_ENERGY_FUNCTION_D[MAX_NE] = {0, 0.00, 0.24, 0.34, 0.41, 0.45, 0.48, 0.50, 0.51, 0.52, 0.55, 0.57, 0.58, 0.59};
 const real_t SlowingDownFrequency::MEAN_EXCITATION_ENERGY_FUNCTION_S_0[MAX_NE] = {0, 0.30, 1.51, 2.32, 3.13, 3.90, 4.67, 5.44, 6.21, 6.97, 8.10, 9.08, 10.03, 10.94};
-const real_t SlowingDownFrequency::HIGH_Z_EXCITATION_ENERGY_PER_Z = 10.0; // according to Berger et al., J of the ICRU os19 22 (1984), all neutral ions with Z >= 19 have I~10*Z eV (8.8 to 11.1 eV) 
+// according to Berger et al., J of the ICRU os19 22 (1984), all neutral ions with Z >= 19 have I~10*Z eV (8.8 to 11.1 eV) 
+const real_t SlowingDownFrequency::HIGH_Z_EXCITATION_ENERGY_PER_Z = 10.0; 
 const real_t SlowingDownFrequency::HYDROGEN_MEAN_EXCITATION_ENERGY = 14.99; // Mean excitation energy for neutral H
 
 /**

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -21,50 +21,37 @@ using namespace DREAM;
 
 /**
  * Mean excitation energy atomic data for ions from 
- *   Sauer, S.P., Oddershede, J. and Sabin, J.R., 2015. 
- *   The mean excitation energy of atomic ions. 
- *   In Advances in Quantum Chemistry (Vol. 71, pp. 29-40). 
- *   Academic Press.
+ * Sauer, Sabin, Oddershede J Chem Phys 148, 174307 (2018)
  */
 
-// Number of mean excitation energies that there is data for (the length of lists below)
-const len_t SlowingDownFrequency::meanExcI_len = 40;
+const len_t SlowingDownFrequency::MAX_Z = 18; // tabulated mean excitation energies up to Z = 18
+const len_t SlowingDownFrequency::MAX_NE = 14; // tabulated constants for analytic formula up to Ne = 14
 
-// List of atomic charge numbers Z
-const real_t SlowingDownFrequency::meanExcI_Zs[meanExcI_len] = 
-{
-/*H */ 1,
-/*He*/ 2, 2,
-/*Li*/ 3, 3, 3, 
-/*C */ 6, 6, 6, 6, 6, 6, 
-/*Ne*/ 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 
-/*Ar*/ 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18
-};
+// List of mean excitation energies in units of eV
+const real_t SlowingDownFrequency::MEAN_EXCITATION_ENERGY_DATA[MAX_Z][MAX_Z] = {
+/* H  */ { 14.99, NaN,   NaN,   NaN,   NaN,   NaN,   NaN,   NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* He */ { 42.68, 59.88, NaN,   NaN,   NaN,   NaN,   NaN,   NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* Li */ { 33.1,  108.3, 134.5, NaN,   NaN,   NaN,   NaN,   NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* Be */ { 42.2,  76.9,  205.0, 240.2, NaN,   NaN,   NaN,   NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* B  */ { 52.6,  82.3,  136.9, 330.4, 374.6, NaN,   NaN,   NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* C  */ { 65.9,  92.6,  134.8, 214.2, 486.2, 539.5, NaN,   NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* N  */ { 81.6,  107.4, 142.4, 200.2, 308.7, 672.0, 734.3, NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* O  */ { 97.9,  125.2, 157.2, 202.2, 278.6, 420.7, 887.8, 959.0,  NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* F  */ { 116.5, 144.0, 176.4, 215.6, 272.3, 370.2, 550.0, 1133.5, 1213.7, NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* Ne */ { 137.2, 165.2, 196.9, 235.2, 282.8, 352.6, 475.0, 696.8,  1409.2, 1498.4, NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* Na */ { 125.7, 189.2, 220.4, 256.8, 301.9, 358.7, 443.5, 593.3,  861.2,  1715.6, 1813.9, NaN,    NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* Mg */ { 128.0, 173.7, 246.8, 282.5, 324.3, 376.7, 443.8, 544.8,  724.8,  1043.2, 2051.5, 2158.8, NaN,    NaN,    NaN,    NaN,    NaN,    NaN},
+/* Al */ { 132.2, 172.7, 225.8, 310.8, 351.0, 398.8, 459.2, 537.4,  656.4,  869.6,  1242.7, 2417.2, 2533.5, NaN,    NaN,    NaN,    NaN,    NaN},
+/* Si */ { 140.8, 177.2, 221.2, 283.1, 381.4, 426.5, 480.6, 549.7,  640.1,  778.6,  1027.9, 1459.8, 2813.0, 2938.3, NaN,    NaN,    NaN,    NaN},
+/* P  */ { 151.6, 185.3, 225.2, 274.3, 345.9, 458.5, 508.8, 569.7,  648.2,  751.7,  911.2,  1199.7, 1694.6, 3238.8, 3373.1, NaN,    NaN,    NaN},
+/* S  */ { 162.4, 195.7, 232.8, 277.3, 332.4, 414.4, 542.1, 598.0,  666.2,  754.6,  872.2,  1054.5, 1384.9, 1947.0, 3694.5, 3837.8, NaN,    NaN},
+/* Cl */ { 174.9, 206.8, 242.9, 284.1, 333.8, 395.5, 488.6, 632.1,  694.0,  769.9,  869.1,  1001.8, 1208.2, 1583.7, 2217.2, 4180.2, 4332.5, NaN},
+/* Ar */ { 188.7, 219.5, 254.0, 293.7, 339.4, 394.9, 463.9, 568.6,  728.8,  797.0,  881.1,  991.6,  1140.3, 1372.6, 1796.0, 2505.0, 4695.9, 4857.2 }};
 
-// List of charge states Z0
-const real_t SlowingDownFrequency::meanExcI_Z0s[meanExcI_len] = 
-{
-/*H */ 0, 
-/*He*/ 0, 1, 
-/*Li*/ 0, 1, 2, 
-/*C */ 0, 1, 2, 3, 4, 5, 
-/*Ne*/ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 
-/*Ar*/ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
-};
-
-// List of corresponding mean excitation energies in units of mc2
-const real_t SlowingDownFrequency::meanExcI_data[meanExcI_len] = 
-{
-/*H */ 2.9295e-5, 
-/*He*/ 8.3523e-05, 1.1718e-04, 
-/*Li*/ 6.4775e-05, 2.1155e-04, 2.6243e-04, 
-/*C */ 1.2896e-04, 1.8121e-04, 2.6380e-04, 4.1918e-04, 9.5147e-04, 0.0011, 
-/*Ne*/ 2.6849e-04, 3.2329e-04, 3.8532e-04, 4.6027e-04, 5.5342e-04, 6.9002e-04, 9.2955e-04, 0.0014, 0.0028, 0.0029, 
-/*Ar*/ 3.6888e-04, 4.2935e-04, 4.9667e-04, 5.7417e-04, 6.6360e-04, 7.7202e-04, 9.0685e-04, 0.0011, 0.0014, 0.0016, 0.0017, 0.0019, 0.0022, 0.0027, 0.0035, 0.0049, 0.0092, 0.0095
-};
-
-// Mean excitation energy of neutral hydrogen: also found in meanExcI_data above
-const real_t SlowingDownFrequency::HYDROGEN_MEAN_EXCITATION_ENERGY = 2.9295e-5;
+const real_t SlowingDownFrequency::MEAN_EXCITATION_ENERGY_FUNCTION_D[MAX_NE] = {0, 0.00, 0.24, 0.34, 0.41, 0.45, 0.48, 0.50, 0.51, 0.52, 0.55, 0.57, 0.58, 0.59};
+const real_t SlowingDownFrequency::MEAN_EXCITATION_ENERGY_FUNCTION_S_0[MAX_NE] = {0, 0.30, 1.51, 2.32, 3.13, 3.90, 4.67, 5.44, 6.21, 6.97, 8.10, 9.08, 10.03, 10.94};
+const real_t SlowingDownFrequency::HIGH_Z_EXCITATION_ENERGY_PER_Z = 10.0; // according to Berger et al., J of the ICRU os19 22 (1984), all neutral ions with Z >= 19 have I~10*Z eV (8.8 to 11.1 eV) 
+const real_t SlowingDownFrequency::HYDROGEN_MEAN_EXCITATION_ENERGY = 14.99; // Mean excitation energy for neutral H
 
 
 /**
@@ -95,7 +82,7 @@ SlowingDownFrequency::~SlowingDownFrequency(){
 real_t SlowingDownFrequency::evaluateScreenedTermAtP(len_t iz, len_t Z0, real_t p, OptionConstants::collqty_collfreq_mode collfreq_mode){
     len_t Z = ionHandler->GetZ(iz); 
     len_t ind = ionHandler->GetIndex(iz,Z0);
-    if (atomicParameter[ind]==0)
+    if (Z==Z0) // is there really a reason to have atomicParameter[ind]=0 for Z = Z0? otherwise I would prefer to simply put it to 0 here  
         return 0;
     real_t p2 = p*p;
     real_t gamma = sqrt(1+p2);
@@ -115,23 +102,34 @@ real_t SlowingDownFrequency::evaluateScreenedTermAtP(len_t iz, len_t Z0, real_t 
 
 /**
  * Returns the mean excitation energy of ion species with index iz and charge state Z0.
- * Currently only for ions we have actual data for -- should investigate approximate models for other species.
- * TODO: Implement the approximate analytical 1-parameter formula (8) when data is missing, from 
- *       Sauer, Sabin, Oddershede J Chem Phys 148, 174307 (2018)
+ * When data is missing, it uses the approximate analytical 2-parameter formula (8) from 
+ * Sauer, Sabin, Oddershede J Chem Phys 148, 174307 (2018)
  */
 real_t SlowingDownFrequency::GetAtomicParameter(len_t iz, len_t Z0){
     len_t Z = ionHandler->GetZ(iz);
-    if(Z0==Z)
-        return 0;
-    else if(Z0==(Z-1)) // For hydrogenic ions the mean excitation energy is 14.9916*Z^2 eV 
-        return Z*Z*HYDROGEN_MEAN_EXCITATION_ENERGY;
 
-    // Fetch value from table if it exists:
-    for (len_t n=0; n<meanExcI_len; n++)
-        if( (Z==meanExcI_Zs[n]) && (Z0==meanExcI_Z0s[n]) )
-            return meanExcI_data[n];
+    real_t I;
+    real_t D_N;
+    real_t S_N0;
 
-    throw FVM::FVMException("Mean excitation energy for ion species: '%s' in charge state Z0 = " LEN_T_PRINTF_FMT " is missing.", ionHandler->GetName(iz).c_str(), Z0); 
+    if (Z < MAX_Z){ /* use tabulated data */
+        I = MEAN_EXCITATION_ENERGY_DATA[Z-1][Z0]; // or maybe the other way around...
+    }else{ /* use the formula instead */
+        len_t Ne = Z-Z0;
+        if (Ne <= MAX_NE){
+            D_N = MEAN_EXCITATION_ENERGY_FUNCTION_D[Ne-1]; 
+            S_N0 = MEAN_EXCITATION_ENERGY_FUNCTION_S_0[Ne-1];
+        }else{
+            D_N = MEAN_EXCITATION_ENERGY_FUNCTION_D[MAX_NE]; 
+            S_N0 = Ne - sqrt(Z*HIGH_Z_EXCITATION_ENERGY_PER_Z / HYDROGEN_MEAN_EXCITATION_ENERGY);
+        }
+        real_t A_N = pow(1-D_N, 2);
+        real_t B_N = 2*(1-D_N) * (Ne*D_N - S_N0);
+        real_t C_N = pow(Ne*D_N - S_N0, 2);
+
+        I = HYDROGEN_MEAN_EXCITATION_ENERGY * (A_N*Z*Z + B_N*Z + C_N);
+    }
+    return I / Constants::mc2inEV;
 }
 
 

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -118,7 +118,7 @@ real_t SlowingDownFrequency::GetAtomicParameter(len_t iz, len_t Z0){
             S_N0 = MEAN_EXCITATION_ENERGY_FUNCTION_S_0[Ne-1];
         }else{
             D_N = MEAN_EXCITATION_ENERGY_FUNCTION_D[MAX_NE]; 
-            S_N0 = Ne - sqrt(Z*HIGH_Z_EXCITATION_ENERGY_PER_Z / HYDROGEN_MEAN_EXCITATION_ENERGY);
+            S_N0 = Ne - sqrt(Ne*HIGH_Z_EXCITATION_ENERGY_PER_Z / HYDROGEN_MEAN_EXCITATION_ENERGY); // S_N0: for a neutral atom with Z=N
         }
         real_t A_N = pow(1-D_N, 2);
         real_t B_N = 2*(1-D_N) * (Ne*D_N - S_N0);

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -113,7 +113,7 @@ real_t SlowingDownFrequency::GetAtomicParameter(len_t iz, len_t Z0){
     if (Z == Z0){
         return NAN;
     }
-    if (Z < MAX_Z){ /* use tabulated data */
+    if (Z <= MAX_Z){ /* use tabulated data */
         I = MEAN_EXCITATION_ENERGY_DATA[Z-1][Z0]; // or maybe the other way around...
     }else{ /* use the formula instead */
         len_t Ne = Z-Z0;
@@ -121,12 +121,12 @@ real_t SlowingDownFrequency::GetAtomicParameter(len_t iz, len_t Z0){
             D_N = MEAN_EXCITATION_ENERGY_FUNCTION_D[Ne-1]; 
             S_N0 = MEAN_EXCITATION_ENERGY_FUNCTION_S_0[Ne-1];
         }else{
-            D_N = MEAN_EXCITATION_ENERGY_FUNCTION_D[MAX_NE]; 
+            D_N = MEAN_EXCITATION_ENERGY_FUNCTION_D[MAX_NE-1]; 
             S_N0 = Ne - sqrt(Ne*HIGH_Z_EXCITATION_ENERGY_PER_Z / HYDROGEN_MEAN_EXCITATION_ENERGY); // S_N0: for a neutral atom with Z=N
         }
-        real_t A_N = pow(1-D_N, 2);
+        real_t A_N = (1-D_N) * (1-D_N);
         real_t B_N = 2*(1-D_N) * (Ne*D_N - S_N0);
-        real_t C_N = pow(Ne*D_N - S_N0, 2);
+        real_t C_N = (Ne*D_N - S_N0) * (Ne*D_N - S_N0);
 
         I = HYDROGEN_MEAN_EXCITATION_ENERGY * (A_N*Z*Z + B_N*Z + C_N);
     }

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -114,7 +114,7 @@ real_t SlowingDownFrequency::GetAtomicParameter(len_t iz, len_t Z0){
         return NAN;
     }
     if (Z <= MAX_Z){ /* use tabulated data */
-        I = MEAN_EXCITATION_ENERGY_DATA[Z-1][Z0]; // or maybe the other way around...
+        I = MEAN_EXCITATION_ENERGY_DATA[Z-1][Z0];
     }else{ /* use the formula instead */
         len_t Ne = Z-Z0;
         if (Ne <= MAX_NE){

--- a/src/Equations/SlowingDownFrequency.cpp
+++ b/src/Equations/SlowingDownFrequency.cpp
@@ -80,7 +80,7 @@ SlowingDownFrequency::~SlowingDownFrequency(){
 real_t SlowingDownFrequency::evaluateScreenedTermAtP(len_t iz, len_t Z0, real_t p, OptionConstants::collqty_collfreq_mode collfreq_mode){
     len_t Z = ionHandler->GetZ(iz); 
     len_t ind = ionHandler->GetIndex(iz,Z0);
-    if (Z==Z0) // is there really a reason to have atomicParameter[ind]=0 for Z = Z0? otherwise I would prefer to simply put it to 0 here  
+    if (Z==Z0)
         return 0;
     real_t p2 = p*p;
     real_t gamma = sqrt(1+p2);

--- a/tests/cxx/CMakeLists.txt
+++ b/tests/cxx/CMakeLists.txt
@@ -6,10 +6,11 @@ set(dreamtests_core
 )
 
 set(dreamtests_dream
+    "${PROJECT_SOURCE_DIR}/tests/cxx/tests/DREAM/AvalancheSourceRP.cpp"
     "${PROJECT_SOURCE_DIR}/tests/cxx/tests/DREAM/BoundaryFlux.cpp"
     "${PROJECT_SOURCE_DIR}/tests/cxx/tests/DREAM/IonRateEquation.cpp"
+    "${PROJECT_SOURCE_DIR}/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp"
     "${PROJECT_SOURCE_DIR}/tests/cxx/tests/DREAM/RunawayFluid.cpp"
-    "${PROJECT_SOURCE_DIR}/tests/cxx/tests/DREAM/AvalancheSourceRP.cpp"
 )
 
 set(dreamtests_fvm

--- a/tests/cxx/runtest.cpp
+++ b/tests/cxx/runtest.cpp
@@ -21,6 +21,7 @@
 #include "tests/DREAM/IonRateEquation.hpp"
 #include "tests/DREAM/RunawayFluid.hpp"
 #include "tests/DREAM/AvalancheSourceRP.hpp"
+#include "tests/DREAM/MeanExcitationEnergy.hpp"
 
 #include "tests/FVM/AdvectionTerm.hpp"
 #include "tests/FVM/AdvectionDiffusionTerm.hpp"
@@ -40,10 +41,11 @@ void add_test(UnitTest *t) {
 	tests.push_back(t);
 }
 void init() {
+    add_test(new DREAMTESTS::_DREAM::AvalancheSourceRP("dream/avalanche"));
     add_test(new DREAMTESTS::_DREAM::BoundaryFlux("dream/boundaryflux"));
     add_test(new DREAMTESTS::_DREAM::IonRateEquation("dream/ionrateequation"));
+    add_test(new DREAMTESTS::_DREAM::MeanExcitationEnergy("dream/meanexcitationenergy"));
     add_test(new DREAMTESTS::_DREAM::RunawayFluid("dream/runawayfluid"));
-    add_test(new DREAMTESTS::_DREAM::AvalancheSourceRP("dream/avalanche"));
 
     add_test(new DREAMTESTS::FVM::AdvectionTerm("fvm/advectionterm"));
     add_test(new DREAMTESTS::FVM::AdvectionDiffusionTerm("fvm/advectiondiffusionterm"));

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp
@@ -1,0 +1,191 @@
+/**
+ * A test to verify the updated values for the mean excitation energy,
+ * using the model by Sauer, Sabin, Oddershede J Chem Phys 148, 174307 (2018)
+ */
+
+#include <vector>
+#include <string>
+#include "MeanExcitationEnergy.hpp"
+#include "DREAM/ADAS.hpp"
+#include "DREAM/IonHandler.hpp"
+#include "DREAM/Settings/OptionConstants.hpp"
+#include "FVM/UnknownQuantityHandler.hpp"
+#include "FVM/Grid/Grid.hpp"
+#include <iostream>
+
+using namespace DREAMTESTS::_DREAM;
+using namespace std;
+
+/**
+ * Run this test.
+ */
+bool MeanExcitationEnergy::Run(bool) {
+
+    bool success = true;
+    if (CompareMeanExcitationEnergyWithTabulated())
+        this->PrintOK("The mean excitation energy agrees with tabulated values.");
+    else {
+        success = false;
+        this->PrintError("The mean excitation energy test failed.");
+    }
+    return success;
+}
+
+
+/**
+ * Generate an unknown quantity handler.
+ */
+DREAM::FVM::UnknownQuantityHandler *MeanExcitationEnergy::GetUnknownHandler(DREAM::FVM::Grid *g, 
+    const len_t N_IONS, const len_t *Z_IONS, const real_t ION_DENSITY_REF, const real_t T_cold) {
+    DREAM::FVM::UnknownQuantityHandler *uqh = new DREAM::FVM::UnknownQuantityHandler();
+
+    len_t nZ0 = 0;
+    for (len_t i = 0; i < N_IONS; i++)
+        nZ0 += Z_IONS[i] + 1;
+
+    this->id_ions = uqh->InsertUnknown(DREAM::OptionConstants::UQTY_ION_SPECIES, "0", g, nZ0);
+    uqh->InsertUnknown(DREAM::OptionConstants::UQTY_N_COLD, "0", g);
+    uqh->InsertUnknown(DREAM::OptionConstants::UQTY_N_HOT, "0", g);
+    uqh->InsertUnknown(DREAM::OptionConstants::UQTY_N_TOT, "0", g);
+    uqh->InsertUnknown(DREAM::OptionConstants::UQTY_T_COLD, "0", g);
+    uqh->InsertUnknown(DREAM::OptionConstants::UQTY_F_HOT, "0", g);
+    uqh->InsertUnknown(DREAM::OptionConstants::UQTY_E_FIELD, "0", g);
+    
+
+    real_t ni;
+    // Set initial values
+    // we don't care about the density, just set it to the same value everywhere.
+    const len_t N = nZ0*g->GetNr();
+    real_t *nions = new real_t[N];
+    real_t ncold = 0;
+    real_t ntot = 0;
+    len_t ionOffset = 0, rOffset = 0;
+    for (len_t iIon = 0; iIon < N_IONS; iIon++) 
+        for (len_t Z0 = 0; Z0 <= Z_IONS[iIon]; Z0++, ionOffset++){ 
+            ni =  ION_DENSITY_REF;
+            ncold += Z0*ni;
+            ntot  += Z_IONS[iIon]*ni;
+            for (len_t ir = 0; ir < g->GetNr(); ir++, rOffset++)
+                nions[rOffset] = ni;
+        }
+        
+    
+    uqh->SetInitialValue(DREAM::OptionConstants::UQTY_ION_SPECIES, nions);
+
+    #define SETVAL(NAME, v) do { \
+            for (len_t i = 0; i < g->GetNr(); i++) \
+                temp[i] = (v); \
+            uqh->SetInitialValue((NAME), temp); \
+        } while (false)
+
+    // Set electron quantities
+    real_t *temp = new real_t[g->GetNr()];
+    SETVAL(DREAM::OptionConstants::UQTY_N_COLD, ncold);
+    SETVAL(DREAM::OptionConstants::UQTY_N_HOT,  ncold*1e-12);
+    SETVAL(DREAM::OptionConstants::UQTY_N_TOT,  ntot);
+    SETVAL(DREAM::OptionConstants::UQTY_T_COLD, T_cold);
+    SETVAL(DREAM::OptionConstants::UQTY_F_HOT, 0);
+
+    for(len_t i=0;i<g->GetNr();i++)
+        temp[i] = 20*(30*i+1);
+    uqh->SetInitialValue(DREAM::OptionConstants::UQTY_E_FIELD,temp);
+
+    delete [] nions;
+    delete [] temp;
+    
+    return uqh;
+}
+
+
+/**
+ * Generate a default ion handler.
+ */
+DREAM::IonHandler *MeanExcitationEnergy::GetIonHandler(
+    DREAM::FVM::Grid *g, DREAM::FVM::UnknownQuantityHandler *uqh, const len_t N_IONS, const len_t *Z_IONS
+) {
+    vector<string> tritiumNames(0);
+    vector<string> names(N_IONS);
+    for (len_t i = 0; i < N_IONS; i++)
+        names[i] = "";//ION_NAMES[i];
+
+    return new DREAM::IonHandler(
+        g->GetRadialGrid(), uqh, Z_IONS, N_IONS, names, tritiumNames
+    );
+}
+
+// it's not really practical to use a runaway fluid, because nuS and nuD are private. Maybe I should return both nuS and nuD?
+// I thought methods should not be capitalized? 
+real_t *MeanExcitationEnergy::GetMeanExcitationEnergies(
+    DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS, 
+    const lent_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST,
+    const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr,
+){
+    DREAM::FVM::Grid *grid = this->InitializeFluidGrid(nr,B0);
+    
+    DREAM::FVM::UnknownQuantityHandler *unknowns = GetUnknownHandler(grid,N_IONS, Z_IONS, ION_DENSITY_REF,T_cold);
+    DREAM::IonHandler *ionHandler = GetIonHandler(grid,unknowns, N_IONS, Z_IONS);
+    DREAM::OptionConstants::momentumgrid_type gridtype = DREAM::OptionConstants::MOMENTUMGRID_TYPE_PXI;
+
+    DREAM::CoulombLogarithm *lnLEE = new DREAM::CoulombLogarithm(grid,unknowns,ionHandler,gridtype,cq,DREAM::CollisionQuantity::LNLAMBDATYPE_EE);
+    DREAM::CoulombLogarithm *lnLEI = new DREAM::CoulombLogarithm(grid,unknowns,ionHandler,gridtype,cq,DREAM::CollisionQuantity::LNLAMBDATYPE_EI);
+    DREAM::SlowingDownFrequency *nuS = new DREAM::SlowingDownFrequency(grid,unknowns,ionHandler,lnLEE,lnLEI,gridtype,cq);
+    DREAM::PitchScatterFrequency *nuD = new DREAM::PitchScatterFrequency(grid,unknowns,ionHandler,lnLEI,lnLEE,gridtype,cq);
+
+    //DREAM::RunawayFluid *REFluid = new DREAM::RunawayFluid(grid, unknowns, nuS,nuD,lnLEE,lnLEI, cq, ionHandler, dreicer_mode, DREAM::OptionConstants::COLLQTY_ECEFF_MODE_FULL, DREAM::OptionConstants::EQTERM_AVALANCHE_MODE_FLUID, DREAM::OptionConstants::EQTERM_COMPTON_MODE_NEGLECT, 0.0);
+    //REFluid->Rebuild();
+    
+    real_t meanExcitationEnergies[N_SPECIES_TO_TEST];
+    len_t iz = 0; Z_old = Z_IONS[iz]
+    for (len_t is = 0; is < N_SPECIES_TO_TEST; is++) {
+        if (Z_TO_TEST[is] != Z_IONS[iz]){ iz++; }
+        meanExcitationEnergies[is] = nuS.getAtomicParameter(iz,Z0_TO_TEST[is]);
+    }
+
+    return meanExcitationEnergies; // If we want to test the length parameter in nuD as well, we might want to generalize this to return either nuS or nuD? it doesn't seem obvious how to return multiple parameter
+  
+}
+
+bool MeanExcitationEnergy::CompareMeanExcitationEnergyWithTabulated(){
+
+    DREAM::CollisionQuantity::collqty_settings *cq =
+        new DREAM::CollisionQuantity::collqty_settings;
+
+    cq->collfreq_type = DREAM::OptionConstants::COLLQTY_COLLISION_FREQUENCY_TYPE_PARTIALLY_SCREENED;
+    cq->collfreq_mode = DREAM::OptionConstants::COLLQTY_COLLISION_FREQUENCY_MODE_SUPERTHERMAL;
+    cq->lnL_type      = DREAM::OptionConstants::COLLQTY_LNLAMBDA_ENERGY_DEPENDENT;
+    cq->bremsstrahlung_mode = DREAM::OptionConstants::EQTERM_BREMSSTRAHLUNG_MODE_STOPPING_POWER;
+
+    len_t nr = 1;
+
+    const len_t N_IONS = 3;
+    const len_t Z_IONS[N_IONS] = {10,18,36};
+    const len_t N_SPECIES_TO_TEST = 9;
+    const len_t Z_TO_TEST[N_SPECIES_TO_TEST] =  {10,10,10,18,18,18,36,36,36};
+    const len_t Z0_TO_TEST[N_SPECIES_TO_TEST] = { 0, 1, 5, 0, 1, 9, 0, 1,18};
+
+    const real_t TABULATED_MEAN_EXCITATION_ENERGIES[] = {//Ne0, Ne1, Ne5, Ar0, Ar1, Ar9, Kr0, Kr1, Kr18
+    2.68494e-04, 
+    3.23288e-04, 
+    6.90021e-04, 
+    3.69277e-04, 
+    4.29551e-04, 
+    1.55969e-03, 
+    7.04502e-04, 
+    8.06097e-04, 
+    3.45034e-03, 
+    };
+
+    real_t ION_DENSITY_REF = 1e18; // m-3
+    real_t T_cold = 1; // eV
+    real_t B0 = 5;
+    real_t *meanExciationEnergies = GetMeanExcitationEnergies(cq,N_IONS, Z_IONS, 
+    N_SPECIES_TO_TEST, Z_TO_TEST, Z0_TO_TEST,
+    ION_DENSITY_REF, T_cold,B0,nr);
+    
+    bool success = true;
+    const real_t TOLERANCE = 100.0*std::numeric_limits<real_t>::epsilon();
+    for (len_t is = 0; is < N_SPECIES_TO_TEST; is++) {
+        delta = abs(meanExciationEnergies[is] - TABULATED_MEAN_EXCITATION_ENERGIES[is]) / TABULATED_MEAN_EXCITATION_ENERGIES[is];
+        success = success & delta < TOLERANCE;
+    }
+}

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp
@@ -117,9 +117,8 @@ DREAM::IonHandler *MeanExcitationEnergy::GetIonHandler(
     );
 }
 
-real_t *MeanExcitationEnergy::GetMeanExcitationEnergies(
-    DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS, 
-    const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST, real_t *meanExcitationEnergies,
+real_t* MeanExcitationEnergy::GetMeanExcitationEnergies(DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS, 
+    const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST,
     const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr
 ){
     DREAM::FVM::Grid *grid = this->InitializeFluidGrid(nr,B0);
@@ -133,6 +132,7 @@ real_t *MeanExcitationEnergy::GetMeanExcitationEnergies(
     DREAM::SlowingDownFrequency nuS(grid,unknowns,ionHandler,&lnLEE,&lnLEI,gridtype,cq);
     // DREAM::PitchScatterFrequency *nuD = new DREAM::PitchScatterFrequency(grid,unknowns,ionHandler,lnLEI,lnLEE,gridtype,cq);
     
+    real_t *meanExcitationEnergies = new real_t[N_SPECIES_TO_TEST];
     len_t iz = 0;
     for (len_t is = 0; is < N_SPECIES_TO_TEST; is++) {
         if (Z_TO_TEST[is] != Z_IONS[iz]){ iz++; }
@@ -142,7 +142,7 @@ real_t *MeanExcitationEnergy::GetMeanExcitationEnergies(
     delete ionHandler;
     delete unknowns;
     delete grid;
-    return meanExcitationEnergies; // If we want to test the length parameter in nuD as well, we might want to generalize this to return either nuS or nuD? it doesn't seem obvious how to return multiple parameters
+    return meanExcitationEnergies; // If we want to test the length parameter in nuD as well, we might want to generalize this to return either nuS or nuD?
   
 }
 
@@ -181,20 +181,18 @@ bool MeanExcitationEnergy::CompareMeanExcitationEnergyWithTabulated(){
     real_t T_cold = 1; // eV
     real_t B0 = 5;
 
-    real_t meanExcitationEnergies[N_SPECIES_TO_TEST];
-    real_t *meanExciationEnergies = GetMeanExcitationEnergies(cq,N_IONS, Z_IONS, 
-    N_SPECIES_TO_TEST, Z_TO_TEST, Z0_TO_TEST,meanExcitationEnergies,ION_DENSITY_REF, T_cold,B0,nr);
+    real_t *meanExcitationEnergies = GetMeanExcitationEnergies(cq,N_IONS, Z_IONS,
+    N_SPECIES_TO_TEST, Z_TO_TEST, Z0_TO_TEST,ION_DENSITY_REF, T_cold,B0,nr);
     
     real_t delta;
     bool success = true;
     const real_t TOLERANCE = 1e-4;
     for (len_t is = 0; is < N_SPECIES_TO_TEST; is++) {
-        delta = abs(meanExciationEnergies[is] - TABULATED_MEAN_EXCITATION_ENERGIES[is]) / TABULATED_MEAN_EXCITATION_ENERGIES[is];
+        delta = abs(meanExcitationEnergies[is] - TABULATED_MEAN_EXCITATION_ENERGIES[is]) / TABULATED_MEAN_EXCITATION_ENERGIES[is];
         success = success & (delta < TOLERANCE);
-        printf("is=" LEN_T_PRINTF_FMT ", Z=" LEN_T_PRINTF_FMT ", Z0=" LEN_T_PRINTF_FMT ",\t delta = %.5f, I = %.5e, I_table = %.5e \n", 
-        is, Z_TO_TEST[is], Z0_TO_TEST[is], delta, meanExciationEnergies[is], TABULATED_MEAN_EXCITATION_ENERGIES[is]);
     }
 
     delete cq;
     return success;
+    delete meanExcitationEnergies;
 }

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
@@ -5,10 +5,8 @@
 #include "FVM/Grid/Grid.hpp"
 #include "FVM/UnknownQuantityHandler.hpp"
 #include "DREAM/IonHandler.hpp"
-#include "DREAM/Equations/ConnorHastie.hpp"
-#include "DREAM/Equations/RunawayFluid.hpp"
-#include "DREAM/Settings/OptionConstants.hpp"
 #include "UnitTest.hpp"
+#include "DREAM/Equations/CollisionQuantity.hpp"
 
 namespace DREAMTESTS::_DREAM {
     class MeanExcitationEnergy : public UnitTest {
@@ -16,16 +14,15 @@ namespace DREAMTESTS::_DREAM {
         len_t id_ions;
 
     public:
-        RunawayFluid(const std::string& s) : UnitTest(s) {}
+        MeanExcitationEnergy(const std::string& s) : UnitTest(s) {}
+        virtual ~MeanExcitationEnergy() {}
 
         DREAM::IonHandler *GetIonHandler(DREAM::FVM::Grid*, DREAM::FVM::UnknownQuantityHandler*, const len_t, const len_t*);
         DREAM::FVM::UnknownQuantityHandler *GetUnknownHandler(DREAM::FVM::Grid*,
             const len_t, const len_t*, const real_t, const real_t);
-        real_t *RunawayFluid::GetMeanExcitationEnergies(
-        DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS, 
-            const lent_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST,
-            const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr,
-        );
+        real_t *GetMeanExcitationEnergies(DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS,
+            const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST, real_t *meanExcitationEnergies, 
+            const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr);
         bool CompareMeanExcitationEnergyWithTabulated();
 
         virtual bool Run(bool) override;

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
@@ -1,0 +1,35 @@
+#ifndef _DREAMTESTS_DREAM_MEAN_EXCITATION_ENERGY_HPP
+#define _DREAMTESTS_DREAM_MEAN_EXCITATION_ENERGY_HPP
+
+#include <string>
+#include "FVM/Grid/Grid.hpp"
+#include "FVM/UnknownQuantityHandler.hpp"
+#include "DREAM/IonHandler.hpp"
+#include "DREAM/Equations/ConnorHastie.hpp"
+#include "DREAM/Equations/RunawayFluid.hpp"
+#include "DREAM/Settings/OptionConstants.hpp"
+#include "UnitTest.hpp"
+
+namespace DREAMTESTS::_DREAM {
+    class MeanExcitationEnergy : public UnitTest {
+    private:
+        len_t id_ions;
+
+    public:
+        RunawayFluid(const std::string& s) : UnitTest(s) {}
+
+        DREAM::IonHandler *GetIonHandler(DREAM::FVM::Grid*, DREAM::FVM::UnknownQuantityHandler*, const len_t, const len_t*);
+        DREAM::FVM::UnknownQuantityHandler *GetUnknownHandler(DREAM::FVM::Grid*,
+            const len_t, const len_t*, const real_t, const real_t);
+        real_t *RunawayFluid::GetMeanExcitationEnergies(
+        DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS, 
+            const lent_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST,
+            const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr,
+        );
+        bool CompareMeanExcitationEnergyWithTabulated();
+
+        virtual bool Run(bool) override;
+    };
+}
+
+#endif/*_DREAMTESTS_DREAM_MEAN_EXCITATION_ENERGY_HPP*/

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
@@ -21,7 +21,7 @@ namespace DREAMTESTS::_DREAM {
         DREAM::FVM::UnknownQuantityHandler *GetUnknownHandler(DREAM::FVM::Grid*,
             const len_t, const len_t*, const real_t, const real_t);
         real_t *GetMeanExcitationEnergies(DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS,
-            const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST, real_t *meanExcitationEnergies, 
+            const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST,// real_t *meanExcitationEnergies, 
             const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr);
         bool CompareMeanExcitationEnergyWithTabulated();
 

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.hpp
@@ -20,8 +20,8 @@ namespace DREAMTESTS::_DREAM {
         DREAM::IonHandler *GetIonHandler(DREAM::FVM::Grid*, DREAM::FVM::UnknownQuantityHandler*, const len_t, const len_t*);
         DREAM::FVM::UnknownQuantityHandler *GetUnknownHandler(DREAM::FVM::Grid*,
             const len_t, const len_t*, const real_t, const real_t);
-        real_t *GetMeanExcitationEnergies(DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS,
-            const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST,// real_t *meanExcitationEnergies, 
+        void GetMeanExcitationEnergies(real_t *meanExcitationEnergies, DREAM::CollisionQuantity::collqty_settings *cq, const len_t N_IONS, const len_t *Z_IONS,
+            const len_t N_SPECIES_TO_TEST, const len_t *Z_TO_TEST, const len_t *Z0_TO_TEST, 
             const real_t ION_DENSITY_REF, const real_t T_cold, const real_t B0, const len_t nr);
         bool CompareMeanExcitationEnergyWithTabulated();
 

--- a/tests/cxx/tests/DREAM/RunawayFluid.cpp
+++ b/tests/cxx/tests/DREAM/RunawayFluid.cpp
@@ -3,6 +3,8 @@
  * derived collision quantities such as the avalanche growth rate and critical E field. 
  * Calculations are benchmarked with values tabulated by DREAM simulations in
  * commit c8f1923d962b3b565ace4e2b033e37ad0a0cb5a8.
+ * The Eceff values were updated in commit b5c5dab98742f3925c71177e27b536a4693a25aa when
+ * the mean excitation energies were updated. 
  * The Eceff calculation was compared with the function used to generate figures (2-3) 
  * of Hesslow et al, PPCF 60, 074010 (2018), CODE_screened/getEceffWithSynch.m, yielding
  * errors <1% in all three cases when the same bremsstrahlung formula was used in DREAM.

--- a/tests/cxx/tests/DREAM/RunawayFluid.cpp
+++ b/tests/cxx/tests/DREAM/RunawayFluid.cpp
@@ -197,8 +197,8 @@ bool RunawayFluid::CompareEceffWithTabulated(){
     REFluid = GetRunawayFluid(cq,N_IONS2, Z_IONS2, ION_DENSITY_REF, T_cold,B0,nr);
     Eceff3 = REFluid->GetEffectiveCriticalField(0);
 
-    real_t TabulatedEceff1 = 8.88124;
-    real_t TabulatedEceff2 = 8.00712;
+    real_t TabulatedEceff1 = 8.86778;
+    real_t TabulatedEceff2 = 7.99316;
     real_t TabulatedEceff3 = 1.10307;
     real_t delta1 = abs(Eceff1-TabulatedEceff1)/TabulatedEceff1;
     real_t delta2 = abs(Eceff2-TabulatedEceff2)/TabulatedEceff2;

--- a/tests/cxx/tests/DREAM/RunawayFluid.cpp
+++ b/tests/cxx/tests/DREAM/RunawayFluid.cpp
@@ -199,8 +199,8 @@ bool RunawayFluid::CompareEceffWithTabulated(){
     REFluid = GetRunawayFluid(cq,N_IONS2, Z_IONS2, ION_DENSITY_REF, T_cold,B0,nr);
     Eceff3 = REFluid->GetEffectiveCriticalField(0);
 
-    real_t TabulatedEceff1 = 8.86778;
-    real_t TabulatedEceff2 = 7.99316;
+    real_t TabulatedEceff1 = 8.88081;
+    real_t TabulatedEceff2 = 8.00666;
     real_t TabulatedEceff3 = 1.10307;
     real_t delta1 = abs(Eceff1-TabulatedEceff1)/TabulatedEceff1;
     real_t delta2 = abs(Eceff2-TabulatedEceff2)/TabulatedEceff2;


### PR DESCRIPTION
Implemented Sauer's model for the mean excitation energy, and wrote a test to check with my python code. A description (along with a sensitivity test on D_N) can be found at svn under linnea/DREAM_related/notes. Please check whether I should use the GetMeanExciatationEnergy function instead, and in that case, why it does not run.