### PR TITLE
Refactored handling of advection interpolation

### DIFF
--- a/examples/runaway/basic.py
+++ b/examples/runaway/basic.py
@@ -61,6 +61,7 @@ ds.eqsys.f_hot.setInitialProfiles(n0=n, T0=T)
 #ds.eqsys.f_hot.setBoundaryCondition(DistFunc.BC_PHI_CONST) # extrapolate flux to boundary
 ds.eqsys.f_hot.setBoundaryCondition(DistFunc.BC_F_0) # F=0 outside the boundary
 ds.eqsys.f_hot.setSynchrotronMode(DistFunc.SYNCHROTRON_MODE_NEGLECT)
+ds.eqsys.f_hot.setAdvectionInterpolationMethod(DistFunc.AD_INTERP_UPWIND)
 
 # Disable runaway grid
 ds.runawaygrid.setEnabled(False)

--- a/py/DREAM/Settings/AdvectionInterpolation.py
+++ b/py/DREAM/Settings/AdvectionInterpolation.py
@@ -1,0 +1,136 @@
+# Routines for setting advection interpolation methods.
+
+
+AD_INTERP_CENTRED  = 1
+AD_INTERP_UPWIND   = 2
+AD_INTERP_UPWIND_2ND_ORDER = 3
+AD_INTERP_DOWNWIND = 4
+AD_INTERP_QUICK    = 5
+AD_INTERP_SMART    = 6
+AD_INTERP_MUSCL    = 7
+AD_INTERP_OSPRE    = 8
+AD_INTERP_TCDF     = 9
+
+AD_INTERP_JACOBIAN_LINEAR = 1
+AD_INTERP_JACOBIAN_FULL   = 2
+AD_INTERP_JACOBIAN_UPWIND = 3
+
+
+class AdvectionInterpolation:
+    
+
+    def __init__(self, kinetic=True,
+        ad_int_r=AD_INTERP_CENTRED, ad_int_p1=AD_INTERP_CENTRED,
+        ad_int_p2=AD_INTERP_CENTRED, ad_jac_r=AD_INTERP_JACOBIAN_FULL,
+        ad_jac_p1=AD_INTERP_JACOBIAN_FULL, ad_jac_p2=AD_INTERP_JACOBIAN_FULL,
+        fluxlimiterdamping=1.0):
+        """
+        Constructor.
+        """
+        self.kinetic = kinetic
+
+        self.adv_interp_r  = ad_int_r
+        self.adv_interp_p1 = ad_int_p1
+        self.adv_interp_p2 = ad_int_p2
+
+        self.adv_jac_r  = ad_jac_r
+        self.adv_jac_p1 = ad_jac_p1
+        self.adv_jac_p2 = ad_jac_p2
+
+        self.fluxlimiterdamping = fluxlimiterdamping
+
+
+    def setMethod(self, ad_int=None, ad_int_r=AD_INTERP_CENTRED,
+        ad_int_p1=AD_INTERP_CENTRED, ad_int_p2=AD_INTERP_CENTRED, ad_jac=None, 
+        ad_jac_r=AD_INTERP_JACOBIAN_LINEAR, ad_jac_p1=AD_INTERP_JACOBIAN_LINEAR,
+        ad_jac_p2=AD_INTERP_JACOBIAN_LINEAR, fluxlimiterdamping=1.0):
+        """
+        Sets the interpolation method that is used in the advection terms of
+        the equation. To set all three components simultaneously, provide ad_int
+        and/or ad_jac. Otherwise the three components can use separate interpolation
+        methods.
+        
+        :param int ad_int:               Interpolation method to use for all coordinates.
+        :param int ad_int_r:             Interpolation method to use for the radial coordinate.
+        :param int ad_int_p1:            Interpolation method to use for the first momentum coordinate.
+        :param int ad_int_p2:            Interpolation method to use for the second momentum coordinate.
+        :param int ad_jac:               Jacobian interpolation mode to use for all coordinates.
+        :param int ad_jac_r:             Jacobian interpolation mode to use for the radial coordinate.
+        :param int ad_jac_p1:            Jacobian interpolation mode to use for the first momentum coordinate.
+        :param int ad_jac_p2:            Jacobian interpolation mode to use for the second momentum coordinate.
+        :param float fluxlimiterdamping: Damping parameter used to under-relax the interpolation coefficients during non-linear iterations (should be between 0 and 1).
+        """
+        self.fluxlimiterdamping = fluxlimiterdamping
+        if ad_int is not None:
+            self.adv_interp_r  = ad_int
+            self.adv_interp_p1 = ad_int
+            self.adv_interp_p2 = ad_int
+        else:
+            self.adv_interp_r  = ad_int_r
+            self.adv_interp_p1 = ad_int_p1
+            self.adv_interp_p2 = ad_int_p2
+
+        if ad_jac is not None:
+            self.adv_jac_r  = ad_jac
+            self.adv_jac_p1 = ad_jac
+            self.adv_jac_p2 = ad_jac
+        else:
+            self.adv_jac_r  = ad_jac_r
+            self.adv_jac_p1 = ad_jac_p1
+            self.adv_jac_p2 = ad_jac_p2
+
+
+    def fromdict(self, data):
+        """
+        Load settings from the specified dictionary.
+        """
+        self.adv_interp_r = data['r']
+        self.adv_jac_r = data['r_jac']
+
+        if self.kinetic:
+            self.adv_interp_p1 = data['p1']
+            self.adv_interp_p2 = data['p2']
+            self.adv_jac_p1 = data['p1_jac']
+            self.adv_jac_p2 = data['p2_jac']
+
+        self.fluxlimiterdamping = data['fluxlimiterdamping']
+
+
+    def todict(self):
+        """
+        Convert these settings to a dictionary.
+        """
+        data = {}
+
+        data['r']  = self.adv_interp_r
+        data['r_jac'] = self.adv_jac_r
+
+        if self.kinetic:
+            data['p1'] = self.adv_interp_p1
+            data['p2'] = self.adv_interp_p2
+            data['p1_jac'] = self.adv_jac_p1
+            data['p2_jac'] = self.adv_jac_p2
+
+        data['fluxlimiterdamping'] = self.fluxlimiterdamping
+
+        return data
+
+
+    def verifySettings(self):
+        ad_int_opts = [
+            AD_INTERP_CENTRED, AD_INTERP_DOWNWIND, AD_INTERP_UPWIND, AD_INTERP_UPWIND_2ND_ORDER, 
+            AD_INTERP_QUICK, AD_INTERP_SMART, AD_INTERP_MUSCL, AD_INTERP_OSPRE, AD_INTERP_TCDF
+        ]
+        if self.adv_interp_r not in ad_int_opts:
+            raise EquationException("{}: Invalid radial interpolation coefficient set: {}.".format(self.name, self.adv_interp_r))
+
+        if self.kinetic:
+            if self.adv_interp_p1 not in ad_int_opts:
+                raise EquationException("{}: Invalid p1 interpolation coefficient set: {}.".format(self.name, self.adv_interp_p1))
+            if self.adv_interp_p2 not in ad_int_opts:
+                raise EquationException("{}: Invalid p2 interpolation coefficient set: {}.".format(self.name, self.adv_interp_p2))
+
+        if (self.fluxlimiterdamping<0.0) or (self.fluxlimiterdamping>1.0):
+            raise EquationException("{}: Invalid flux limiter damping coefficient: {}. Choose between 0 and 1.".format(self.name, self.fluxlimiterdamping))
+
+

