### PR TITLE
New heateq

### DIFF
--- a/examples/consistentE/basicE.py
+++ b/examples/consistentE/basicE.py
@@ -33,9 +33,7 @@ ds = DREAMSettings()
 # set collision settings
 ds.collisions.collfreq_mode = Collisions.COLLFREQ_MODE_FULL
 ds.collisions.collfreq_type = Collisions.COLLFREQ_TYPE_PARTIALLY_SCREENED
-#ds.collisions.bremsstrahlung_mode = Collisions.BREMSSTRAHLUNG_MODE_NEGLECT
 ds.collisions.bremsstrahlung_mode = Collisions.BREMSSTRAHLUNG_MODE_STOPPING_POWER
-#ds.collisions.lnlambda = Collisions.LNLAMBDA_CONSTANT
 ds.collisions.lnlambda = Collisions.LNLAMBDA_ENERGY_DEPENDENT
 
 #############################
@@ -51,10 +49,10 @@ E_initial = 60      # initial electric field in V/m
 E_wall = 0.0        # boundary electric field in V/m
 T_initial = 4       # initial temperature in eV
 
-Tmax_init2 = 1e-3    # simulation time in seconds
-Nt_init2 = 10         # number of time steps
-Tmax_init1 = 5e-5    # simulation time in seconds
-Nt_init1 = 7         # number of time steps
+Tmax_init2 = 1e-3   # simulation time in seconds
+Nt_init2 = 10       # number of time steps
+Tmax_init1 = 5e-5   # simulation time in seconds
+Nt_init1 = 7        # number of time steps
 Nr = 4              # number of radial grid points
 Np = 200            # number of momentum grid points
 Nxi = 5             # number of pitch grid points
@@ -74,9 +72,6 @@ ds.radialgrid.setNr(Nr)
 # Set ions
 ds.eqsys.n_i.addIon(name='D', Z=1, iontype=Ions.IONS_DYNAMIC_FULLY_IONIZED, n=1e20)
 ds.eqsys.n_i.addIon(name='Ar', Z=18, iontype=Ions.IONS_DYNAMIC_NEUTRAL, n=1e20)
-#ds.eqsys.n_i.addIon(name='D', Z=1, iontype=Ions.IONS_PRESCRIBED_FULLY_IONIZED, n=1e20)
-#ds.eqsys.n_i.addIon(name='Ar', Z=18, iontype=Ions.IONS_PRESCRIBED_NEUTRAL, n=1e20)
-
 
 # Set E_field 
 efield = E_initial*np.ones((len(times), len(radius)))
@@ -106,10 +101,9 @@ ds.runawaygrid.setEnabled(False)
 
 # Use the new nonlinear solver
 ds.solver.setType(Solver.NONLINEAR)
-#ds.solver.setLinearSolver(linsolv=Solver.LINEAR_SOLVER_GMRES)
 ds.solver.setTolerance(reltol=1e-4)
 ds.solver.setMaxIterations(maxiter = 100)
-ds.solver.setVerbose(False)
+ds.solver.setVerbose(True)
 
 
 ds.other.include('fluid', 'lnLambda','nu_s','nu_D')
@@ -126,9 +120,10 @@ ds.timestep.setTmax(Tmax_init2)
 ds.timestep.setNt(Nt_init2)
 if T_selfconsistent:
     ds.eqsys.T_cold.setType(ttype=T_cold.TYPE_SELFCONSISTENT)
+ds.solver.setLinearSolver(Solver.LINEAR_SOLVER_LU)
 
-ds.save('init_settings.h5')
 ds.fromOutput('output_init.h5')
+ds.save('init_settings.h5')
 runiface(ds, 'output_init.h5', quiet=False)
 
 
@@ -148,5 +143,5 @@ ds2.timestep.setTmax(Tmax_restart)
 ds2.timestep.setNt(Nt_restart)
 
 ds2.save('restart_settings.h5')
-runiface(ds, 'output.h5', quiet=False)
+runiface(ds2, 'output.h5', quiet=False)
 

--- a/include/DREAM/Equations/Fluid/RadiatedPowerTerm.hpp
+++ b/include/DREAM/Equations/Fluid/RadiatedPowerTerm.hpp
@@ -7,11 +7,13 @@
 #include "DREAM/Equations/RunawayFluid.hpp"
 #include "DREAM/IonHandler.hpp"
 #include "DREAM/ADAS.hpp"