--- a/src/Settings/Equations/distribution.cpp
+++ b/src/Settings/Equations/distribution.cpp
@@ -41,11 +41,11 @@ void SimulationGenerator::DefineOptions_f_general(Settings *s, const string& mod
 
     // Flux limiter settings
     s->DefineSetting(mod + "/adv_interp/r", "Type of interpolation method to use in r-component of advection term of kinetic equation.", (int_t)FVM::AdvectionInterpolationCoefficient::AD_INTERP_CENTRED);
-    s->DefineSetting(mod + "/adv_jac_mode/r", "Type of interpolation method to use in the jacobian of the r-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
+    s->DefineSetting(mod + "/adv_interp/r_jac", "Type of interpolation method to use in the jacobian of the r-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
     s->DefineSetting(mod + "/adv_interp/p1", "Type of interpolation method to use in p1-component of advection term of kinetic equation.", (int_t)FVM::AdvectionInterpolationCoefficient::AD_INTERP_CENTRED);
-    s->DefineSetting(mod + "/adv_jac_mode/p1", "Type of interpolation method to use in the jacobian of the p1-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
+    s->DefineSetting(mod + "/adv_interp/p1_jac", "Type of interpolation method to use in the jacobian of the p1-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
     s->DefineSetting(mod + "/adv_interp/p2", "Type of interpolation method to use in p2-component of advection term of kinetic equation.", (int_t)FVM::AdvectionInterpolationCoefficient::AD_INTERP_CENTRED);
-    s->DefineSetting(mod + "/adv_jac_mode/p2", "Type of interpolation method to use in the jacobian of the p2-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
+    s->DefineSetting(mod + "/adv_interp/p2_jac", "Type of interpolation method to use in the jacobian of the p2-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
     s->DefineSetting(mod + "/adv_interp/fluxlimiterdamping", "Underrelaxation parameter that may be needed to achieve convergence with flux limiter methods", (real_t) 1.0);
 
     s->DefineSetting(mod + "/ripplemode", "Enables/disables pitch scattering due to the magnetic ripple", (int_t)OptionConstants::EQTERM_RIPPLE_MODE_NEGLECT);
@@ -166,15 +166,15 @@ FVM::Operator *SimulationGenerator::ConstructEquation_f_general(
     enum FVM::AdvectionInterpolationCoefficient::adv_interpolation adv_interp_r =
 			(enum FVM::AdvectionInterpolationCoefficient::adv_interpolation)s->GetInteger(mod + "/adv_interp/r");
     OptionConstants::adv_jacobian_mode adv_jac_mode_r = 
-            (OptionConstants::adv_jacobian_mode)s->GetInteger(mod + "/adv_jac_mode/r");
+            (OptionConstants::adv_jacobian_mode)s->GetInteger(mod + "/adv_interp/r_jac");
     enum FVM::AdvectionInterpolationCoefficient::adv_interpolation adv_interp_p1 =
 			(enum FVM::AdvectionInterpolationCoefficient::adv_interpolation)s->GetInteger(mod + "/adv_interp/p1");
     OptionConstants::adv_jacobian_mode adv_jac_mode_p1 = 
-            (OptionConstants::adv_jacobian_mode)s->GetInteger(mod + "/adv_jac_mode/p1");
+            (OptionConstants::adv_jacobian_mode)s->GetInteger(mod + "/adv_interp/p1_jac");
     enum FVM::AdvectionInterpolationCoefficient::adv_interpolation adv_interp_p2 =
 			(enum FVM::AdvectionInterpolationCoefficient::adv_interpolation)s->GetInteger(mod + "/adv_interp/p2");
     OptionConstants::adv_jacobian_mode adv_jac_mode_p2 = 
-            (OptionConstants::adv_jacobian_mode)s->GetInteger(mod + "/adv_jac_mode/p2");
+            (OptionConstants::adv_jacobian_mode)s->GetInteger(mod + "/adv_interp/p2_jac");
     real_t fluxLimiterDamping = (real_t)s->GetReal(mod + "/adv_interp/fluxlimiterdamping");
     eqn->SetAdvectionInterpolationMethod(
         adv_interp_r,  adv_jac_mode_r,  FVM::FLUXGRIDTYPE_RADIAL, 

--- a/src/Settings/Equations/n_re.cpp
+++ b/src/Settings/Equations/n_re.cpp
@@ -33,7 +33,7 @@ void SimulationGenerator::DefineOptions_n_re(
     s->DefineSetting(MODULENAME "/Eceff", "Model to use for calculation of the effective critical field.", (int_t)OptionConstants::COLLQTY_ECEFF_MODE_CYLINDRICAL);
 
     s->DefineSetting(MODULENAME "/adv_interp/r", "Type of interpolation method to use in r-component of advection term of kinetic equation.", (int_t)FVM::AdvectionInterpolationCoefficient::AD_INTERP_CENTRED);
-    s->DefineSetting(MODULENAME "/adv_jac_mode/r", "Type of interpolation method to use in the jacobian of the r-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
+    s->DefineSetting(MODULENAME "/adv_interp/r_jac", "Type of interpolation method to use in the jacobian of the r-component of advection term of kinetic equation.", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
     s->DefineSetting(MODULENAME "/adv_interp/fluxlimiterdamping", "Underrelaxation parameter that may be needed to achieve convergence with flux limiter methods", (real_t) 1.0);
 
     DefineOptions_Transport(MODULENAME, s, false);
@@ -133,7 +133,7 @@ void SimulationGenerator::ConstructEquation_n_re(
         enum FVM::AdvectionInterpolationCoefficient::adv_interpolation adv_interp_r =
             (enum FVM::AdvectionInterpolationCoefficient::adv_interpolation)s->GetInteger(MODULENAME "/adv_interp/r");
         enum OptionConstants::adv_jacobian_mode adv_jac_mode_r =
-            (enum OptionConstants::adv_jacobian_mode)s->GetInteger(MODULENAME "/adv_jac_mode/r");
+            (enum OptionConstants::adv_jacobian_mode)s->GetInteger(MODULENAME "/adv_interp/r_jac");
         real_t fluxLimiterDamping = s->GetReal(MODULENAME "/adv_interp/fluxlimiterdamping");
 
         Op_nRE->SetAdvectionInterpolationMethod(


### PR DESCRIPTION
In this commit I propose a unification of the advection interpolation interface which should make it easier to apply more generally to equations. In particular, it arose out of the perceived need to include advection interpolation in the transport equation for ``n_re`` and may be useful in other transport equations in the future.

(note that this is **NOT** a pull request to master, but rather just to the WIP branch ``SvenssonTransport``)