+#include "DREAM/NIST.hpp"
 
 namespace DREAM {
     class RadiatedPowerTerm : public FVM::DiagonalComplexTerm {
     private:
         ADAS *adas;
+        NIST *nist;
         IonHandler *ionHandler;
 
         len_t id_ncold;
@@ -25,7 +27,7 @@ namespace DREAM {
         virtual void SetDiffWeights(len_t derivId, len_t nMultiples) override;
 
     public:
-        RadiatedPowerTerm(FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*, ADAS*);
+        RadiatedPowerTerm(FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*, ADAS*, NIST*);
     };
 }
 

--- a/include/DREAM/Settings/SimulationGenerator.hpp
+++ b/include/DREAM/Settings/SimulationGenerator.hpp
@@ -152,7 +152,7 @@ namespace DREAM {
         static void ConstructEquation_T_cold(EquationSystem*, Settings*, ADAS*, NIST*, struct OtherQuantityHandler::eqn_terms*);
         static void ConstructEquation_T_cold_prescribed(EquationSystem*, Settings*);
         static void ConstructEquation_T_cold_selfconsistent(EquationSystem*, Settings*, ADAS*, NIST*, struct OtherQuantityHandler::eqn_terms*);
-        static void ConstructEquation_W_cold(EquationSystem*, Settings*, NIST*);
+        static void ConstructEquation_W_cold(EquationSystem*, Settings*);
 
         template<typename T>
         static T *ConstructTransportTerm_internal(const std::string&, FVM::Grid*, enum OptionConstants::momentumgrid_type, Settings*, bool, const std::string& subname="transport");

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,6 @@ set(dream_equations
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/IonTransientTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/FreeElectronDensityTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/TotalElectronDensityTerm.cpp"
-    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/BindingEnergyTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/RadiatedPowerTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/IonisationHeatingTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/CollisionalEnergyTransferKineticTerm.cpp"

--- a/src/Equations/Fluid/RadiatedPowerTerm.cpp
+++ b/src/Equations/Fluid/RadiatedPowerTerm.cpp
@@ -17,10 +17,11 @@
 using namespace DREAM;
 
 
-RadiatedPowerTerm::RadiatedPowerTerm(FVM::Grid* g, FVM::UnknownQuantityHandler *u, IonHandler *ionHandler, ADAS *adas) 
+RadiatedPowerTerm::RadiatedPowerTerm(FVM::Grid* g, FVM::UnknownQuantityHandler *u, IonHandler *ionHandler, ADAS *adas, NIST *nist) 
     : FVM::DiagonalComplexTerm(g,u) 
 {
     this->adas = adas;
+    this->nist = nist;
     this->ionHandler = ionHandler;
 
     this->id_ncold = unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD);
@@ -44,21 +45,31 @@ void RadiatedPowerTerm::SetWeights()
     real_t *T_cold = unknowns->GetUnknownData(id_Tcold);
     real_t *n_i    = unknowns->GetUnknownData(id_ni);
     
-
     for (len_t i = 0; i < NCells; i++)
             weights[i] = 0;
-
 
     for(len_t iz = 0; iz<nZ; iz++){
         ADASRateInterpolator *PLT_interper = adas->GetPLT(Zs[iz]);
         ADASRateInterpolator *PRB_interper = adas->GetPRB(Zs[iz]);
+        ADASRateInterpolator *ACD_interper = adas->GetACD(Zs[iz]);
+        ADASRateInterpolator *SCD_interper = adas->GetSCD(Zs[iz]);
+        real_t dWi = 0;
         for(len_t Z0 = 0; Z0<=Zs[iz]; Z0++){
             len_t nMultiple = ionHandler->GetIndex(iz,Z0);
             for (len_t i = 0; i < NCells; i++){
+                // Radiated power term
                 real_t Li =  PLT_interper->Eval(Z0, n_cold[i], T_cold[i])
                             + PRB_interper->Eval(Z0, n_cold[i], T_cold[i]);
+                real_t Bi = 0;
+                // Binding energy rate term
+                if(Z0>0)       // Recombination gain
+                    Bi -= dWi * ACD_interper->Eval(Z0, n_cold[i], T_cold[i]);
+                if(Z0<Zs[iz]){ // Ionization loss
+                    dWi = Constants::ec * nist->GetIonizationEnergy(Zs[iz],Z0);
+                    Bi += dWi * SCD_interper->Eval(Z0, n_cold[i], T_cold[i]);
+                }
                 real_t ni = n_i[nMultiple*NCells + i];
-                weights[i] += ni*Li;
+                weights[i] += ni*(Li+Bi);
             }
         }
     }
@@ -77,12 +88,22 @@ void RadiatedPowerTerm::SetDiffWeights(len_t derivId, len_t /*nMultiples*/){
         for(len_t iz = 0; iz<nZ; iz++){
             ADASRateInterpolator *PLT_interper = adas->GetPLT(Zs[iz]);
             ADASRateInterpolator *PRB_interper = adas->GetPRB(Zs[iz]);
+            ADASRateInterpolator *ACD_interper = adas->GetACD(Zs[iz]);
+            ADASRateInterpolator *SCD_interper = adas->GetSCD(Zs[iz]);
+            real_t dWi = 0;
             for(len_t Z0 = 0; Z0<=Zs[iz]; Z0++){
                 len_t nMultiple = ionHandler->GetIndex(iz,Z0);
                 for (len_t i = 0; i < NCells; i++){
                     real_t Li =  PLT_interper->Eval(Z0, n_cold[i], T_cold[i])
                                 + PRB_interper->Eval(Z0, n_cold[i], T_cold[i]);
-                    diffWeights[NCells*nMultiple + i] = Li;
+                    real_t Bi = 0;
+                    if(Z0>0)
+                        Bi -= dWi * ACD_interper->Eval(Z0, n_cold[i], T_cold[i]);
+                    if(Z0<Zs[iz]){
+                        dWi = Constants::ec * nist->GetIonizationEnergy(Zs[iz],Z0);
+                        Bi += dWi * SCD_interper->Eval(Z0, n_cold[i], T_cold[i]);
+                    }
+                    diffWeights[NCells*nMultiple + i] = Li+Bi;
                 }
             }
         }
@@ -90,13 +111,23 @@ void RadiatedPowerTerm::SetDiffWeights(len_t derivId, len_t /*nMultiples*/){
         for(len_t iz = 0; iz<nZ; iz++){
             ADASRateInterpolator *PLT_interper = adas->GetPLT(Zs[iz]);
             ADASRateInterpolator *PRB_interper = adas->GetPRB(Zs[iz]);
+            ADASRateInterpolator *ACD_interper = adas->GetACD(Zs[iz]);
+            ADASRateInterpolator *SCD_interper = adas->GetSCD(Zs[iz]);
+            real_t dWi = 0;
             for(len_t Z0 = 0; Z0<=Zs[iz]; Z0++){
                 len_t nMultiple = ionHandler->GetIndex(iz,Z0);
                 for (len_t i = 0; i < NCells; i++){
                     real_t dLi =  PLT_interper->Eval_deriv_n(Z0, n_cold[i], T_cold[i])
                                 + PRB_interper->Eval_deriv_n(Z0, n_cold[i], T_cold[i]);
+                    real_t dBi = 0;
+                    if(Z0>0)
+                        dBi -= dWi * ACD_interper->Eval_deriv_n(Z0, n_cold[i], T_cold[i]);
+                    if(Z0<Zs[iz]){
+                        dWi = Constants::ec * nist->GetIonizationEnergy(Zs[iz],Z0);
+                        dBi += dWi * SCD_interper->Eval_deriv_n(Z0, n_cold[i], T_cold[i]);
+                    }
                     real_t ni = n_i[nMultiple*NCells + i];
-                    diffWeights[i] += ni*dLi;
+                    diffWeights[i] += ni*(dLi+dBi);
                 }
             }
         }
@@ -104,13 +135,23 @@ void RadiatedPowerTerm::SetDiffWeights(len_t derivId, len_t /*nMultiples*/){
         for(len_t iz = 0; iz<nZ; iz++){
             ADASRateInterpolator *PLT_interper = adas->GetPLT(Zs[iz]);
             ADASRateInterpolator *PRB_interper = adas->GetPRB(Zs[iz]);
+            ADASRateInterpolator *ACD_interper = adas->GetACD(Zs[iz]);
+            ADASRateInterpolator *SCD_interper = adas->GetSCD(Zs[iz]);
+            real_t dWi = 0;
             for(len_t Z0 = 0; Z0<=Zs[iz]; Z0++){
                 len_t nMultiple = ionHandler->GetIndex(iz,Z0);
                 for (len_t i = 0; i < NCells; i++){
                     real_t dLi =  PLT_interper->Eval_deriv_T(Z0, n_cold[i], T_cold[i])
                                 + PRB_interper->Eval_deriv_T(Z0, n_cold[i], T_cold[i]);
+                    real_t dBi = 0;
+                    if(Z0>0)
+                        dBi -= dWi * ACD_interper->Eval_deriv_T(Z0, n_cold[i], T_cold[i]);
+                    if(Z0<Zs[iz]){
+                        dWi = Constants::ec * nist->GetIonizationEnergy(Zs[iz],Z0);
+                        dBi += dWi * SCD_interper->Eval_deriv_T(Z0, n_cold[i], T_cold[i]);
+                    }
                     real_t ni = n_i[nMultiple*NCells + i];
-                    diffWeights[i] += ni*dLi;
+                    diffWeights[i] += ni*(dLi+dBi);
                 }
             }
         }

--- a/src/Settings/Constants.cpp
+++ b/src/Settings/Constants.cpp
@@ -54,4 +54,4 @@ const char *OptionConstants::UQTY_PSI_EDGE_DESC     = "Poloidal magnetic flux at
 const char *OptionConstants::UQTY_S_PARTICLE_DESC   = "Cold-electron density added in previous time step [m^-3]";
 const char *OptionConstants::UQTY_T_COLD_DESC       = "Cold electron temperature [eV]";
 const char *OptionConstants::UQTY_V_LOOP_WALL_DESC  = "Loop voltage on tokamak wall normalized to major radius R0 [V/m]";
-const char *OptionConstants::UQTY_W_COLD_DESC       = "Cold electron total energy density (kinetic plus binding) [J/m^3]";
+const char *OptionConstants::UQTY_W_COLD_DESC       = "Cold electron heat energy content (3nT/2) [J/m^3]";

--- a/src/Settings/Equations/T_cold.cpp
+++ b/src/Settings/Equations/T_cold.cpp
@@ -154,17 +154,10 @@ void SimulationGenerator::ConstructEquation_T_cold_selfconsistent(
         }
 
         FVM::Operator *Op4 = new FVM::Operator(fluidGrid);
-
-
         Op4->AddTerm( new CollisionalEnergyTransferKineticTerm(fluidGrid,eqsys->GetHotTailGrid(),
             id_T_cold, id_f_hot,eqsys->GetHotTailCollisionHandler(), eqsys->GetUnknownHandler(), -1.0,
             pThreshold, pMode));
         eqsys->SetOperator(id_T_cold, id_f_hot, Op4);
-
-        // TODO: IonisationHeatingTerm here is the old approximate hot-electron ionization correction. Should be replaced.
-        FVM::Operator *Op5 = new FVM::Operator(fluidGrid);
-        Op5->AddTerm( new IonisationHeatingTerm(fluidGrid, unknowns, eqsys->GetIonHandler(), adas, nist) );
-        eqsys->SetOperator(id_T_cold, id_n_hot, Op5);
         desc += " - int(nu_E*f_hot)";
     }
     // If runaway grid and not FULL collfreqmode, add collisional  
@@ -215,10 +208,7 @@ namespace DREAM {
 
 /**
  * Construct the equation for electron energy content:
- *    W_cold = 3n_cold*T_cold/2 + W_binding,
- * where W_binding is the total binding energy of all
- * ions (i.e. the minimum energy required to fully ionise
- * the entire plasma). 
+ *    W_cold = 3n_cold*T_cold/2
 */
 void SimulationGenerator::ConstructEquation_W_cold(
     EquationSystem *eqsys, Settings* /*s*/, NIST* nist

--- a/src/Settings/Equations/T_cold.cpp
+++ b/src/Settings/Equations/T_cold.cpp
@@ -12,7 +12,6 @@
 #include "DREAM/Equations/Fluid/OhmicHeatingTerm.hpp"
 #include "DREAM/Equations/Fluid/RadiatedPowerTerm.hpp"
 #include "DREAM/Equations/Fluid/IonisationHeatingTerm.hpp"
-#include "DREAM/Equations/Fluid/BindingEnergyTerm.hpp"
 #include "DREAM/Equations/Fluid/CollisionalEnergyTransferKineticTerm.hpp"
 #include "FVM/Equation/PrescribedParameter.hpp"
 #include "FVM/Grid/Grid.hpp"
@@ -109,7 +108,6 @@ void SimulationGenerator::ConstructEquation_T_cold_selfconsistent(
     len_t id_T_cold  = unknowns->GetUnknownID(OptionConstants::UQTY_T_COLD);
     len_t id_W_cold  = unknowns->GetUnknownID(OptionConstants::UQTY_W_COLD);
     len_t id_n_cold  = unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD);
-    len_t id_n_hot   = unknowns->GetUnknownID(OptionConstants::UQTY_N_HOT);
     len_t id_E_field = unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD);
 
     
@@ -119,7 +117,7 @@ void SimulationGenerator::ConstructEquation_T_cold_selfconsistent(
 
     Op1->AddTerm(new FVM::TransientTerm(fluidGrid,id_W_cold) );
     Op2->AddTerm(new OhmicHeatingTerm(fluidGrid,unknowns));
-    oqty_terms->T_cold_radterm = new RadiatedPowerTerm(fluidGrid,unknowns,eqsys->GetIonHandler(),adas);
+    oqty_terms->T_cold_radterm = new RadiatedPowerTerm(fluidGrid,unknowns,eqsys->GetIonHandler(),adas,nist);
     Op3->AddTerm(oqty_terms->T_cold_radterm);
 
 
@@ -130,9 +128,9 @@ void SimulationGenerator::ConstructEquation_T_cold_selfconsistent(
         OptionConstants::MOMENTUMGRID_TYPE_PXI, s, false
     );
 
-    std::string desc = "dWc/dt = j_ohm*E - sum_i n_cold*n_i*L_i";
     eqsys->SetOperator(id_T_cold, id_E_field,Op2);
     eqsys->SetOperator(id_T_cold, id_n_cold,Op3);
+    std::string desc = "dWc/dt = j_ohm*E - sum_i n_cold*n_i*L_i";
 
     if(hasTransport){
         eqsys->SetOperator(id_T_cold, id_T_cold,Op4);
@@ -184,7 +182,7 @@ void SimulationGenerator::ConstructEquation_T_cold_selfconsistent(
     delete [] Tcold_init;
 
 
-    ConstructEquation_W_cold(eqsys, s, nist);
+    ConstructEquation_W_cold(eqsys, s);
 }
 
 
@@ -211,33 +209,28 @@ namespace DREAM {
  *    W_cold = 3n_cold*T_cold/2
 */
 void SimulationGenerator::ConstructEquation_W_cold(
-    EquationSystem *eqsys, Settings* /*s*/, NIST* nist
+    EquationSystem *eqsys, Settings* /*s*/
 ) {
     FVM::Grid *fluidGrid = eqsys->GetFluidGrid();
     
     FVM::Operator *Op1 = new FVM::Operator(fluidGrid);
     FVM::Operator *Op2 = new FVM::Operator(fluidGrid);
-    FVM::Operator *Op3 = new FVM::Operator(fluidGrid);
 
     len_t id_W_cold = eqsys->GetUnknownID(OptionConstants::UQTY_W_COLD);
     len_t id_T_cold = eqsys->GetUnknownID(OptionConstants::UQTY_T_COLD);
     len_t id_n_cold = eqsys->GetUnknownID(OptionConstants::UQTY_N_COLD);
-    len_t id_n_i = eqsys->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
     
     Op1->AddTerm(new FVM::IdentityTerm(fluidGrid,-1.0) );
     Op2->AddTerm(new ElectronHeatTerm(fluidGrid,eqsys->GetUnknownHandler()) );
-    Op3->AddTerm(new BindingEnergyTerm(fluidGrid, eqsys->GetIonHandler(), nist));
 
-    eqsys->SetOperator(OptionConstants::UQTY_W_COLD, OptionConstants::UQTY_W_COLD, Op1, "W_c = 3nT/2 + W_bind");
+    eqsys->SetOperator(OptionConstants::UQTY_W_COLD, OptionConstants::UQTY_W_COLD, Op1, "W_c = 3nT/2");
     eqsys->SetOperator(OptionConstants::UQTY_W_COLD, OptionConstants::UQTY_T_COLD, Op2);    
-    eqsys->SetOperator(OptionConstants::UQTY_W_COLD, OptionConstants::UQTY_ION_SPECIES, Op3);
 
     eqsys->initializer->AddRule(
         id_W_cold,
         EqsysInitializer::INITRULE_EVAL_EQUATION,
         nullptr,
         id_T_cold,
-        id_n_i,
         id_n_cold
     );
 


### PR DESCRIPTION
The heat equation has been revised, by changing the definition of the total electron energy from

W = 1.5nT + W_binding

to simply

W = 1.5nT.

This was accomplished by adding the binding-energy contribution -dW_binding/dt due to ionization and recombination into the RadiatedPowerTerm. A few minor bugs in the basicE example were also fixed.

The changes have been tested by verifying that the output of basicE (which simulates a self-consistent temperature drop due to radiation) is identical before and after the changes. Ida reports a very small effect on runaway generation in her more complex self-consistent iTER-like simulations. Since previously-unstable simulations became stable after the fix, I suspect that there was a subtle contribution to W_binding that we forgot to compensate for in the old model.