### PR TITLE
Backup inverter

### DIFF
--- a/doc/sphinx/source/frontend/api/Settings/solver.rst
+++ b/doc/sphinx/source/frontend/api/Settings/solver.rst
@@ -170,6 +170,35 @@ use of four different LU factorization algorithms, namely
 | ``LINEAR_SOLVER_SUPERLU`` | The `SuperLU <https://portal.nersc.gov/project/sparse/superlu/>`_ direct LU solver.                                                                                                                                                                                               |
 +---------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+
+Backup linear solver
+--------------------
+Some linear solvers are less robust than others. The less robust solvers however
+usually compensate for this by being orders of magnitudes faster. To obtain the
+best of both worlds, DREAM provides the ability to specify a "backup" linear
+solver which can take over inversions if the ordinary linear solver fails for
+some reason. In this way, we can use a fast solver (such as MKL Pardiso) to
+advance for as many time steps as possible, while using a more robust solver
+(typically PETSc's built-in LU solver) when the ordinary solver is no longer
+capable of inverting the system of equations.
+
+The backup linear solver is specified using the ``setBackupSolver()`` as
+follows:
+
+.. code-block:: python
+
+   import DREAM.Settings.Solver as Solver
+
+   ds = DREAMSettings()
+   ...
+   # Use PETSc's built-in LU solver if the main solver fails.
+   ds.solver.setBackupSolver(Solver.LINEAR_SOLVER_LU)
+
+.. note::
+
+   ...that the backup linear solver may *not* be the same as the main linear
+   solver.
+
 Debug settings
 --------------
 A number of options are available which can aid in debugging numerical issues

--- a/fvm/Equation/AdvectionInterpolationCoefficient.cpp
+++ b/fvm/Equation/AdvectionInterpolationCoefficient.cpp
@@ -109,8 +109,9 @@ void AdvectionInterpolationCoefficient::SetCoefficient(real_t **A, real_t **/*D*
                 x   = grid->GetMomentumGrid(ir)->GetP2();
                 x_f = grid->GetMomentumGrid(ir)->GetP2_f();
                 YFunc = YFunc_f2;
-            default:
                 break;
+            default:
+                throw FVMException("AdvectionInterpolationCoefficient: Invalid flux grid type specified.");
         }
         
         for(len_t i=0; i<n1[ir]; i++)

--- a/fvm/Equation/AdvectionTerm.cpp
+++ b/fvm/Equation/AdvectionTerm.cpp
@@ -431,9 +431,10 @@ void AdvectionTerm::ResetDifferentiationCoefficients() {
  * jac:     Jacobian matrix block to populate.
  * x:       Value of the unknown quantity.
  */
-void AdvectionTerm::SetJacobianBlock(
+bool AdvectionTerm::SetJacobianBlock(
     const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x
 ) {
+    bool contributes = (uqtyId == derivId);
     interp_mode = AdvectionInterpolationCoefficient::AD_INTERP_MODE_JACOBIAN;
     if ( (uqtyId == derivId) && !this->coefficientsShared)
         this->SetMatrixElements(jac, nullptr);
@@ -444,7 +445,9 @@ void AdvectionTerm::SetJacobianBlock(
     */
     len_t nMultiples;
     if(!HasJacobianContribution(derivId, &nMultiples))
-        return;
+        return contributes;
+    else
+        contributes = true;
     
 
     // TODO: allocate differentiation coefficients in a more logical location
@@ -459,6 +462,8 @@ void AdvectionTerm::SetJacobianBlock(
         SetPartialJacobianContribution(-1,JACOBIAN_SET_LOWER, n, jac, x);
         SetPartialJacobianContribution(+1,JACOBIAN_SET_UPPER, n, jac, x);
     }
+
+    return contributes;
 }
 
 

--- a/fvm/Equation/BoundaryConditions/PXiAdvectionDiffusionBoundaryCondition.cpp
+++ b/fvm/Equation/BoundaryConditions/PXiAdvectionDiffusionBoundaryCondition.cpp
@@ -60,10 +60,12 @@ bool PXiAdvectionDiffusionBoundaryCondition::GridRebuilt() {
  *                         interpolated across several points on the distribution
  *                         grid.
  */
-void PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
+bool PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
     const len_t, const len_t derivId, Matrix *jac, const real_t *x,
     bool hasRadialContributions
 ) {
+    bool contributes = false;
+
     // Iterate over all advection operators...
     const len_t nr = this->grid->GetNr();
     const AdvectionDiffusionTerm *adt = oprtr->GetAdvectionDiffusion();
@@ -71,6 +73,8 @@ void PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
         len_t nMultiples;
         if (!at->HasJacobianContribution(derivId, &nMultiples))
             continue;
+        else
+            contributes = true;
 
         at->SetPartialAdvectionTerm(derivId, nMultiples);
 
@@ -115,6 +119,8 @@ void PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
         len_t nMultiples;
         if (!dt->HasJacobianContribution(derivId, &nMultiples))
             continue;
+        else
+            contributes = true;
 
         dt->SetPartialDiffusionTerm(derivId, nMultiples);
 
@@ -152,6 +158,8 @@ void PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
             }
         }
     }
+
+    return contributes;
 }
 
 /**

--- a/fvm/Equation/BoundaryConditions/PXiExternalKineticKinetic.cpp
+++ b/fvm/Equation/BoundaryConditions/PXiExternalKineticKinetic.cpp
@@ -30,7 +30,10 @@ PXiExternalKineticKinetic::PXiExternalKineticKinetic(
     enum condition_type ctype
 ) : PXiAdvectionDiffusionBoundaryCondition(grid, eqn),
     lowerGrid(lowerGrid), upperGrid(upperGrid),
-    id_f_low(id_f_low), id_f_upp(id_f_upp), type(ctype) { }
+    id_f_low(id_f_low), id_f_upp(id_f_upp), type(ctype) {
+    
+    SetName("PXiExternalKineticKinetic");
+}
 
 /**
  * Destructor.
@@ -97,9 +100,10 @@ bool PXiExternalKineticKinetic::Rebuild(const real_t, UnknownQuantityHandler *uq
 /**
  * Add flux to jacobian block.
  */
-void PXiExternalKineticKinetic::AddToJacobianBlock(
+bool PXiExternalKineticKinetic::AddToJacobianBlock(
     const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t *x
 ) {
+    bool contributes = (derivId == uqtyId);
     if (derivId == uqtyId)
         // Note that this will also set the off-diagonal block 
         // corresponding to the quantity/ies that is/are not
@@ -109,9 +113,12 @@ void PXiExternalKineticKinetic::AddToJacobianBlock(
     // Handle derivatives of coefficients (we assume that the coefficients
     // do not depend on either of the distribution functions...)
     if (derivId != this->id_f_low && derivId != this->id_f_upp)
-        this->PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
-            uqtyId, derivId, jac, x, false
-        );
+        contributes |=
+            this->PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
+                uqtyId, derivId, jac, x, false
+            );
+
+    return contributes;
 }
 
 /**

--- a/fvm/Equation/BoundaryConditions/PXiExternalLoss.cpp
+++ b/fvm/Equation/BoundaryConditions/PXiExternalLoss.cpp
@@ -32,6 +32,8 @@ PXiExternalLoss::PXiExternalLoss(
     enum boundary_type boundary, enum bc_type bc
 ) : PXiAdvectionDiffusionBoundaryCondition(g, eqn), fId(fId),
     boundaryCondition(bc), boundary(boundary) {
+
+    SetName("PXiExternalLoss");
     
     if (distGrid == nullptr) {
         this->distributionGrid = g;
@@ -85,19 +87,25 @@ bool PXiExternalLoss::Rebuild(const real_t, UnknownQuantityHandler*) { return fa
 /**
  * Add flux to jacobian block.
  */
-void PXiExternalLoss::AddToJacobianBlock(
+bool PXiExternalLoss::AddToJacobianBlock(
     const len_t qtyId, const len_t derivId, Matrix * jac, const real_t *x
 ) {
+    bool contributes = false;
     //if ((derivId == this->fId) && (this->fId == qtyId))
-    if (derivId == this->fId)
+    if (derivId == this->fId) {
         this->AddToMatrixElements(jac, nullptr);
+        contributes = true;
+    }
 
     // Handle derivatives of coefficients (we neglect any dependence
     // on f in coefficients (which usually isn't there anyway)...)
     if (derivId != this->fId)
-        this->PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
-            qtyId, derivId, jac, x, false
-        );
+        contributes |=
+            this->PXiAdvectionDiffusionBoundaryCondition::AddPartialJacobianContributions(
+                qtyId, derivId, jac, x, false
+            );
+
+    return contributes;
 }
 
 /**

--- a/fvm/Equation/ConstantParameter.cpp
+++ b/fvm/Equation/ConstantParameter.cpp
@@ -18,6 +18,8 @@ using namespace DREAM::FVM;
 ConstantParameter::ConstantParameter(Grid *g, const real_t v)
     : PredeterminedParameter(g) {
 
+    SetName("Constant");
+
     const len_t N = g->GetNCells();
 
     for (len_t i = 0; i < N; i++)

--- a/fvm/Equation/DiagonalComplexTerm.cpp
+++ b/fvm/Equation/DiagonalComplexTerm.cpp
@@ -33,7 +33,7 @@ DiagonalComplexTerm::~DiagonalComplexTerm(){
 * (so that w at phase-space point z only depends on U(z) and not, for example,
 * on integrals of U). 
 */
-void DiagonalComplexTerm::AddWeightsJacobian(
+bool DiagonalComplexTerm::AddWeightsJacobian(
     const len_t /*uqtyId*/, const len_t derivId, Matrix *jac, const real_t* x
 ){
     /**
@@ -42,7 +42,7 @@ void DiagonalComplexTerm::AddWeightsJacobian(
     */
     len_t nMultiples=0;
     if(!HasJacobianContribution(derivId, &nMultiples))
-        return;
+        return false;
     
     ResetDiffWeights();
     SetDiffWeights(derivId, nMultiples);
@@ -78,6 +78,8 @@ void DiagonalComplexTerm::AddWeightsJacobian(
             for(len_t i=0; i<NCells; i++)
                 jac->SetElement(i, n*NCells+i, diffWeights[n*NCells + i] * x[i] ); 
     }
+
+    return true;
 }
 
 /**

--- a/fvm/Equation/DiagonalQuadraticTerm.cpp
+++ b/fvm/Equation/DiagonalQuadraticTerm.cpp
@@ -42,7 +42,7 @@ DiagonalQuadraticTerm::DiagonalQuadraticTerm(Grid *g,
 * in SetJacobianBlock, and again here. Thus, quadratic terms of 
 * the form x^2 correctly get a factor of 2. 
 */
-void DiagonalQuadraticTerm::AddWeightsJacobian(
+bool DiagonalQuadraticTerm::AddWeightsJacobian(
     const len_t /*uqtyId*/, const len_t derivId, Matrix *jac, const real_t* x
 ){
 
@@ -51,7 +51,11 @@ void DiagonalQuadraticTerm::AddWeightsJacobian(
         for (len_t i = 0; i < N; i++)
             for(len_t n=0; n<wUqtyNMultiples; n++)            
                 jac->SetElement(i, n*N+i, x[i]*weights[n*N+i]);
+        
+        return true;
     }
+
+    return false;
 }
 
 /**

--- a/fvm/Equation/DiagonalTerm.cpp
+++ b/fvm/Equation/DiagonalTerm.cpp
@@ -63,12 +63,18 @@ bool DiagonalTerm::GridRebuilt(){
 /**
  * Set a block for this term in the given jacobian matrix.
  */
-void DiagonalTerm::SetJacobianBlock(
+bool DiagonalTerm::SetJacobianBlock(
     const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x
 ) {
-    if (derivId == uqtyId)
+    bool contributes = false;
+    if (derivId == uqtyId) {
         this->SetMatrixElements(jac, nullptr);
-    AddWeightsJacobian(uqtyId, derivId, jac, x);
+        contributes = true;
+    }
+
+    contributes |= AddWeightsJacobian(uqtyId, derivId, jac, x);
+
+    return contributes;
 }
 
 /**

--- a/fvm/Equation/DiffusionTerm.cpp
+++ b/fvm/Equation/DiffusionTerm.cpp
@@ -353,9 +353,10 @@ void DiffusionTerm::ResetDifferentiationCoefficients() {
  * jac:     Jacobian matrix block to populate.
  * x:       Value of the unknown quantity.
  */
-void DiffusionTerm::SetJacobianBlock(
+bool DiffusionTerm::SetJacobianBlock(
     const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x
 ) {
+    bool contributes = (uqtyId == derivId);
     if ( (uqtyId == derivId) && !this->coefficientsShared)
         this->SetMatrixElements(jac, nullptr);
 
@@ -366,7 +367,9 @@ void DiffusionTerm::SetJacobianBlock(
     */
     len_t nMultiples;
     if(!HasJacobianContribution(derivId, &nMultiples))
-        return;
+        return contributes;
+    else
+        contributes = true;
     
     // TODO: allocate differentiation coefficients in a more logical location
     if(dd11 == nullptr)
@@ -380,6 +383,8 @@ void DiffusionTerm::SetJacobianBlock(
         SetPartialJacobianContribution(-1,JACOBIAN_SET_LOWER, n, jac, x);
         SetPartialJacobianContribution(+1,JACOBIAN_SET_UPPER, n, jac, x);
     }
+
+    return contributes;
 }
 
 /**

--- a/fvm/Equation/MomentQuantity.cpp
+++ b/fvm/Equation/MomentQuantity.cpp
@@ -317,15 +317,16 @@ void MomentQuantity::AddDiffEnvelope(){
  * jac:     Jacobian matrix to set elements of.
  * x:       Value of the unknown quantity.
  */
-void MomentQuantity::SetJacobianBlock(
+bool MomentQuantity::SetJacobianBlock(
     const len_t unknId, const len_t derivId, Matrix *jac, const real_t *f
 ) {
+    bool contributes = (derivId == unknId);
     if (derivId == unknId)
         this->SetMatrixElements(jac,nullptr);
 
     len_t nMultiples;
     if(!HasJacobianContribution(derivId, &nMultiples))
-        return;
+        return contributes;
 
     // Add off-diagonal contributions from fluid quantities
     ResetDiffIntegrand();
@@ -348,6 +349,8 @@ void MomentQuantity::SetJacobianBlock(
     }
     #undef ApplyX
     #undef X
+
+    return true;
 }
 
 /**

--- a/fvm/Equation/PredeterminedParameter.cpp
+++ b/fvm/Equation/PredeterminedParameter.cpp
@@ -38,9 +38,9 @@ PredeterminedParameter::~PredeterminedParameter() {
  * with respect to anything of a constant is zero, we don't need
  * to do anything).
  */
-void PredeterminedParameter::SetJacobianBlock(
+bool PredeterminedParameter::SetJacobianBlock(
     const len_t /*derivId*/, const len_t /*uqtyId*/, Matrix* /*jac*/, const real_t* /*x*/
-) { }
+) { return false; }
 
 /**
  * Set the elements in the matrix and on the RHS corresponding

--- a/fvm/Equation/ScalarLinearTerm.cpp
+++ b/fvm/Equation/ScalarLinearTerm.cpp
@@ -89,12 +89,16 @@ void ScalarLinearTerm::SetVectorElements(real_t *vec, const real_t *x) {
 /**
  * Set a block for this term in the given jacobian matrix.
  */
-void ScalarLinearTerm::SetJacobianBlock(
+bool ScalarLinearTerm::SetJacobianBlock(
     const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* /*x*/
 ) {
+    bool contributes = false;
     if (derivId == uqtyId) {
         this->SetMatrixElements(jac, nullptr);
+        contributes = true;
     }
+
+    return contributes;
 }
 
 /**

--- a/fvm/Solvers/MILU.cpp
+++ b/fvm/Solvers/MILU.cpp
@@ -54,6 +54,6 @@ void MILU::Invert(Matrix *A, Vec *b, Vec *x) {
     KSPSetType(this->ksp, KSPPREONLY);
 
     // Solve
-    KSPSolve(this->ksp, *b, *x);
+    this->errorcode = KSPSolve(this->ksp, *b, *x);
 }
 

--- a/fvm/Solvers/MIMKL.cpp
+++ b/fvm/Solvers/MIMKL.cpp
@@ -69,7 +69,6 @@ void MIMKL::Invert(Matrix *A, Vec *b, Vec *x) {
     MatMkl_PardisoSetCntl(F, 65, 1);
 
     // Maximum iterations for refinement
-    //MatMkl_PardisoSetCntl(F, 8, 30);
     MatMkl_PardisoSetCntl(F, 8, 10);
 
     if (this->verbose)

--- a/fvm/Solvers/MIMKL.cpp
+++ b/fvm/Solvers/MIMKL.cpp
@@ -48,8 +48,8 @@ MIMKL::~MIMKL() {
  * x: Solution vector. Contains solution on return. Must be
  *    of size n at least.
  */
-void MIMKL::Invert(Matrix *A, Vec *b, Vec *x) {
 #ifdef PETSC_HAVE_MKL_PARDISO
+void MIMKL::Invert(Matrix *A, Vec *b, Vec *x) {
     Mat F;
     PC pc;
 
@@ -79,6 +79,8 @@ void MIMKL::Invert(Matrix *A, Vec *b, Vec *x) {
 
     if (this->errorcode != 0)
         PCPostSolve(pc, this->ksp);
+#else
+void MIMKL::Invert(Matrix*, Vec*, Vec*) {
 #endif
 }
 

--- a/fvm/Solvers/MIMKL.cpp
+++ b/fvm/Solvers/MIMKL.cpp
@@ -68,11 +68,18 @@ void MIMKL::Invert(Matrix *A, Vec *b, Vec *x) {
     // error)
     MatMkl_PardisoSetCntl(F, 65, 1);
 
+    // Maximum iterations for refinement
+    //MatMkl_PardisoSetCntl(F, 8, 30);
+    MatMkl_PardisoSetCntl(F, 8, 10);
+
     if (this->verbose)
         MatMkl_PardisoSetCntl(F, 68, 1);
 
     // Solve
-    KSPSolve(this->ksp, *b, *x);
+    this->errorcode = KSPSolve(this->ksp, *b, *x);
+
+    if (this->errorcode != 0)
+        PCPostSolve(pc, this->ksp);
 #endif
 }
 

--- a/fvm/Solvers/MIMUMPS.cpp
+++ b/fvm/Solvers/MIMUMPS.cpp
@@ -45,6 +45,7 @@ MIMUMPS::~MIMUMPS() {
  */
 void MIMUMPS::Invert(Matrix *A, Vec *b, Vec *x) {
     PC pc;
+    Mat F;
 
     KSPSetOperators(this->ksp, A->mat(), A->mat());
     
@@ -52,9 +53,21 @@ void MIMUMPS::Invert(Matrix *A, Vec *b, Vec *x) {
     KSPGetPC(this->ksp, &pc);
     PCSetType(pc, PCLU);
     PCFactorSetMatSolverType(pc, MATSOLVERMUMPS);
+    //PCFactorSetUpMatSolverType(pc);
     KSPSetType(this->ksp, KSPPREONLY);
 
     // Solve
     KSPSolve(this->ksp, *b, *x);
+
+    PCFactorGetMatrix(pc, &F);
+
+    PetscInt info1, info2;
+    MatMumpsGetInfo(F, 1, &info1);
+    MatMumpsGetInfo(F, 2, &info2);
+
+    if (info1 != 0) {
+        printf(":: MUMPS INFO(1) = %d\n", info1);
+        printf(":: MUMPS INFO(2) = %d\n", info2);
+    }
 }
 

--- a/fvm/Solvers/MIMUMPS.cpp
+++ b/fvm/Solvers/MIMUMPS.cpp
@@ -43,6 +43,7 @@ MIMUMPS::~MIMUMPS() {
  * x: Solution vector. Contains solution on return. Must be
  *    of size n at least.
  */
+#ifdef PETSC_HAVE_MUMPS
 void MIMUMPS::Invert(Matrix *A, Vec *b, Vec *x) {
     PC pc;
     Mat F;
@@ -69,5 +70,8 @@ void MIMUMPS::Invert(Matrix *A, Vec *b, Vec *x) {
         printf(":: MUMPS INFO(1) = %d\n", info1);
         printf(":: MUMPS INFO(2) = %d\n", info2);
     }
+#else
+void MIMUMPS::Invert(Matrix*, Vec*, Vec*) {
+#endif
 }
 

--- a/fvm/UnknownQuantityHandler.cpp
+++ b/fvm/UnknownQuantityHandler.cpp
@@ -58,6 +58,37 @@ const real_t *UnknownQuantityHandler::GetLongVector(const len_t n, const len_t *
 }
 
 /**
+ * Returns the unknown data for the previous time step in a single,
+ * contiguously stored vector for all the specified unknowns.
+ *
+ * nontrivial_unknowns: List of unknowns to get data for.
+ *                      (these are usually the "non-trivial" unknowns that
+ *                      appear in the equation system solved)
+ */
+const real_t *UnknownQuantityHandler::GetLongVectorPrevious(const vector<len_t>& nontrivial_unknowns, real_t *vec) {
+    return GetLongVectorPrevious(nontrivial_unknowns.size(), nontrivial_unknowns.data(), vec);
+}
+const real_t *UnknownQuantityHandler::GetLongVectorPrevious(const len_t n, const len_t *iuqn, real_t *vec) {
+    const len_t size = GetLongVectorSize(n, iuqn);
+
+    if (vec == nullptr)
+        vec = new real_t[size];
+
+    for (len_t i = 0, offset = 0; i < n; i++) {
+        UnknownQuantity *uqn = unknowns[iuqn[i]];
+        const len_t N = uqn->NumberOfElements();
+        const real_t *data = uqn->GetDataPrevious();
+
+        for (len_t j = 0; j < N; j++)
+            vec[offset + j] = data[j];
+
+        offset += N;
+    }
+
+    return vec;
+}
+
+/**
  * Returns the data for all unknowns in a single long vector.
  *
  * vec: Vector to store data in. Must be of the size reported by

--- a/include/DREAM/EquationSystem.hpp
+++ b/include/DREAM/EquationSystem.hpp
@@ -179,6 +179,7 @@ namespace DREAM {
         void SetSolver(Solver*);
         void SetTimeStepper(TimeStepper *ts) { this->timestepper = ts; }
 
+        void SaveSolverData(SFile *sf, const std::string& n) { this->solver->WriteDataSFile(sf, n); }
         void SaveTimings(SFile*, const std::string&);
 
         void Solve();

--- a/include/DREAM/Equations/Fluid/AmperesLawBoundaryAtRMax.hpp
+++ b/include/DREAM/Equations/Fluid/AmperesLawBoundaryAtRMax.hpp
@@ -26,12 +26,12 @@ namespace DREAM::FVM::BC {
 
         virtual bool Rebuild(const real_t, UnknownQuantityHandler*) override;
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
+        virtual bool AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
         virtual void AddToMatrixElements(DREAM::FVM::Matrix*, real_t*) override;
         virtual void AddToVectorElements(real_t*, const real_t*) override;
 
         // Not implemented (not used)
-        virtual void SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {return false;}
         virtual void SetMatrixElements(DREAM::FVM::Matrix*, real_t*) override {}
         virtual void SetVectorElements(real_t*, const real_t*) override {}
     };

--- a/include/DREAM/Equations/Fluid/DensityFromBoundaryFluxPXI.hpp
+++ b/include/DREAM/Equations/Fluid/DensityFromBoundaryFluxPXI.hpp
@@ -24,7 +24,7 @@ namespace DREAM {
 
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override {}
 
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
         virtual void SetMatrixElements(FVM::Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };

--- a/include/DREAM/Equations/Fluid/DreicerRateTerm.hpp
+++ b/include/DREAM/Equations/Fluid/DreicerRateTerm.hpp
@@ -50,7 +50,7 @@ namespace DREAM {
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return 1; }   /* XXX TODO XXX */
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
 
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };
 }

--- a/include/DREAM/Equations/Fluid/HotTailCurrentDensityFromDistributionFunction.hpp
+++ b/include/DREAM/Equations/Fluid/HotTailCurrentDensityFromDistributionFunction.hpp
@@ -53,7 +53,7 @@ namespace DREAM {
         virtual len_t GetNumberOfNonZerosPerRow() const override
             { return hottailGrid->GetMomentumGrid(0)->GetNp1(); }
 
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
 
         virtual bool GridRebuilt() override;

--- a/include/DREAM/Equations/Fluid/HottailRateTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HottailRateTerm.hpp
@@ -39,7 +39,7 @@ namespace DREAM {
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override {}
 
         virtual void SetVectorElements(real_t*, const real_t*) override;
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override {return false;}
     };
 }
 

--- a/include/DREAM/Equations/Fluid/HottailRateTermHighZ.hpp
+++ b/include/DREAM/Equations/Fluid/HottailRateTermHighZ.hpp
@@ -47,7 +47,7 @@ namespace DREAM {
         virtual bool GridRebuilt() override;
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
 
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
     };
 }
 

--- a/include/DREAM/Equations/Fluid/IonEquationTerm.hpp
+++ b/include/DREAM/Equations/Fluid/IonEquationTerm.hpp
@@ -35,11 +35,11 @@ namespace DREAM {
          */
 
         // Replace these 'Set...' methods with...
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
         virtual void SetMatrixElements(FVM::Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
         // ..these 'SetCS...' (CS = Charge State) methods.
-        virtual void SetCSJacobianBlock(
+        virtual bool SetCSJacobianBlock(
             const len_t, const len_t, FVM::Matrix*, const real_t*,
             const len_t iIon, const len_t Z0, const len_t rOffset
         ) = 0;

--- a/include/DREAM/Equations/Fluid/IonEquationTerm.tcc
+++ b/include/DREAM/Equations/Fluid/IonEquationTerm.tcc
@@ -50,14 +50,18 @@ IonEquationTerm<T>::~IonEquationTerm() {}
  * uqtyId:  ID of the unknown quantity to differentiate.
  */
 template<class T>
-void IonEquationTerm<T>::SetJacobianBlock(
+bool IonEquationTerm<T>::SetJacobianBlock(
     const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t *x
 ) {
+    bool contributes = false;
     const len_t nr = this->grid->GetNr();
 
     len_t idx = this->ions->GetIndex(iIon, 0);
     for (len_t Z0 = 0; Z0 <= Zion; Z0++, idx++)
-        this->SetCSJacobianBlock(uqtyId, derivId, jac, x, iIon, Z0, idx*nr);
+        contributes |=
+            this->SetCSJacobianBlock(uqtyId, derivId, jac, x, iIon, Z0, idx*nr);
+
+    return contributes;
 }
 
 /**

--- a/include/DREAM/Equations/Fluid/IonKineticIonizationTerm.hpp
+++ b/include/DREAM/Equations/Fluid/IonKineticIonizationTerm.hpp
@@ -61,7 +61,7 @@ namespace DREAM {
         virtual bool GridRebuilt() override;
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override{}
 
-        virtual void SetCSJacobianBlock(
+        virtual bool SetCSJacobianBlock(
             const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t *nions,
             const len_t iIon, const len_t Z0, const len_t rOffset
         ) override;

--- a/include/DREAM/Equations/Fluid/IonPrescribedParameter.hpp
+++ b/include/DREAM/Equations/Fluid/IonPrescribedParameter.hpp
@@ -45,7 +45,7 @@ namespace DREAM {
 
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
 
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
         virtual void SetMatrixElements(FVM::Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };

--- a/include/DREAM/Equations/Fluid/IonRateEquation.hpp
+++ b/include/DREAM/Equations/Fluid/IonRateEquation.hpp
@@ -44,7 +44,7 @@ namespace DREAM {
         virtual bool GridRebuilt() override;
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
 
-        virtual void SetCSJacobianBlock(
+        virtual bool SetCSJacobianBlock(
             const len_t, const len_t, FVM::Matrix*, const real_t*,
             const len_t iIon, const len_t Z0, const len_t rOffset
         ) override;

--- a/include/DREAM/Equations/Fluid/IonSpeciesIdentityTerm.hpp
+++ b/include/DREAM/Equations/Fluid/IonSpeciesIdentityTerm.hpp
@@ -23,9 +23,10 @@ namespace DREAM{
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return 1; }
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override {}
 
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t*) override {
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t*) override {
             if(uqtyId==derivId)
                 SetMatrixElements(jac, nullptr);
+            return (uqtyId==derivId);
         }
         virtual void SetMatrixElements(FVM::Matrix *mat, real_t*) override {
             for(len_t ir=0; ir<nr; ir++)

--- a/include/DREAM/Equations/Fluid/IonSpeciesTransientTerm.hpp
+++ b/include/DREAM/Equations/Fluid/IonSpeciesTransientTerm.hpp
@@ -29,9 +29,10 @@ namespace DREAM{
             this->xPrev = u->GetUnknownDataPrevious(this->unknownId);
         }
 
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t*) override {
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t*) override {
             if(uqtyId==derivId)
                 SetMatrixElements(jac, nullptr);
+            return (uqtyId==derivId);
         }
         virtual void SetMatrixElements(FVM::Matrix *mat, real_t *rhs) override {
             for(len_t ir=0; ir<nr; ir++)

--- a/include/DREAM/Equations/Fluid/IonTransientTerm.hpp
+++ b/include/DREAM/Equations/Fluid/IonTransientTerm.hpp
@@ -21,7 +21,7 @@ namespace DREAM {
 
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
 
-        virtual void SetCSJacobianBlock(
+        virtual bool SetCSJacobianBlock(
             const len_t, const len_t, FVM::Matrix*, const real_t*,
             const len_t iIon, const len_t Z0, const len_t rOffset
         ) override;

--- a/include/DREAM/Equations/Fluid/KineticEquationTermIntegratedOverMomentum.hpp
+++ b/include/DREAM/Equations/Fluid/KineticEquationTermIntegratedOverMomentum.hpp
@@ -36,7 +36,7 @@ namespace DREAM {
             {kineticOperator->RebuildTerms(t,dt,u);}
         virtual bool GridRebuilt() override;
         virtual void SetMatrixElements(FVM::Matrix*, real_t*) override;
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix*, const real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };
 }

--- a/include/DREAM/Equations/Fluid/MaxwellianCollisionalEnergyTransferTerm.hpp
+++ b/include/DREAM/Equations/Fluid/MaxwellianCollisionalEnergyTransferTerm.hpp
@@ -37,7 +37,7 @@ namespace DREAM{
         virtual len_t GetNumberOfNonZerosPerRow() const override { return 0; }
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override {}
 
-        virtual void SetJacobianBlock(const len_t uqtyI, const len_t derivId, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t uqtyI, const len_t derivId, FVM::Matrix*, const real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };
 }

--- a/include/DREAM/Equations/Fluid/NetIonDensityFromIonChargeStatesTerm.hpp
+++ b/include/DREAM/Equations/Fluid/NetIonDensityFromIonChargeStatesTerm.hpp
@@ -20,9 +20,10 @@ namespace DREAM {
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return this->ionHandler->GetNzs(); }
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override {}
 
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t*) override {
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t*) override {
             if(uqtyId==derivId)
                 SetMatrixElements(jac, nullptr);
+            return (uqtyId==derivId);
         }
         virtual void SetMatrixElements(FVM::Matrix *mat, real_t *) override {
             for(len_t Z0=0; Z0<=Z; Z0++){

--- a/include/DREAM/Equations/Fluid/TritiumRateTerm.hpp
+++ b/include/DREAM/Equations/Fluid/TritiumRateTerm.hpp
@@ -31,7 +31,7 @@ namespace DREAM {
 
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override {}
         
-        virtual void SetCSJacobianBlock(
+        virtual bool SetCSJacobianBlock(
             const len_t, const len_t, FVM::Matrix*, const real_t*,
             const len_t iIon, const len_t Z0, const len_t rOffset
         ) override;

--- a/include/DREAM/Equations/FluidSourceTerm.hpp
+++ b/include/DREAM/Equations/FluidSourceTerm.hpp
@@ -20,7 +20,7 @@ namespace DREAM {
 
         virtual void SetMatrixElements(FVM::Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t* x) override;
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t* x) override;
 
         virtual len_t GetNumberOfNonZerosPerRow() const override 
             { return 1; }

--- a/include/DREAM/Equations/TransportBC.hpp
+++ b/include/DREAM/Equations/TransportBC.hpp
@@ -34,11 +34,11 @@ namespace DREAM {
         // Rebuilding is handled by the
         virtual bool Rebuild(const real_t, FVM::UnknownQuantityHandler*) override { return false; }
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
+        virtual bool AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
         virtual void AddToMatrixElements(DREAM::FVM::Matrix*, real_t*) override;
         virtual void AddToVectorElements(real_t*, const real_t*) override;
 
-        virtual void SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {return false;}
         virtual void SetMatrixElements(DREAM::FVM::Matrix*, real_t*) override {}
         virtual void SetVectorElements(real_t*, const real_t*) override {}
     };

--- a/include/DREAM/Equations/TransportBC.tcc
+++ b/include/DREAM/Equations/TransportBC.tcc
@@ -15,6 +15,8 @@ DREAM::TransportBC<T>::TransportBC(
     DREAM::FVM::Grid *grid, T *tt,
     enum bctype type
 ) : FVM::BC::BoundaryCondition(grid), transportOperator(tt), type(type) {
+    
+    SetName("TransportBC");
 
     if (type == TRANSPORT_BC_DF_CONST && grid->GetNr() == 1)
         throw DREAMException(
@@ -28,13 +30,16 @@ DREAM::TransportBC<T>::TransportBC(
  * Add elements to the given Jacobian.
  */
 template<typename T>
-void DREAM::TransportBC<T>::AddToJacobianBlock(
+bool DREAM::TransportBC<T>::AddToJacobianBlock(
     const len_t uqtyId, const len_t derivId, DREAM::FVM::Matrix *jac, const real_t*
 ) {
+    bool contributes = (derivId == uqtyId);
     if (derivId == uqtyId)
         this->AddToMatrixElements(jac, nullptr);
 
     // TODO handle derivatives of coefficients
+    
+    return contributes;
 }
 
 /**

--- a/include/DREAM/Equations/TransportPrescribed.tcc
+++ b/include/DREAM/Equations/TransportPrescribed.tcc
@@ -26,6 +26,8 @@ DREAM::TransportPrescribed<T>::TransportPrescribed(
     nt(nt), nr(nr), np1(np1), np2(np2),
     coeff(coeff), t(t), r(r), p1(p1), p2(p2),
     momtype(inptype), gridtype(gridtype), interpmethod(interpmethod) {
+
+    this->T::SetName("TransportPrescribed");
     
     // Interpolate input coefficient onto 'grid'...
     InterpolateCoefficient();

--- a/include/DREAM/OutputGenerator.hpp
+++ b/include/DREAM/OutputGenerator.hpp
@@ -20,6 +20,7 @@ namespace DREAM {
 		virtual void SaveIonMetaData(const std::string&) = 0;
 		virtual void SaveOtherQuantities(const std::string&) = 0;
 		virtual void SaveSettings(const std::string&) = 0;
+        virtual void SaveSolverData(const std::string&) = 0;
 		virtual void SaveTimings(const std::string&) = 0;
 		virtual void SaveUnknowns(const std::string&, bool) = 0;
 	public:

--- a/include/DREAM/OutputGeneratorSFile.hpp
+++ b/include/DREAM/OutputGeneratorSFile.hpp
@@ -15,6 +15,7 @@ namespace DREAM {
 		virtual void SaveIonMetaData(const std::string&) override;
 		virtual void SaveOtherQuantities(const std::string&) override;
 		virtual void SaveSettings(const std::string&) override;
+        virtual void SaveSolverData(const std::string&) override;
 		virtual void SaveTimings(const std::string&) override;
 		virtual void SaveUnknowns(const std::string&, bool) override;
 

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -87,12 +87,12 @@ enum adv_jacobian_mode {
 /////////////////////////////////////
 enum solver_type {
     SOLVER_TYPE_LINEARLY_IMPLICIT=1,
-    SOLVER_TYPE_NONLINEAR=2,
-    SOLVER_TYPE_NONLINEAR_SNES=3
+    SOLVER_TYPE_NONLINEAR=2
 };
 // Linear solver type (used by both the linear-implicit
 // and nonlinear solvers)
 enum linear_solver {
+    LINEAR_SOLVER_NONE=0,       // only for backup solver
     LINEAR_SOLVER_LU=1,
     LINEAR_SOLVER_MUMPS=2,
     LINEAR_SOLVER_MKL=3,

--- a/include/DREAM/Solver/SolverLinearlyImplicit.hpp
+++ b/include/DREAM/Solver/SolverLinearlyImplicit.hpp
@@ -55,6 +55,8 @@ namespace DREAM {
 
         void SaveDebugInfo(len_t, FVM::Matrix*, const real_t*);
         void SetDebugMode(bool, bool, bool, int_t, bool);
+
+        virtual void WriteDataSFile(SFile*, const std::string&) override;
     };
 }
 

--- a/include/FVM/Equation/AdvectionTerm.hpp
+++ b/include/FVM/Equation/AdvectionTerm.hpp
@@ -145,7 +145,7 @@ namespace DREAM::FVM {
         { return df1pSqAtZero[ir+nr*nMultiple][i2]; }
 
         virtual bool GridRebuilt() override;
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
         virtual void SetMatrixElements(Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
         virtual void SetVectorElements(

--- a/include/FVM/Equation/BoundaryCondition.hpp
+++ b/include/FVM/Equation/BoundaryCondition.hpp
@@ -1,6 +1,7 @@
 #ifndef _DREAM_FVM_BOUNDARY_CONDITION_HPP
 #define _DREAM_FVM_BOUNDARY_CONDITION_HPP
 
+#include <string>
 #include "FVM/config.h"
 #include "FVM/Grid/Grid.hpp"
 #include "FVM/Matrix.hpp"
@@ -10,10 +11,14 @@ namespace DREAM::FVM::BC {
     class BoundaryCondition {
     protected:
         Grid *grid;
+        std::string name;
 
     public:
         BoundaryCondition(Grid *g) : grid(g) {};
         virtual ~BoundaryCondition() {}
+
+        const std::string& GetName() const { return this->name; }
+        void SetName(const std::string& n) { this->name = n; }
 
         // By default, we assume that these do not add any
         // additional non-zero elements (which did not already
@@ -26,8 +31,8 @@ namespace DREAM::FVM::BC {
 
         virtual bool Rebuild(const real_t t, UnknownQuantityHandler*) = 0;
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) = 0;
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) = 0;
+        virtual bool AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) = 0;
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) = 0;
         virtual void AddToMatrixElements(Matrix*, real_t*) =0;
         virtual void SetMatrixElements(Matrix*, real_t*) = 0;
         virtual void AddToVectorElements(real_t*, const real_t*) = 0;

--- a/include/FVM/Equation/BoundaryConditions/PInternalBoundaryCondition.hpp
+++ b/include/FVM/Equation/BoundaryConditions/PInternalBoundaryCondition.hpp
@@ -26,10 +26,10 @@ namespace DREAM::FVM::BC {
         virtual bool GridRebuilt() override;
         virtual bool Rebuild(const real_t, UnknownQuantityHandler*) override;
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {}
+        virtual bool AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {return false;}
         virtual void AddToMatrixElements(Matrix*, real_t*) override;
         virtual void AddToVectorElements(real_t*, const real_t*) override;
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {return false;}
         virtual void SetMatrixElements(Matrix*, real_t*) override {};
         virtual void SetVectorElements(real_t*, const real_t*) override {}
     };

--- a/include/FVM/Equation/BoundaryConditions/PXiAdvectionDiffusionBoundaryCondition.hpp
+++ b/include/FVM/Equation/BoundaryConditions/PXiAdvectionDiffusionBoundaryCondition.hpp
@@ -38,7 +38,7 @@ namespace DREAM::FVM::BC {
             jacobian_interp_mode set_mode=NO_JACOBIAN
         ) = 0;
 
-        void AddPartialJacobianContributions(const len_t, const len_t, Matrix*, const real_t*, bool);
+        bool AddPartialJacobianContributions(const len_t, const len_t, Matrix*, const real_t*, bool);
         void SetPartialJacobianContribution(
             const int_t, const len_t, Matrix*, const real_t*,
             jacobian_interp_mode,

--- a/include/FVM/Equation/BoundaryConditions/PXiExternalKineticKinetic.hpp
+++ b/include/FVM/Equation/BoundaryConditions/PXiExternalKineticKinetic.hpp
@@ -43,7 +43,7 @@ namespace DREAM::FVM::BC {
 
         virtual bool Rebuild(const real_t, UnknownQuantityHandler*) override;
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
+        virtual bool AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
         virtual void AddToMatrixElements(DREAM::FVM::Matrix*, real_t*) override;
         virtual void AddToVectorElements_c(
             real_t*, const real_t*,
@@ -55,7 +55,7 @@ namespace DREAM::FVM::BC {
         ) override;
 
         // Not implemented (not used)
-        virtual void SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {return false;}
         virtual void SetMatrixElements(DREAM::FVM::Matrix*, real_t*) override {}
         virtual void SetVectorElements(real_t*, const real_t*) override {}
     };

--- a/include/FVM/Equation/BoundaryConditions/PXiExternalLoss.hpp
+++ b/include/FVM/Equation/BoundaryConditions/PXiExternalLoss.hpp
@@ -75,7 +75,7 @@ namespace DREAM::FVM::BC {
 
         virtual bool Rebuild(const real_t, UnknownQuantityHandler*) override;
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
+        virtual bool AddToJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override;
         virtual void AddToMatrixElements(DREAM::FVM::Matrix*, real_t*) override;
         virtual void AddToVectorElements_c(
             real_t*, const real_t*,
@@ -87,7 +87,7 @@ namespace DREAM::FVM::BC {
         ) override;
 
         // Not implemented (not used)
-        virtual void SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, DREAM::FVM::Matrix*, const real_t*) override {return false;}
         virtual void SetMatrixElements(DREAM::FVM::Matrix*, real_t*) override {}
         virtual void SetVectorElements(real_t*, const real_t*) override {}
     };

--- a/include/FVM/Equation/BoundaryConditions/PXiInternalTrapping.hpp
+++ b/include/FVM/Equation/BoundaryConditions/PXiInternalTrapping.hpp
@@ -54,7 +54,7 @@ namespace DREAM::FVM::BC {
         void DeallocateTrappedIndices();
         void LocateTrappedRegion();
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
         virtual void AddToMatrixElements(Matrix*, real_t*) override;
         virtual void AddToVectorElements_c(
             real_t*, const real_t*,
@@ -65,7 +65,7 @@ namespace DREAM::FVM::BC {
             jacobian_interp_mode set_mode=NO_JACOBIAN
         ) override;
 
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
         virtual void SetMatrixElements(Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };

--- a/include/FVM/Equation/BoundaryConditions/XiInternalBoundaryCondition.hpp
+++ b/include/FVM/Equation/BoundaryConditions/XiInternalBoundaryCondition.hpp
@@ -12,10 +12,10 @@ namespace DREAM::FVM::BC {
 
         bool Rebuild(const real_t, UnknownQuantityHandler*) override;
 
-        virtual void AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {}
+        virtual bool AddToJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {return false;}
         virtual void AddToMatrixElements(Matrix*, real_t*) override {}
         virtual void AddToVectorElements(real_t*, const real_t*) override {}
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {}
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override {return false;}
         virtual void SetMatrixElements(Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override {}
     };

--- a/include/FVM/Equation/DiagonalComplexTerm.hpp
+++ b/include/FVM/Equation/DiagonalComplexTerm.hpp
@@ -31,7 +31,7 @@ namespace DREAM::FVM {
         UnknownQuantityHandler *unknowns;
 
         virtual bool TermDependsOnUnknowns() override {return true;}
-        virtual void AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override;
         virtual void SetDiffWeights(len_t, len_t) = 0; 
     public:
         DiagonalComplexTerm(Grid*, UnknownQuantityHandler*, Grid *operandGrid=nullptr);

--- a/include/FVM/Equation/DiagonalLinearTerm.hpp
+++ b/include/FVM/Equation/DiagonalLinearTerm.hpp
@@ -10,7 +10,7 @@ namespace DREAM::FVM {
     class DiagonalLinearTerm : public DiagonalTerm, public EvaluableEquationTerm {
     protected:
         virtual bool TermDependsOnUnknowns() override {return false;}
-        virtual void AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override {}
+        virtual bool AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override {return false;}
         Grid *grid;
         len_t nr;
         len_t *n1, *n2;
@@ -32,7 +32,7 @@ namespace DREAM::FVM {
         virtual len_t GetNumberOfNonZerosPerRow() const override { return this->DiagonalTerm::GetNumberOfNonZerosPerRow(); }
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return this->DiagonalTerm::GetNumberOfNonZerosPerRow_jac(); }
         virtual void Rebuild(const real_t t, const real_t dt, UnknownQuantityHandler *u) override { this->DiagonalTerm::Rebuild(t,dt,u); };
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x) override
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x) override
             {return this->DiagonalTerm::SetJacobianBlock(uqtyId,derivId,jac,x);}
 
     };

--- a/include/FVM/Equation/DiagonalQuadraticTerm.hpp
+++ b/include/FVM/Equation/DiagonalQuadraticTerm.hpp
@@ -23,7 +23,7 @@ namespace DREAM::FVM {
             {return wUqtyNMultiples * this->grid->GetNCells();}
 
         virtual bool TermDependsOnUnknowns() override {return false;}
-        virtual void AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override;
     public:
         DiagonalQuadraticTerm(Grid*, const len_t, UnknownQuantityHandler*);
         
@@ -36,7 +36,7 @@ namespace DREAM::FVM {
         virtual void SetVectorElements(real_t*, const real_t*) override;
 
         virtual void Rebuild(const real_t, const real_t, UnknownQuantityHandler*) override { this->DiagonalTerm::Rebuild(0,0,nullptr); };
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x) override
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x) override
             {return this->DiagonalTerm::SetJacobianBlock(uqtyId,derivId,jac,x);}
     };
 }

--- a/include/FVM/Equation/DiagonalTerm.hpp
+++ b/include/FVM/Equation/DiagonalTerm.hpp
@@ -23,7 +23,7 @@ namespace DREAM::FVM {
         virtual void InitializeWeights();
         virtual bool TermDependsOnUnknowns() = 0; // determines whether weights should be set at every Rebuild or just on GridRebuilt
         virtual void SetWeights() = 0;
-        virtual void AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) = 0;
+        virtual bool AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) = 0;
     public:
         DiagonalTerm(Grid*);
         ~DiagonalTerm();
@@ -32,7 +32,7 @@ namespace DREAM::FVM {
 
         virtual void Rebuild(const real_t, const real_t, UnknownQuantityHandler*) override;
         virtual bool GridRebuilt() override;
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
     };
 }
 

--- a/include/FVM/Equation/DiffusionTerm.hpp
+++ b/include/FVM/Equation/DiffusionTerm.hpp
@@ -150,7 +150,7 @@ namespace DREAM::FVM {
         { return dd22[ir+nMultiple*nr][i2_f*n1[ir] + i1]; }
 
         virtual bool GridRebuilt() override;
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
         virtual void SetMatrixElements(Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
         virtual void SetVectorElements(

--- a/include/FVM/Equation/EquationTerm.hpp
+++ b/include/FVM/Equation/EquationTerm.hpp
@@ -1,6 +1,7 @@
 #ifndef _DREAM_FVM_EQUATION_TERM_HPP
 #define _DREAM_FVM_EQUATION_TERM_HPP
 
+#include <string>
 #include "FVM/Grid/Grid.hpp"
 #include "FVM/Matrix.hpp"
 #include "FVM/UnknownQuantityHandler.hpp"
@@ -12,6 +13,8 @@ namespace DREAM::FVM {
         std::vector<len_t> derivNMultiplesJacobian;
 
     protected:
+        std::string name = "<NOT SET>";
+
         len_t nr, *n1=nullptr, *n2=nullptr;
         Grid *grid;
 
@@ -48,6 +51,9 @@ namespace DREAM::FVM {
 
         virtual bool GridRebuilt();
 
+        const std::string& GetName() const { return this->name; }
+        void SetName(const std::string& n) { this->name = n; }
+
         virtual len_t GetNumberOfNonZerosPerRow() const = 0;
         virtual len_t GetNumberOfNonZerosPerRow_jac() const {
             return GetNumberOfNonZerosPerRow() + GetNumberOfMultiplesJacobian();
@@ -63,8 +69,13 @@ namespace DREAM::FVM {
          * but should rather be used to identify which unknown parameters
          * should be differentiated, and which should be differentiated
          * _with respect to_.
+         *
+         * The RETURN value indicates whether or not any elements were
+         * set in the jacobian. If 'true', one or more elements were set
+         * in the matrix, while 'false' indicates that no elements were
+         * set.
          */
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix*, const real_t*) = 0;
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix*, const real_t*) = 0;
         /**
          * Sets the 'matrix' elements which is used when running in 
          * semi-implicit mode. In general, equation terms are non-linear

--- a/include/FVM/Equation/LinearTransientTerm.hpp
+++ b/include/FVM/Equation/LinearTransientTerm.hpp
@@ -18,7 +18,7 @@ namespace DREAM::FVM {
         real_t *xn;
     protected:
         virtual bool TermDependsOnUnknowns() override {return false;}
-        virtual void AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override {}
+        virtual bool AddWeightsJacobian(const len_t, const len_t, Matrix*, const real_t*) override {return false;}
     public:
         LinearTransientTerm(Grid*, const len_t);
         

--- a/include/FVM/Equation/MomentQuantity.hpp
+++ b/include/FVM/Equation/MomentQuantity.hpp
@@ -82,7 +82,7 @@ namespace DREAM::FVM {
 
         virtual bool GridRebuilt() override;
 
-        virtual void SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, Matrix*, const real_t*) override;
         virtual void SetMatrixElements(Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };

--- a/include/FVM/Equation/Operator.hpp
+++ b/include/FVM/Equation/Operator.hpp
@@ -112,8 +112,8 @@ namespace DREAM::FVM {
 
         void RebuildTerms(const real_t, const real_t, UnknownQuantityHandler*);
 
-        void SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix*, const real_t*);
-        void SetJacobianBlockBC(const len_t uqtyId, const len_t derivId, Matrix*, const real_t*);
+        bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix*, const real_t*, bool printTerms=false);
+        bool SetJacobianBlockBC(const len_t uqtyId, const len_t derivId, Matrix*, const real_t*, bool printTerms=false);
         void SetMatrixElements(Matrix*, real_t*);
         void SetVectorElements(real_t*, const real_t*);
 

--- a/include/FVM/Equation/PredeterminedParameter.hpp
+++ b/include/FVM/Equation/PredeterminedParameter.hpp
@@ -17,7 +17,7 @@ namespace DREAM::FVM {
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return GetNumberOfNonZerosPerRow(); }
 
         virtual const real_t *GetData() { return this->currentData; }
-        virtual void SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
+        virtual bool SetJacobianBlock(const len_t, const len_t, FVM::Matrix*, const real_t*) override;
         virtual void SetMatrixElements(FVM::Matrix*, real_t*) override;
         virtual void SetVectorElements(real_t*, const real_t*) override;
     };

--- a/include/FVM/Equation/ScalarLinearTerm.hpp
+++ b/include/FVM/Equation/ScalarLinearTerm.hpp
@@ -36,7 +36,7 @@ namespace DREAM::FVM {
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override
             {return GetNumberOfNonZerosPerRow(); }
         virtual void Rebuild(const real_t, const real_t, UnknownQuantityHandler*) override;
-        virtual void SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x) override;
+        virtual bool SetJacobianBlock(const len_t uqtyId, const len_t derivId, Matrix *jac, const real_t* x) override;
         virtual bool GridRebuilt() override;
 
     };

--- a/include/FVM/MatrixInverter.hpp
+++ b/include/FVM/MatrixInverter.hpp
@@ -10,10 +10,13 @@ namespace DREAM::FVM {
 	protected:
 		Vec *solution = nullptr;
         KSP ksp;
+
+        PetscInt errorcode=0;
 	public:
 		MatrixInverter() {}
         virtual ~MatrixInverter() {}
 
+        virtual int_t GetReturnCode() { return this->errorcode; }
 		virtual void Invert(Matrix*, Vec*, Vec*) = 0;
 
         virtual void PrintInfo();

--- a/include/FVM/UnknownQuantityHandler.hpp
+++ b/include/FVM/UnknownQuantityHandler.hpp
@@ -25,6 +25,8 @@ namespace DREAM::FVM {
 
         const real_t *GetLongVector(const std::vector<len_t>& nontrivials, real_t *vec=nullptr);
         const real_t *GetLongVector(const len_t, const len_t*, real_t *vec=nullptr);
+        const real_t *GetLongVectorPrevious(const std::vector<len_t>& nontrivials, real_t *vec=nullptr);
+        const real_t *GetLongVectorPrevious(const len_t, const len_t*, real_t *vec=nullptr);
         const len_t GetLongVectorSize(const std::vector<len_t>& nontrivials);
         const len_t GetLongVectorSize(const len_t, const len_t*);
 

--- a/py/DREAM/DREAMOutput.py
+++ b/py/DREAM/DREAMOutput.py
@@ -12,7 +12,11 @@ from .Output.EquationSystem import EquationSystem
 from .Output.Grid import Grid
 from .Output.IonMetaData import IonMetaData
 from .Output.OtherQuantityHandler import OtherQuantityHandler
+from .Output.SolverLinear import SolverLinear
+from .Output.SolverNonLinear import SolverNonLinear
 from .Output.Timings import Timings
+
+from .Settings import Solver as SettingsSolver
 
 
 class DREAMOutput:
@@ -35,6 +39,7 @@ class DREAMOutput:
         self.ionmeta = None
         self.other = None
         self.settings = None
+        self.solver = None
         self.timings = None
 
         self.filename = None
@@ -66,6 +71,17 @@ class DREAMOutput:
         """
         if self.h5handle is not None:
             self.h5handle.close()
+
+
+    def _getsolver(self, solverdata, output):
+        if 'type' in solverdata:
+            if solverdata['type'] == SettingsSolver.LINEAR_IMPLICIT:
+                return SolverLinear(solverdata, output)
+            elif solverdata['type'] == SettingsSolver.NONLINEAR:
+                return SolverNonLinear(solverdata, output)
+        else:
+            print('WARNING: Invalid solver data given.')
+            return None
 
 
     def load(self, filename, path="", lazy=True):
@@ -109,6 +125,10 @@ class DREAMOutput:
         # Load settings for the run
         if 'settings' in od:
             self.settings = DREAMSettings(settings=od['settings'])
+
+        # Solver statistics
+        if 'solver' in od:
+            self.solver = self._getsolver(od['solver'], output=self)
 
         # Timing information
         if 'timings' in od:

--- a/py/DREAM/Output/Solver.py
+++ b/py/DREAM/Output/Solver.py
@@ -1,0 +1,49 @@
+# Output handler for solver statistics
+
+import numpy as np
+from ..DREAMException import DREAMException
+from ..DataObject import DataObject
+
+import DREAM.Settings.Solver
+
+
+class Solver:
+    
+
+    def __init__(self, solverdata=None, output=None):
+        """
+        Constructor.
+        """
+        self.solverdata = None
+        self.output = output
+
+
+
+    def __contains__(self, item):
+        """
+        Overrides the Python 'in' operator.
+        """
+        return (item in self.__dict__)
+
+
+    def __getitem__(self, index):
+        """
+        Direct access by name to the timing information.
+        """
+        return self.__dict__[index]
+
+
+    def __repr__(self):
+        """
+        Convert this object to an "official" string.
+        """
+        return self.__str__()
+
+
+    def plot(self):
+        """
+        Generic plotting routine
+        """
+        print("Method 'plot()' not implemented for this solver.")
+
+

--- a/py/DREAM/Output/SolverLinear.py
+++ b/py/DREAM/Output/SolverLinear.py
@@ -1,0 +1,23 @@
+# Container class for linear solver data
+
+
+from .Solver import Solver
+
+
+class SolverLinear(Solver):
+    
+
+    def __init__(self, solverdata=None, output=None):
+        """
+        Constructor.
+        """
+        super().__init__(solverdata, output)
+
+
+    def __str__(self):
+        """
+        Convert this object into a string.
+        """
+        return "<Empty linear solver data>"
+
+

--- a/py/DREAM/Output/SolverNonLinear.py
+++ b/py/DREAM/Output/SolverNonLinear.py
@@ -1,0 +1,62 @@
+# Container class for linear solver data
+
+
+from .Solver import Solver
+
+
+class SolverNonLinear(Solver):
+    
+
+    def __init__(self, solverdata=None, output=None):
+        """
+        Constructor.
+        """
+        super().__init__(solverdata, output)
+
+        self.iterations = [int(x) for x in solverdata['iterations'][:]]
+        self.backupinverter = [x==1 for x in solverdata['backupinverter'][:]]
+
+
+    def __str__(self):
+        """
+        Convert this object into a string.
+        """
+        s = "Non-linear solver statistics\n\n"
+
+        s += "Max. iterations: {}\n".format(max(self.iterations))
+        s += "Avg. iterations: {}\n".format(sum(self.iterations)/len(self.iterations))
+        s += "Min. iterations: {}\n\n".format(min(self.iterations))
+        
+        bi = sum(self.backupinverter)
+        if bi == 0:
+            s += "Backup inverter not used\n"
+        elif bi == 1:
+            s += "Backup inverter used: 1 time\n"
+        else:
+            s += "Backup inverter used: {} times\n".format(bi)
+
+        return s
+
+    
+    def plot(self, ax=None, show=None, **kwargs):
+        """
+        Visualize the solver statistics.
+        """
+        genax = ax is None
+
+        if genax:
+            ax = plt.axes()
+            
+            if show is None:
+                show = True
+
+        ax.plot(self.output.grid.t[1:], self.iterations, linewidth=2, **kwargs)
+        ax.set_xlabel(r'Simulation time (s)')
+        ax.set_ylabel(r'Number of iterations')
+
+        if show:
+            plt.show(block=False)
+
+        return ax
+
+

--- a/py/DREAM/Output/SolverNonLinear.py
+++ b/py/DREAM/Output/SolverNonLinear.py
@@ -1,6 +1,8 @@
 # Container class for linear solver data
 
 
+import matplotlib.pyplot as plt
+import numpy as np
 from .Solver import Solver
 
 
@@ -37,8 +39,32 @@ class SolverNonLinear(Solver):
 
         return s
 
+
+    def getBackupRanges(self):
+        """
+        Return the time step ranges for which the backup solver was used.
+        This method returns an array of tuples, where each tuple denotes a
+        single range of time steps where the backup solver was used.
+        """
+        r = np.linspace(1, self.output.grid.t.size, self.output.grid.t.size)[np.where(self.backupinverter)]
+
+        arr = []
+        start = r[0]
+        i = 1
+        while i < r.size:
+            # One step in between _without_ backup solver
+            if r[i] > r[i-1]+1:
+                arr.append((start, r[i-1]))
+                start = r[i]
+
+            i += 1
+
+        arr.append((start, r[-1]))
+
+        return arr
+
     
-    def plot(self, ax=None, show=None, **kwargs):
+    def plot(self, time=True, ax=None, show=None, **kwargs):
         """
         Visualize the solver statistics.
         """
@@ -50,9 +76,36 @@ class SolverNonLinear(Solver):
             if show is None:
                 show = True
 
-        ax.plot(self.output.grid.t[1:], self.iterations, linewidth=2, **kwargs)
-        ax.set_xlabel(r'Simulation time (s)')
+        if time:
+            t = self.output.grid.t[1:]
+            xlbl = r'Simulation time (s)'
+        else:
+            t = np.linspace(1, self.output.grid.t.size-1, self.output.grid.t.size-1)
+            xlbl = r'Time step'
+
+        ax.plot(t, self.iterations, linewidth=2, **kwargs)
+
+        ax.set_xlabel(xlbl)
         ax.set_ylabel(r'Number of iterations')
+
+        ymax = max(self.iterations)*1.2
+        ax.set_ylim([0, ymax])
+
+        # Plot where backup solver is used
+        xr = self.getBackupRanges()
+        for rg in xr:
+            if time:
+                ts1 = 0.5*self.output.grid.t[int(rg[0])] + 0.5*self.output.grid.t[int(rg[0])-1]
+                ts2 = 0.5*self.output.grid.t[int(rg[1])]
+
+                if rg[1]+1 < self.output.grid.t.size:
+                    ts2 += 0.5*self.output.grid.t[int(rg[1])+1]
+                else:
+                    ts2 += 2*ts2 - 0.5*self.output.grid.t[int(rg[1])-1]
+            else:
+                ts1, ts2 = rg[0]-0.5, rg[1]+0.5
+
+            ax.fill_between([ts1, ts2], [0, 0], [ymax, ymax], color='r', alpha=0.3)
 
         if show:
             plt.show(block=False)

--- a/py/DREAM/Settings/Solver.py
+++ b/py/DREAM/Settings/Solver.py
@@ -37,6 +37,7 @@ class Solver:
         self.debug_timestep = 0
         self.debug_iteration = 1
 
+        self.backupsolver = None
         self.tolerance = ToleranceSettings()
         self.preconditioner = Preconditioner()
         self.setOption(linsolv=linsolv, maxiter=maxiter, verbose=verbose)
@@ -73,6 +74,14 @@ class Solver:
         self.debug_savesystem = savesystem
         self.debug_timestep = timestep
         self.debug_iteration = iteration
+
+
+    def setBackupSolver(self, backup):
+        """
+        Set the backup linear solver to use in case the main linear
+        solver fails. Set to ``None`` to disable (default).
+        """
+        self.backupsolver = backup
 
 
     def setLinearSolver(self, linsolv):
@@ -150,6 +159,9 @@ class Solver:
         if 'preconditioner' in data:
             self.preconditioner.fromdict(data['preconditioner'])
 
+        if 'backupsolver' in data:
+            self.backupsolver = int(data['backupsolver'])
+
         if 'debug' in data:
             flags = ['printmatrixinfo', 'printjacobianinfo', 'savejacobian', 'savematrix', 'savenumericaljacobian', 'saverhs', 'saveresidual', 'savesystem']
 
@@ -201,6 +213,9 @@ class Solver:
                 'timestep': self.debug_timestep,
                 'iteration': self.debug_iteration
             }
+
+            if self.backupsolver is not None:
+                data['backupsolver'] = self.backupsolver
 
         return data
 
@@ -256,5 +271,7 @@ class Solver:
         solv = [LINEAR_SOLVER_LU, LINEAR_SOLVER_MUMPS, LINEAR_SOLVER_MKL, LINEAR_SOLVER_SUPERLU]
         if self.linsolv not in solv:
             raise DREAMException("Solver: Unrecognized linear solver type: {}.".format(self.linsolv))
+        elif self.backupsolver is not None and self.backupsolver not in solv:
+            raise DREAMException("Solver: Unrecognized backup linear solver type: {}.".format(self.backupsolver))
 
 

--- a/py/DREAM/interactive.py
+++ b/py/DREAM/interactive.py
@@ -36,6 +36,7 @@ def setup_interactive(do, glob):
     # Declare other useful stuff
     glob['grid']  = do.grid
     glob['other'] = do.other
+    glob['solver'] = do.solver
 
     print('Loaded {} unknowns ({})'.format(len(do.eqsys.keys()), do.getFileSize_s()))
     print(do.grid)

--- a/src/ConvergenceChecker.cpp
+++ b/src/ConvergenceChecker.cpp
@@ -161,6 +161,10 @@ bool ConvergenceChecker::IsConverged(const real_t *x, const real_t *dx, bool ver
 		//if(x_2norm[i]>0)
         conv = (dx_2norm[i] <= (epsa + epsr*x_2norm[i])); 
 
+        // Guard against infinity...
+        if (std::isinf(dx_2norm[i]) || std::isinf(x_2norm[i]))
+            conv = false;
+
         if (verbose) {
 #ifdef COLOR_TERMINAL
             if (conv)

--- a/src/Equations/CollisionFrequency.cpp
+++ b/src/Equations/CollisionFrequency.cpp
@@ -513,7 +513,7 @@ real_t CollisionFrequency::evaluatePsi0(len_t ir, real_t p) {
     F.params = &Theta;
     real_t psi0int, error; 
 
-    real_t epsabs = 0, epsrel = 5e-4, lim = gsl_ad_w->limit; 
+    real_t epsabs = 0, epsrel = 5e-8, lim = gsl_ad_w->limit; 
     gsl_integration_qag(&F,0,p,epsabs,epsrel,lim,QAG_KEY,gsl_ad_w,&psi0int,&error);
     return psi0int;
 }
@@ -530,7 +530,7 @@ real_t CollisionFrequency::evaluatePsi1(len_t ir, real_t p) {
     F.params = &Theta;
     real_t psi1int, error; 
 
-    real_t epsabs = 0, epsrel = 5e-4, lim = gsl_ad_w->limit; 
+    real_t epsabs = 0, epsrel = 5e-8, lim = gsl_ad_w->limit; 
     gsl_integration_qag(&F,0,p,epsabs,epsrel,lim,QAG_KEY,gsl_ad_w,&psi1int,&error);
     return psi1int;
 }
@@ -544,7 +544,7 @@ real_t CollisionFrequency::evaluatePsi2(len_t ir, real_t p) {
     F.params = &Theta;
     real_t psi2int, error; 
 
-    real_t epsabs = 0, epsrel = 5e-4, lim = gsl_ad_w->limit; 
+    real_t epsabs = 0, epsrel = 5e-8, lim = gsl_ad_w->limit; 
     gsl_integration_qags(&F,0,p,epsabs,epsrel,lim,gsl_ad_w,&psi2int,&error);
     return psi2int;
 }

--- a/src/Equations/Fluid/AmperesLawBoundaryAtRMax.cpp
+++ b/src/Equations/Fluid/AmperesLawBoundaryAtRMax.cpp
@@ -19,7 +19,10 @@ using namespace DREAM::FVM::BC;
  */
 AmperesLawBoundaryAtRMax::AmperesLawBoundaryAtRMax(Grid *g, Grid *targetGrid, 
     const Operator *eqn, real_t scaleFactor)
-    : BoundaryCondition(g), equation(eqn), targetGrid(targetGrid), scaleFactor(scaleFactor) { }
+    : BoundaryCondition(g), equation(eqn), targetGrid(targetGrid), scaleFactor(scaleFactor) {
+    
+    SetName("AmperesLawBoundaryAtRMax");
+}
 
 /**
  * Destructor.
@@ -57,12 +60,12 @@ bool AmperesLawBoundaryAtRMax::Rebuild(const real_t, UnknownQuantityHandler*){
 /**
  * Add flux to jacobian block.
  */
-void AmperesLawBoundaryAtRMax::AddToJacobianBlock(
+bool AmperesLawBoundaryAtRMax::AddToJacobianBlock(
     const len_t derivId, const len_t qtyId, Matrix * jac, const real_t* /*x*/
 ) {
     if (derivId == qtyId)
         this->AddToMatrixElements(jac, nullptr);
-
+    return (derivId == qtyId);
 }
 
 /**

--- a/src/Equations/Fluid/BindingEnergyTerm.cpp
+++ b/src/Equations/Fluid/BindingEnergyTerm.cpp
@@ -8,7 +8,10 @@ using namespace DREAM;
  * Constructor.
  */
 BindingEnergyTerm::BindingEnergyTerm(FVM::Grid* g, IonHandler *ionHandler, NIST *nist)
-    : FVM::DiagonalLinearTerm(g), ionHandler(ionHandler), nist(nist) {}
+    : FVM::DiagonalLinearTerm(g), ionHandler(ionHandler), nist(nist) {
+    
+    SetName("BindingEnergyTerm");
+}
 
 /** 
  * Sets weights to the binding potential, which is _minus_

--- a/src/Equations/Fluid/CollisionalEnergyTransferKineticTerm.cpp
+++ b/src/Equations/Fluid/CollisionalEnergyTransferKineticTerm.cpp
@@ -13,6 +13,9 @@ CollisionalEnergyTransferKineticTerm::CollisionalEnergyTransferKineticTerm(
     real_t pThreshold, pThresholdMode pMode
 ) : MomentQuantity(densityGrid, distributionGrid, id_n, id_f,u, 
     pThreshold, pMode), collQtyHandler(cqh), mgtype(mgt), scaleFactor(sf) {
+
+    SetName("CollisionalEnergyTransferKineticTerm");
+
     /**
      * Using "SUPERTHERMAL" collision setting to evaluate energy transfer, 
      * and completely screened type (so that only colliding with n_cold).

--- a/src/Equations/Fluid/ComptonRateTerm.cpp
+++ b/src/Equations/Fluid/ComptonRateTerm.cpp
@@ -15,6 +15,8 @@ ComptonRateTerm::ComptonRateTerm(
 ) : FVM::DiagonalComplexTerm(g,uqn, operandGrid), RunawaySourceTerm(g,uqn),
     REFluid(rf), scaleFactor(scaleFactor) {
 
+    SetName("ComptonRateTerm");
+
     AddUnknownForJacobian(unknowns,unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD));
     AddUnknownForJacobian(unknowns,unknowns->GetUnknownID(OptionConstants::UQTY_N_TOT));
 }

--- a/src/Equations/Fluid/CurrentDensityFromDistributionFunction.cpp
+++ b/src/Equations/Fluid/CurrentDensityFromDistributionFunction.cpp
@@ -20,6 +20,8 @@ CurrentDensityFromDistributionFunction::CurrentDensityFromDistributionFunction(
     FVM::UnknownQuantityHandler *u, real_t pThreshold, pThresholdMode pMode, real_t scaleFactor)
      : MomentQuantity(densityGrid, distributionGrid, id_n, id_f, u, pThreshold, pMode) {
 
+    SetName("CurrentDensityFromDistributionFunction");
+
     this->scaleFactor = scaleFactor;
     // Build moment integrand
     this->GridRebuilt();

--- a/src/Equations/Fluid/DensityFromBoundaryFluxPXI.cpp
+++ b/src/Equations/Fluid/DensityFromBoundaryFluxPXI.cpp
@@ -25,7 +25,10 @@ DensityFromBoundaryFluxPXI::DensityFromBoundaryFluxPXI(
     FVM::Grid *densityGrid, FVM::Grid *distributionGrid,
     const FVM::Operator *eqn
 ) : FVM::EquationTerm(densityGrid), distributionGrid(distributionGrid), 
-    equation(eqn) {}
+    equation(eqn) {
+
+    SetName("DensityFromBoundaryFluxPXI");
+}
 
 
 /**
@@ -66,14 +69,17 @@ len_t DensityFromBoundaryFluxPXI::GetNumberOfNonZerosPerRow_jac() const {
  * jac:     Jacobian matrix.
  * x:       Value of unknown quantity.
  */
-void DensityFromBoundaryFluxPXI::SetJacobianBlock(
+bool DensityFromBoundaryFluxPXI::SetJacobianBlock(
     const len_t qtyId, const len_t derivId, FVM::Matrix * jac, const real_t* /*x*/
 ) {
+    bool contributes = (qtyId == derivId);
     //throw NotImplementedException("Cannot set jacobian for 'DensityFromBoundaryFluxPXI' term yet.");
     if (qtyId == derivId)
         this->SetMatrixElements(jac, nullptr);
 
     // TODO Handle derivatives of coefficients
+
+    return contributes;
 }
 
 /**

--- a/src/Equations/Fluid/DensityFromDistributionFunction.cpp
+++ b/src/Equations/Fluid/DensityFromDistributionFunction.cpp
@@ -18,6 +18,9 @@ DensityFromDistributionFunction::DensityFromDistributionFunction(
     FVM::Grid *densityGrid, FVM::Grid *distributionGrid, len_t id_n, len_t id_f,
     FVM::UnknownQuantityHandler *u, real_t pThreshold, pThresholdMode pMode
 ) : MomentQuantity(densityGrid, distributionGrid, id_n, id_f, u, pThreshold, pMode) {
+
+    SetName("DensityFromDistributionFunction");
+
     // Build moment integrand
     this->GridRebuilt();
 }

--- a/src/Equations/Fluid/ExternalAvalancheTerm.cpp
+++ b/src/Equations/Fluid/ExternalAvalancheTerm.cpp
@@ -29,6 +29,8 @@ ExternalAvalancheTerm::ExternalAvalancheTerm(
     id_ntot   = unknowns->GetUnknownID(OptionConstants::UQTY_N_TOT);
     id_Efield = unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD);
     
+    SetName("ExternalAvalancheTerm");
+
     AddUnknownForJacobian(unknowns, id_Efield);
     AddUnknownForJacobian(unknowns, id_ntot);
 }

--- a/src/Equations/Fluid/FreeElectronDensityTerm.cpp
+++ b/src/Equations/Fluid/FreeElectronDensityTerm.cpp
@@ -11,7 +11,10 @@ using namespace DREAM;
  * Constructor
  */
 FreeElectronDensityTerm::FreeElectronDensityTerm(FVM::Grid *g, IonHandler *ih, real_t scaleFactor)
-    : DiagonalLinearTerm(g), ionHandler(ih), scaleFactor(scaleFactor) {}
+    : DiagonalLinearTerm(g), ionHandler(ih), scaleFactor(scaleFactor) {
+    
+    this->DiagonalTerm::SetName("FreeElectronDensityTerm");
+}
 
 
 /**

--- a/src/Equations/Fluid/FreeElectronDensityTransientTerm.cpp
+++ b/src/Equations/Fluid/FreeElectronDensityTransientTerm.cpp
@@ -12,7 +12,10 @@ using namespace DREAM;
  * Constructor
  */
 FreeElectronDensityTransientTerm::FreeElectronDensityTransientTerm(FVM::Grid *g, IonHandler *ih, const len_t id_ions, real_t scaleFactor)
-    : DiagonalLinearTerm(g), ionHandler(ih), id_ions(id_ions), scaleFactor(scaleFactor) {}
+    : DiagonalLinearTerm(g), ionHandler(ih), id_ions(id_ions), scaleFactor(scaleFactor) {
+    
+    this->DiagonalTerm::SetName("FreeElectronDensityTransientTerm");
+}
 
 
 /**

--- a/src/Equations/Fluid/HeatTransportDiffusion.cpp
+++ b/src/Equations/Fluid/HeatTransportDiffusion.cpp
@@ -23,6 +23,8 @@ HeatTransportDiffusion::HeatTransportDiffusion(
     FVM::Interpolator1D *D, FVM::UnknownQuantityHandler *unknowns
 ) : FVM::DiffusionTerm(grid), mgtype(mgtype), coeffD(D) {
 
+    SetName("HeatTransportDiffusion");
+
     this->unknowns = unknowns;
     this->id_n_cold = unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD);
     

--- a/src/Equations/Fluid/HeatTransportRechesterRosenbluth.cpp
+++ b/src/Equations/Fluid/HeatTransportRechesterRosenbluth.cpp
@@ -19,6 +19,8 @@ HeatTransportRechesterRosenbluth::HeatTransportRechesterRosenbluth(
     FVM::Interpolator1D *dB_B, FVM::UnknownQuantityHandler *unknowns
 ) : FVM::DiffusionTerm(grid), mgtype(mgtype), deltaBOverB(dB_B) {
 
+    SetName("HeatTransportRechesterRosenbluth");
+
     this->unknowns = unknowns;
     this->id_n_cold = unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD);
     this->id_T_cold = unknowns->GetUnknownID(OptionConstants::UQTY_T_COLD);

--- a/src/Equations/Fluid/HotTailCurrentDensityFromDistributionFunction.cpp
+++ b/src/Equations/Fluid/HotTailCurrentDensityFromDistributionFunction.cpp
@@ -20,6 +20,9 @@ HotTailCurrentDensityFromDistributionFunction::HotTailCurrentDensityFromDistribu
     FVM::Grid *fluidGrid, FVM::Grid *hottailGrid, FVM::UnknownQuantityHandler *u, PitchScatterFrequency *nuD,
     enum OptionConstants::collqty_collfreq_mode collfreq_mode, bool withFullJacobian
 ) : EquationTerm(fluidGrid), fluidGrid(fluidGrid), hottailGrid(hottailGrid), unknowns(u), nuD(nuD) {
+
+    SetName("HotTailCurrentDensityFromDistributionFunction");
+
     id_fhot  = unknowns->GetUnknownID(OptionConstants::UQTY_F_HOT);
     id_Eterm = unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD);
     id_ncold = unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD);
@@ -209,13 +212,13 @@ void HotTailCurrentDensityFromDistributionFunction::Deallocate() {
  * jac:     Jacobian matrix to set elements of.
  * x:       Value of the unknown quantity.
  */
-void HotTailCurrentDensityFromDistributionFunction::SetJacobianBlock(
+bool HotTailCurrentDensityFromDistributionFunction::SetJacobianBlock(
     const len_t /*unknId*/, const len_t derivId, FVM::Matrix *jac, const real_t* f
 ) {
     // return unless derivId corresponds to a quantity that J1Weights depends on
     len_t nMultiples;
     if( !HasJacobianContribution(derivId, &nMultiples) )
-        return;
+        return false;
 
     // treat f_hot block separately 
     const real_t *E = unknowns->GetUnknownData(id_Eterm); 
@@ -283,6 +286,8 @@ void HotTailCurrentDensityFromDistributionFunction::SetJacobianBlock(
 
     if(isCollFreqModeFULL)
         AddJacobianBlockMaxwellian(derivId, jac);
+
+    return true;
 }
 
 /**

--- a/src/Equations/Fluid/HottailRateTerm.cpp
+++ b/src/Equations/Fluid/HottailRateTerm.cpp
@@ -14,7 +14,10 @@ using namespace DREAM;
 HottailRateTerm::HottailRateTerm(           
     FVM::Grid *grid, AnalyticDistributionHottail *dist, FVM::UnknownQuantityHandler *unknowns,
     real_t sf
-) : FVM::EquationTerm(grid), RunawaySourceTerm(grid, unknowns), distHT(dist), unknowns(unknowns), scaleFactor(sf){}
+) : FVM::EquationTerm(grid), RunawaySourceTerm(grid, unknowns), distHT(dist), unknowns(unknowns), scaleFactor(sf) {
+    
+    SetName("HottailRateTerm");
+}
 
 /**
  * Destructor

--- a/src/Equations/Fluid/HottailRateTermHighZ.cpp
+++ b/src/Equations/Fluid/HottailRateTermHighZ.cpp
@@ -23,6 +23,8 @@ HottailRateTermHighZ::HottailRateTermHighZ(
     id_Efield(unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD)),
     id_tau(unknowns->GetUnknownID(OptionConstants::UQTY_TAU_COLL))
 {
+    SetName("HottailRateTermHighZ");
+
     AddUnknownForJacobian(unknowns,id_Efield);
     AddUnknownForJacobian(unknowns,id_ncold);
     AddUnknownForJacobian(unknowns,id_tau);
@@ -187,9 +189,9 @@ real_t HottailRateTermHighZ::evaluatePartialCriticalMomentum(len_t ir, len_t der
 /**
  * Sets the Jacobian of this equation term
  */
-void HottailRateTermHighZ::SetJacobianBlock(const len_t /*uqtyId*/, const len_t derivId, FVM::Matrix *jac, const real_t*){
+bool HottailRateTermHighZ::SetJacobianBlock(const len_t /*uqtyId*/, const len_t derivId, FVM::Matrix *jac, const real_t*){
     if(!HasJacobianContribution(derivId))
-        return;
+        return false;
 
     for(len_t ir=0; ir<nr; ir++){
         const len_t xiIndex = this->GetXiIndexForEDirection(ir);
@@ -217,6 +219,8 @@ void HottailRateTermHighZ::SetJacobianBlock(const len_t /*uqtyId*/, const len_t 
         }
         jac->SetElement(ir + np1*xiIndex, ir + np1_op*xiIndex_op, scaleFactor * dGamma * V);
     }
+
+    return true;
 }
 
 /**

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -14,7 +14,10 @@ using namespace DREAM;
  *       psi_t should probably be retrieved from radialgrid  
  */
 HyperresistiveDiffusionTerm::HyperresistiveDiffusionTerm(FVM::Grid *g, real_t *Lambda, real_t *psi_t) : 
-    FVM::DiffusionTerm(g), Lambda(Lambda), psi_t(psi_t) { }
+    FVM::DiffusionTerm(g), Lambda(Lambda), psi_t(psi_t) {
+    
+    SetName("HyperresistiveDiffusionTerm");
+}
 
 /**
  * Build the coefficients of this diffusion term.

--- a/src/Equations/Fluid/IonKineticIonizationTerm.cpp
+++ b/src/Equations/Fluid/IonKineticIonizationTerm.cpp
@@ -38,6 +38,8 @@ IonKineticIonizationTerm::IonKineticIonizationTerm(
 ) : IonEquationTerm<FVM::MomentQuantity>(momentGrid, fGrid, momentId, fId, u, pThreshold, pMode, ihdl, iIon), 
     ionization_mode(im), isPXiGrid(isPXiGrid), id_nfast(id_nf) 
 {
+    SetName("IonKineticIonizationTerm");
+
     this->id_ions = u->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
     this->FVM::MomentQuantity::AddUnknownForJacobian(u, id_ions);
 
@@ -241,28 +243,34 @@ int_t IonKineticIonizationTerm::GetTableIndex(len_t Z){
  * Sets the jacobian block for this equation term 
  * utilizing the functionality in MomentQuantity.
  */
-void IonKineticIonizationTerm::SetCSJacobianBlock(
+bool IonKineticIonizationTerm::SetCSJacobianBlock(
     const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t *f,
     const len_t iIon, const len_t Z0, const len_t rOffset
 ) {
-    if(uqtyId==derivId && ionization_mode != OptionConstants::EQTERM_IONIZATION_MODE_KINETIC_APPROX_JAC)
+    bool contributes = false;
+    if(uqtyId==derivId && ionization_mode != OptionConstants::EQTERM_IONIZATION_MODE_KINETIC_APPROX_JAC) {
         // set distribution jacobian (uqtyId corresponds to f_hot or f_re)
         this->SetCSMatrixElements(jac,nullptr,iIon,Z0,rOffset);
+        contributes = true;
+    }
 
     if(!HasJacobianContribution(derivId))
-        return;
+        return contributes;
     
     len_t rowOffset0 = jac->GetRowOffset();
     len_t colOffset0 = jac->GetColOffset();
     jac->SetOffset(rowOffset0+rOffset,colOffset0);
     // set n_i jacobian
     if (derivId==id_ions){
+        contributes = true;
+
         this->Z0ForDiffIntegrand = Z0;
         this->rOffsetForDiffIntegrand = rOffset;
         this->FVM::MomentQuantity::SetJacobianBlock(uqtyId, derivId, jac, f);
     }
 
     if(derivId == id_nfast){
+        contributes = true;
         // Set approximate fast electron jacobian under the assumption that the kinetic
         // ionization equation term is directly proportional to the fast density:
         // if hot, integrate over hot region and divide by fast density (n_hot)
@@ -280,6 +288,8 @@ void IonKineticIonizationTerm::SetCSJacobianBlock(
     } 
     
     jac->SetOffset(rowOffset0,colOffset0);
+
+    return contributes;
 }
 
 

--- a/src/Equations/Fluid/IonKineticIonizationTerm.cpp
+++ b/src/Equations/Fluid/IonKineticIonizationTerm.cpp
@@ -269,6 +269,10 @@ void IonKineticIonizationTerm::SetCSJacobianBlock(
         // if re, integrate over entire distribution and divide by fast density (n_re)
         SetIntegrand(Z0);
         const real_t *n = unknowns->GetUnknownData(id_nfast);
+
+        for (len_t ir=0; ir < nr; ir++)
+            tmpVec[ir] = 0;
+
         this->MomentQuantity::SetVectorElements(tmpVec, f);
         for(len_t ir=0; ir<nr; ir++)
             if (n[ir] != 0)

--- a/src/Equations/Fluid/IonPrescribedParameter.cpp
+++ b/src/Equations/Fluid/IonPrescribedParameter.cpp
@@ -19,6 +19,8 @@ IonPrescribedParameter::IonPrescribedParameter(
     const len_t *ionIndices, MultiInterpolator1D *data
 ) : EquationTerm(grid), ions(ihdl), nIons(nIons), ionIndices(ionIndices), iondata(data) {
 
+    SetName("IonPrescribedParameter");
+
     this->Z = new len_t[nIons];
     for (len_t i = 0; i < nIons; i++)
         this->Z[i] = this->ions->GetZ(ionIndices[i]);
@@ -124,7 +126,7 @@ void IonPrescribedParameter::Rebuild(const real_t t, const real_t, FVM::UnknownQ
  * with respect to anything of a constant is zero, we don't need
  * to do anything).
  */
-void IonPrescribedParameter::SetJacobianBlock(
+bool IonPrescribedParameter::SetJacobianBlock(
     const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t* /*x*/
 ) {
     if(uqtyId==derivId)
@@ -134,6 +136,8 @@ void IonPrescribedParameter::SetJacobianBlock(
                 for (len_t ir = 0; ir < nr; ir++)
                     jac->SetElement(idx*nr+ir, idx*nr+ir, 1.0);
             }
+
+    return (uqtyId==derivId);
 }
 
 /**

--- a/src/Equations/Fluid/IonRateEquation.cpp
+++ b/src/Equations/Fluid/IonRateEquation.cpp
@@ -38,6 +38,8 @@ IonRateEquation::IonRateEquation(
 ) : IonEquationTerm<FVM::EquationTerm>(g, ihdl, iIon), adas(adas), 
     addFluidIonization(addFluidIonization), addFluidJacobian(addFluidJacobian) {
     
+    SetName("IonRateEquation");
+
     this->unknowns  = unknowns;
     this->id_ions   = unknowns->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
     this->id_n_cold = unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD);
@@ -173,11 +175,12 @@ void IonRateEquation::Rebuild(
  * Z0:      Ion charge state.
  * rOffset: Offset in matrix block to set elements of.
  */
-void IonRateEquation::SetCSJacobianBlock(
+bool IonRateEquation::SetCSJacobianBlock(
     const len_t uqtyId, const len_t derivId, FVM::Matrix *jac,
     const real_t* nions,
     const len_t iIon, const len_t Z0, const len_t rOffset
 ) {
+    bool contributes = (derivId==uqtyId);
     if (derivId == uqtyId) 
         this->SetCSMatrixElements(jac, nullptr, iIon, Z0, rOffset, JACOBIAN);
 
@@ -189,13 +192,17 @@ void IonRateEquation::SetCSJacobianBlock(
     bool setIonization = addFluidIonization || addFluidJacobian;
 
     if(derivId == id_T_cold) {
+        contributes = true;
         #include "IonRateEquation.setDT.cpp"
     }
 
     if(derivId == id_n_cold){
+        contributes = true;
         #include "IonRateEquation.setDN.cpp"        
     }
     #undef NI
+
+    return contributes;
 }
 
 /**

--- a/src/Equations/Fluid/IonTransientTerm.cpp
+++ b/src/Equations/Fluid/IonTransientTerm.cpp
@@ -13,7 +13,10 @@ using namespace DREAM;
  * Constructor.
  */
 IonTransientTerm::IonTransientTerm(FVM::Grid *g, IonHandler *ih, const len_t iIon, const len_t unknownId)
-    : IonEquationTerm(g, ih, iIon), unknownId(unknownId) { }
+    : IonEquationTerm(g, ih, iIon), unknownId(unknownId) {
+    
+    SetName("IonTransientTerm");
+}
 
 /**
  * Rebuild this equation term.
@@ -41,13 +44,14 @@ void IonTransientTerm::Rebuild(
  * Z0:      Ion charge state.
  * rOffset: Offset in matrix block to set elements of.
  */
-void IonTransientTerm::SetCSJacobianBlock(
+bool IonTransientTerm::SetCSJacobianBlock(
     const len_t uqtyId, const len_t derivId, FVM::Matrix *jac,
     const real_t* /*x*/,
     const len_t iIon, const len_t Z0, const len_t rOffset
 ) {
     if (derivId == uqtyId)
         this->SetCSMatrixElements(jac, nullptr, iIon, Z0, rOffset);
+    return (derivId == uqtyId);
 }
 
 /**

--- a/src/Equations/Fluid/IonisationHeatingTerm.cpp
+++ b/src/Equations/Fluid/IonisationHeatingTerm.cpp
@@ -13,6 +13,8 @@ IonisationHeatingTerm::IonisationHeatingTerm(
     IonHandler *ionHandler, ADAS *adas, NIST *nist) 
     : FVM::DiagonalComplexTerm(g,u) 
 {
+    SetName("IonisationHeatingTerm");
+
     this->adas = adas;
     this->ionHandler = ionHandler;
     this->nist = nist;

--- a/src/Equations/Fluid/MaxwellianCollisionalEnergyTransferTerm.cpp
+++ b/src/Equations/Fluid/MaxwellianCollisionalEnergyTransferTerm.cpp
@@ -28,6 +28,8 @@ MaxwellianCollisionalEnergyTransferTerm::MaxwellianCollisionalEnergyTransferTerm
 ) : FVM::EquationTerm(g), index_i(index_i), index_j(index_j), isIon_i(isIon_i), isIon_j(isIon_j),
     unknowns(u), lnLambda(lnL), ionHandler(ionHandler)
 {
+    SetName("MaxwellianCollisionalEnergyTransferTerm");
+
     if(isIon_i){
         this->mi = ionHandler->GetIonSpeciesMass(index_i);
         this->Zi = ionHandler->GetZ(index_i);
@@ -93,9 +95,9 @@ void MaxwellianCollisionalEnergyTransferTerm::SetVectorElements(real_t *vec, con
 /**
  * Sets the jacobian block of this equation term
  */
-void MaxwellianCollisionalEnergyTransferTerm::SetJacobianBlock(const len_t /*uqtyId*/, const len_t derivId, FVM::Matrix *jac, const real_t*){
+bool MaxwellianCollisionalEnergyTransferTerm::SetJacobianBlock(const len_t /*uqtyId*/, const len_t derivId, FVM::Matrix *jac, const real_t*){
     if( !HasJacobianContribution(derivId) ) 
-        return;
+        return false;
 
     const real_t *lnL = isEI ? lnLambda->GetLnLambdaT() : lnLambda->GetLnLambdaII();
     
@@ -154,6 +156,8 @@ void MaxwellianCollisionalEnergyTransferTerm::SetJacobianBlock(const len_t /*uqt
                 jac->SetElement(ii,n*nr+ir, vec/lnL[ir]*lnLambda->evaluatePartialAtP(ir,0,derivId,n,lnLambda_settings) );
         }
     }
+
+    return true;
 }
 
 /**

--- a/src/Equations/Fluid/RadiatedPowerTerm.cpp
+++ b/src/Equations/Fluid/RadiatedPowerTerm.cpp
@@ -20,6 +20,8 @@ using namespace DREAM;
 RadiatedPowerTerm::RadiatedPowerTerm(FVM::Grid* g, FVM::UnknownQuantityHandler *u, IonHandler *ionHandler, ADAS *adas, NIST *nist, bool includePRB) 
     : FVM::DiagonalComplexTerm(g,u), includePRB(includePRB) 
 {
+    SetName("RadiatedPowerTerm");
+
     this->adas = adas;
     this->nist = nist;
     this->ionHandler = ionHandler;

--- a/src/Equations/Fluid/TotalElectronDensityTerm.cpp
+++ b/src/Equations/Fluid/TotalElectronDensityTerm.cpp
@@ -12,7 +12,10 @@ using namespace DREAM;
  * Constructor
  */
 TotalElectronDensityTerm::TotalElectronDensityTerm(FVM::Grid *g, IonHandler *ih, real_t scaleFactor)
-    : DiagonalLinearTerm(g), ionHandler(ih), scaleFactor(scaleFactor) {}
+    : DiagonalLinearTerm(g), ionHandler(ih), scaleFactor(scaleFactor) {
+    
+    this->DiagonalTerm::SetName("TotalElectronDensityTerm");
+}
 
 
 /**

--- a/src/Equations/Fluid/TritiumRateTerm.cpp
+++ b/src/Equations/Fluid/TritiumRateTerm.cpp
@@ -20,19 +20,23 @@ TritiumRateTerm::TritiumRateTerm(
     FVM::Grid *g, IonHandler *ions, FVM::UnknownQuantityHandler *uqn, const len_t iIon,
     RunawayFluid *rf, real_t scaleFactor
 ) : IonEquationTerm<FVM::EquationTerm>(g, ions, iIon), RunawaySourceTerm(g,uqn),
-    REFluid(rf), scaleFactor(scaleFactor) { }
+    REFluid(rf), scaleFactor(scaleFactor) {
+
+    SetName("TritiumRateTerm");
+}
 
 
 /**
  * Set elements of the Jacobian corresponding to this equation term.
  */
-void TritiumRateTerm::SetCSJacobianBlock(
+bool TritiumRateTerm::SetCSJacobianBlock(
     const len_t uqtyId, const len_t derivId, FVM::Matrix *jac,
     const real_t*,
     const len_t iIon, const len_t Z0, const len_t rOffset
 ) {
     if (uqtyId == derivId)
         this->SetCSMatrixElements(jac, nullptr, iIon, Z0, rOffset);
+    return (uqtyId==derivId);
 }
 
 /**

--- a/src/Equations/FluidSourceTerm.cpp
+++ b/src/Equations/FluidSourceTerm.cpp
@@ -102,13 +102,16 @@ void FluidSourceTerm::SetVectorElements(real_t *vec, const real_t *x){
 /**
  * Set jacobian matrix elements.
  */
-void FluidSourceTerm::SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t* x){
+bool FluidSourceTerm::SetJacobianBlock(const len_t uqtyId, const len_t derivId, FVM::Matrix *jac, const real_t* x){
+    bool contributes = (uqtyId == derivId);
     if(uqtyId == derivId)
         SetMatrixElements(jac, nullptr);
 
     // return if not derivId included in the list of dependent unknowns
     if(!HasJacobianContribution(derivId))
-        return;
+        return contributes;
+    else
+        contributes = true;
 
     len_t offset = 0;
     for(len_t ir=0; ir<nr; ir++){
@@ -117,6 +120,8 @@ void FluidSourceTerm::SetJacobianBlock(const len_t uqtyId, const len_t derivId, 
                 real_t dS = GetSourceFunctionJacobian(ir,i,j,derivId);
                 jac->SetElement(offset + n1[ir]*j + i, ir, dS*x[ir]);
             }
-    offset += n1[ir]*n2[ir];
-    }   
+        offset += n1[ir]*n2[ir];
+    }
+
+    return contributes;
 }

--- a/src/Equations/Kinetic/AvalancheSourceRP.cpp
+++ b/src/Equations/Kinetic/AvalancheSourceRP.cpp
@@ -18,6 +18,8 @@ AvalancheSourceRP::AvalancheSourceRP(
     real_t pCutoff, real_t scaleFactor, RPSourceMode sm
 ) : FluidSourceTerm(kineticGrid, u), scaleFactor(scaleFactor), sourceMode(sm)
 {
+    SetName("AvalancheSourceRP");
+
     id_ntot = unknowns->GetUnknownID(OptionConstants::UQTY_N_TOT);
     id_Efield = unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD);
     this->pCutoff = pCutoff;

--- a/src/Equations/Kinetic/BCIsotropicSourcePXi.cpp
+++ b/src/Equations/Kinetic/BCIsotropicSourcePXi.cpp
@@ -20,6 +20,7 @@ using namespace DREAM;
 BCIsotropicSourcePXi::BCIsotropicSourcePXi(FVM::Grid *g, CollisionQuantityHandler *cqh, len_t id_f)
     : FVM::BC::PInternalBoundaryCondition(g), id_f(id_f) {
     
+    SetName("BCIsotropicSourcePXi");
     this->slowingDownFreq = cqh->GetNuS();
 }
 

--- a/src/Equations/Kinetic/ElectricFieldDiffusionTerm.cpp
+++ b/src/Equations/Kinetic/ElectricFieldDiffusionTerm.cpp
@@ -13,6 +13,9 @@ using namespace DREAM;
 ElectricFieldDiffusionTerm::ElectricFieldDiffusionTerm(FVM::Grid *g, CollisionQuantityHandler *cqh, 
     FVM::UnknownQuantityHandler *unknowns, bool withFullIonJacobian)
     : FVM::DiffusionTerm(g) {
+
+    SetName("ElectricFieldDiffusionTerm");
+
     this->nuD = cqh->GetNuD();
     this->id_Eterm  = unknowns->GetUnknownID(OptionConstants::UQTY_E_FIELD); // E term should be <E*B>/sqrt(<B^2>)
 

--- a/src/Equations/Kinetic/ElectricFieldTerm.cpp
+++ b/src/Equations/Kinetic/ElectricFieldTerm.cpp
@@ -22,6 +22,9 @@ using namespace DREAM;
  */
 ElectricFieldTerm::ElectricFieldTerm(FVM::Grid *g, FVM::UnknownQuantityHandler *unknowns, enum OptionConstants::momentumgrid_type mgtype)
     : FVM::AdvectionTerm(g) {
+
+    SetName("ElectricFieldTerm");
+
     this->gridtypePXI         = (mgtype == OptionConstants::MOMENTUMGRID_TYPE_PXI);
     this->gridtypePPARPPERP   = (mgtype == OptionConstants::MOMENTUMGRID_TYPE_PPARPPERP);
     this->id_Eterm  = unknowns->GetUnknownID( OptionConstants::UQTY_E_FIELD ); // E term should be <E*B>/sqrt(<B^2>)

--- a/src/Equations/Kinetic/EnergyDiffusionTerm.cpp
+++ b/src/Equations/Kinetic/EnergyDiffusionTerm.cpp
@@ -17,8 +17,11 @@ EnergyDiffusionTerm::EnergyDiffusionTerm(FVM::Grid *g, CollisionQuantityHandler 
     enum OptionConstants::momentumgrid_type mgtype, FVM::UnknownQuantityHandler *unknowns,
     bool withKineticIonJacobian)
     : FVM::DiffusionTerm(g) {
-        this->gridtype = mgtype;
-        this->nuPar    = cqh->GetNuPar();
+
+    SetName("EnergyDiffusionTerm");
+
+    this->gridtype = mgtype;
+    this->nuPar    = cqh->GetNuPar();
     AddUnknownForJacobian(unknowns, unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD));
     AddUnknownForJacobian(unknowns, unknowns->GetUnknownID(OptionConstants::UQTY_T_COLD));
     if(withKineticIonJacobian && !(nuPar->GetSettings()->screened_diffusion==OptionConstants::COLLQTY_SCREENED_DIFFUSION_MODE_ZERO))

--- a/src/Equations/Kinetic/ParticleSourceTerm.cpp
+++ b/src/Equations/Kinetic/ParticleSourceTerm.cpp
@@ -20,6 +20,8 @@ ParticleSourceTerm::ParticleSourceTerm(
     FVM::Grid *kineticGrid, FVM::UnknownQuantityHandler *u, ParticleSourceShape pss
 ) : FluidSourceTerm(kineticGrid, u), particleSourceShape(pss)
 {
+    SetName("ParticleSourceTerm");
+
     this->id_Tcold = unknowns->GetUnknownID(OptionConstants::UQTY_T_COLD);
 
     // non-trivial temperature jacobian for Maxwellian-shaped particle source

--- a/src/Equations/Kinetic/PitchScatterTerm.cpp
+++ b/src/Equations/Kinetic/PitchScatterTerm.cpp
@@ -15,6 +15,9 @@ PitchScatterTerm::PitchScatterTerm(FVM::Grid *g, CollisionQuantityHandler *cqh,
     enum OptionConstants::momentumgrid_type mgtype, FVM::UnknownQuantityHandler *unknowns,
     bool withKineticIonJacobian)
     : FVM::DiffusionTerm(g) {
+
+    SetName("PitchScatterTerm");
+
     this->gridtype  = mgtype;
     this->nuD       = cqh->GetNuD();
     AddUnknownForJacobian(unknowns, unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD));

--- a/src/Equations/Kinetic/RechesterRosenbluthTransport.cpp
+++ b/src/Equations/Kinetic/RechesterRosenbluthTransport.cpp
@@ -28,7 +28,10 @@ using namespace DREAM;
  */
 RechesterRosenbluthTransport::RechesterRosenbluthTransport(
     FVM::Grid *grid, enum OptionConstants::momentumgrid_type mgtype, FVM::Interpolator1D *dB_B
-) : DiffusionTerm(grid), mgtype(mgtype), deltaBOverB(dB_B) { }
+) : DiffusionTerm(grid), mgtype(mgtype), deltaBOverB(dB_B) {
+
+    SetName("RechesterRosenbluthTransport");
+}
 
 /**
  * Destructor.

--- a/src/Equations/Kinetic/RipplePitchScattering.cpp
+++ b/src/Equations/Kinetic/RipplePitchScattering.cpp
@@ -35,6 +35,8 @@ RipplePitchScattering::RipplePitchScattering(
 ) : RipplePitchScattering(
     grid, mode, mgtype, (2*M_PI*grid->GetRadialGrid()->GetR0() / nCoils), nModes, m, n, dB_B
 ) {
+    SetName("RipplePitchScattering");
+
     if (grid->GetRadialGrid()->GetR0() == std::numeric_limits<real_t>::infinity())
         throw DREAMException(
             "PitchScattermTerm: Please use the parameter 'deltaCoils' instead of "
@@ -48,6 +50,8 @@ RipplePitchScattering::RipplePitchScattering(
     const real_t deltaCoils, const len_t nModes, const int_t *m,
     const int_t *n, DREAM::MultiInterpolator1D *dB_B
 ) : DiffusionTerm(grid), mode(mode), deltaCoils(deltaCoils), nModes(nModes), m(m), n(n), dB_B(dB_B) {
+    
+    SetName("RipplePitchScattering");
 
     if (mgtype != OptionConstants::MOMENTUMGRID_TYPE_PXI)
         throw DREAMException("PitchScatterTerm: Only p-xi grids are supported.");

--- a/src/Equations/Kinetic/SlowingDownTerm.cpp
+++ b/src/Equations/Kinetic/SlowingDownTerm.cpp
@@ -17,6 +17,8 @@ SlowingDownTerm::SlowingDownTerm(
     bool withKineticIonJacobian
 ) : FVM::AdvectionTerm(g) {
 
+    SetName("SlowingDownTerm");
+
     this->gridtype = mgtype;
     this->nuS = cqh->GetNuS();
     AddUnknownForJacobian(unknowns, unknowns->GetUnknownID(OptionConstants::UQTY_N_COLD));

--- a/src/Equations/Kinetic/SynchrotronTerm.cpp
+++ b/src/Equations/Kinetic/SynchrotronTerm.cpp
@@ -17,7 +17,10 @@ using namespace DREAM;
  */
 SynchrotronTerm::SynchrotronTerm(FVM::Grid *g, enum OptionConstants::momentumgrid_type mgtype)
     : FVM::AdvectionTerm(g) {
-        this->gridtype  = mgtype;
+
+    SetName("SynchrotronTerm");
+
+    this->gridtype  = mgtype;
 }
 
 

--- a/src/OutputGenerator.cpp
+++ b/src/OutputGenerator.cpp
@@ -38,6 +38,9 @@ void OutputGenerator::Save(bool current) {
     // Save ion metadata
     this->SaveIonMetaData("ionmeta");
 
+    // Save solver statistics
+    this->SaveSolverData("solver");
+
     // Save timing information
     this->SaveTimings("timings");
 

--- a/src/OutputGeneratorSFile.cpp
+++ b/src/OutputGeneratorSFile.cpp
@@ -218,6 +218,13 @@ void OutputGeneratorSFile::SaveSettings(const std::string&) {
 }
 
 /**
+ * Save data from the solver.
+ */
+void OutputGeneratorSFile::SaveSolverData(const std::string& name) {
+    this->eqsys->SaveSolverData(this->sf, name);
+}
+
+/**
  * Save timing information.
  */
 void OutputGeneratorSFile::SaveTimings(const std::string& name) {

--- a/src/Settings/Solver.cpp
+++ b/src/Settings/Solver.cpp
@@ -27,6 +27,7 @@ using namespace std;
 void SimulationGenerator::DefineOptions_Solver(Settings *s) {
     s->DefineSetting(MODULENAME "/type", "Equation system solver type", (int_t)OptionConstants::SOLVER_TYPE_NONLINEAR);
 
+    s->DefineSetting(MODULENAME "/backupsolver", "Type of backup linear solver to use if the main linear solver fails", (int_t)OptionConstants::LINEAR_SOLVER_NONE);
     s->DefineSetting(MODULENAME "/linsolv", "Type of linear solver to use", (int_t)OptionConstants::LINEAR_SOLVER_LU);
     s->DefineSetting(MODULENAME "/maxiter", "Maximum number of nonlinear iterations allowed", (int_t)100);
     s->DefineSetting(MODULENAME "/reltol", "Relative tolerance for nonlinear solver", (real_t)1e-6);
@@ -132,8 +133,9 @@ SolverNonLinear *SimulationGenerator::ConstructSolver_nonlinear(
 	vector<UnknownQuantityEquation*> *eqns,
     EquationSystem *eqsys
 ) {
-    enum OptionConstants::linear_solver linsolv =
-        (enum OptionConstants::linear_solver)s->GetInteger(MODULENAME "/linsolv");
+    enum OptionConstants::linear_solver
+        backups = (enum OptionConstants::linear_solver)s->GetInteger(MODULENAME "/backupsolver"),
+        linsolv = (enum OptionConstants::linear_solver)s->GetInteger(MODULENAME "/linsolv");
 
     int_t maxiter     = s->GetInteger(MODULENAME "/maxiter");
     real_t reltol     = s->GetReal(MODULENAME "/reltol");
@@ -146,7 +148,7 @@ SolverNonLinear *SimulationGenerator::ConstructSolver_nonlinear(
     int_t iteration   = s->GetInteger(MODULENAME "/debug/iteration");
     bool savesystem   = s->GetBool(MODULENAME "/debug/savesystem");
 
-    auto snl = new SolverNonLinear(u, eqns, eqsys, linsolv, maxiter, reltol, verbose);
+    auto snl = new SolverNonLinear(u, eqns, eqsys, linsolv, backups, maxiter, reltol, verbose);
     snl->SetDebugMode(printdebug, savejacobian, saveresidual, savenumjac, timestep, iteration, savesystem);
 
     return snl;

--- a/src/Solver/SolverLinearlyImplicit.cpp
+++ b/src/Solver/SolverLinearlyImplicit.cpp
@@ -260,3 +260,16 @@ void SolverLinearlyImplicit::SetDebugMode(
     this->savesystem = savesystem;
 }
 
+/**
+ * Write basic data/statistics from this solver.
+ *
+ * sf:   SFile object to use for writing.
+ * name: Name of group within file to store data in.
+ */
+void SolverLinearlyImplicit::WriteDataSFile(SFile *sf, const std::string &name) {
+    sf->CreateStruct(name);
+
+    int32_t type = (int32_t)OptionConstants::SOLVER_TYPE_LINEARLY_IMPLICIT;
+    sf->WriteList(name+"/type", &type, 1);
+}
+

--- a/src/Solver/SolverNonLinear.cpp
+++ b/src/Solver/SolverNonLinear.cpp
@@ -295,6 +295,7 @@ REDO_ITER:
 void SolverNonLinear::SaveNumericalJacobian(const std::string& name) {
     this->_EvaluateJacobianNumerically(this->jacobian);
     this->jacobian->View(FVM::Matrix::BINARY_MATLAB, name + "_num");
+    abort();
 }
 
 void SolverNonLinear::SaveJacobian() {
@@ -627,6 +628,7 @@ void SolverNonLinear::SetDebugMode(
 void SolverNonLinear::SwitchToBackupInverter() {
     // Switch inverter to use
     this->Solver::SwitchToBackupInverter();
+
     // Restore solution to initial guess for time step
     this->ResetSolution();
 }

--- a/src/Solver/SolverNonLinear.cpp
+++ b/src/Solver/SolverNonLinear.cpp
@@ -22,9 +22,10 @@ SolverNonLinear::SolverNonLinear(
 	vector<UnknownQuantityEquation*> *unknown_equations,
     EquationSystem *eqsys,
     enum OptionConstants::linear_solver ls,
+    enum OptionConstants::linear_solver bk,
 	const int_t maxiter, const real_t reltol,
 	bool verbose
-) : Solver(unknowns, unknown_equations, ls), eqsys(eqsys),
+) : Solver(unknowns, unknown_equations, ls, bk), eqsys(eqsys),
 	maxiter(maxiter), reltol(reltol), verbose(verbose) {
 
     this->timeKeeper = new FVM::TimeKeeper("Solver non-linear");
@@ -74,6 +75,7 @@ void SolverNonLinear::Allocate() {
 	this->x0 = new real_t[N];
 	this->x1 = new real_t[N];
 	this->dx = new real_t[N];
+    this->xinit = new real_t[N];
 
 	this->x_2norm  = new real_t[this->unknown_equations->size()];
 	this->dx_2norm = new real_t[this->unknown_equations->size()];
@@ -120,7 +122,10 @@ void SolverNonLinear::AllocateJacobianMatrix() {
  * Deallocate memory used by this solver.
  */
 void SolverNonLinear::Deallocate() {
-	delete inverter;
+    if (backupInverter != nullptr)
+        delete backupInverter;
+
+	delete mainInverter;
 	delete jacobian;
 
 	delete [] this->x_2norm;
@@ -129,6 +134,7 @@ void SolverNonLinear::Deallocate() {
 	delete [] this->x0;
 	delete [] this->x1;
 	delete [] this->dx;
+    delete [] this->xinit;
 
 	VecDestroy(&this->petsc_F);
 	VecDestroy(&this->petsc_dx);
@@ -162,7 +168,7 @@ void SolverNonLinear::initialize_internal(
  * Check if the solver has converged.
  */
 bool SolverNonLinear::IsConverged(const real_t *x, const real_t *dx) {
-	if (this->GetIteration() >= (len_t)this->MaxIter()){
+	if (this->GetIteration() >= this->MaxIter()){
 		throw SolverException(
 			"Non-linear solver reached the maximum number of allowed "
 			"iterations: " LEN_T_PRINTF_FMT ".",
@@ -172,7 +178,7 @@ bool SolverNonLinear::IsConverged(const real_t *x, const real_t *dx) {
 	
 	// always print verbose for the last few iterations before reaching max
 	const len_t numVerboseBeforeMax = 3; 
-	bool printVerbose = this->Verbose() || ((len_t)this->MaxIter() - this->GetIteration())<=numVerboseBeforeMax;
+	bool printVerbose = this->Verbose() || (this->MaxIter() - this->GetIteration())<=numVerboseBeforeMax;
     if (printVerbose)
         DREAM::IO::PrintInfo("ITERATION %d", this->GetIteration());
 
@@ -195,6 +201,14 @@ void SolverNonLinear::SetInitialGuess(const real_t *guess) {
 }
 
 /**
+ * Revert the solution to the initial guess.
+ */
+void SolverNonLinear::ResetSolution() {
+    this->unknowns->GetLongVectorPrevious(this->nontrivial_unknowns, this->x0);
+	this->StoreSolution(this->x0);
+}
+
+/**
  * Solve the equation system (advance the system in time
  * by one step).
  *
@@ -204,6 +218,10 @@ void SolverNonLinear::SetInitialGuess(const real_t *guess) {
  * (the obtained solution will correspond to time t'=t+dt)
  */
 void SolverNonLinear::Solve(const real_t t, const real_t dt) {
+    // Return to main matrix inverter (in case backup inverter
+    // was used to complete last time step)
+    this->SwitchToMainInverter();
+
     this->nTimeStep++;
 
 	this->t  = t;
@@ -211,6 +229,33 @@ void SolverNonLinear::Solve(const real_t t, const real_t dt) {
 
     this->timeKeeper->StartTimer(timerTot);
 
+	try {
+        this->_InternalSolve();
+    } catch (FVM::FVMException &ex) {
+        // Retry with backup-solver (if allowed and not already used)
+        if (this->backupInverter != nullptr && this->inverter != this->backupInverter) {
+            if (this->Verbose()) {
+                DREAM::IO::PrintInfo(
+                    "Main inverter failed to converge. Switching to backup inverter."
+                );
+                DREAM::IO::PrintError(ex.what());
+            }
+
+            // Retry solve
+            this->SwitchToBackupInverter();
+            this->_InternalSolve();
+        } else  // Rethrow exception
+            throw ex;
+    }
+
+    // Save basic statistics for step
+    this->nIterations.push_back(this->iteration);
+    this->usedBackupInverter.push_back(this->inverter == this->backupInverter);
+
+    this->timeKeeper->StopTimer(timerTot);
+}
+
+void SolverNonLinear::_InternalSolve() {
 	// Take Newton steps
 	len_t iter = 0;
 	const real_t *x, *dx;
@@ -218,16 +263,22 @@ void SolverNonLinear::Solve(const real_t t, const real_t dt) {
 		iter++;
 		this->SetIteration(iter);
 
+REDO_ITER:
 		dx = this->TakeNewtonStep();
+        // Solution rejected (solver likely switched)
+        if (dx == nullptr) {
+            if (iter < this->MaxIter())
+                goto REDO_ITER;
+            else
+                throw SolverException("Maximum number of iterations reached while dx=nullptr.");
+        }
+
 		x  = UpdateSolution(dx);
 
 		// TODO backtracking...
 		
 		AcceptSolution();
 	} while (!IsConverged(x, dx));
-	
-
-    this->timeKeeper->StopTimer(timerTot);
 }
 
 /**
@@ -296,7 +347,17 @@ const real_t *SolverNonLinear::TakeNewtonStep() {
 
 	// Solve J*dx = F
     this->timeKeeper->StartTimer(timerInvert);
-	inverter->Invert(this->jacobian, &this->petsc_F, &this->petsc_dx);
+    inverter->Invert(this->jacobian, &this->petsc_F, &this->petsc_dx);
+
+    if (inverter->GetReturnCode() != 0) {
+        if (this->Verbose())
+            DREAM::IO::PrintInfo("Switching to backup inverter... " INT_T_PRINTF_FMT, inverter->GetReturnCode());
+
+        this->SwitchToBackupInverter();
+
+        return nullptr;
+    }
+
     this->timeKeeper->StopTimer(timerInvert);
 
     // Undo preconditioner (if enabled)
@@ -332,7 +393,7 @@ const real_t MaximalStepLengthAtGridPoint(
  * physically-motivated constraints, such as positivity of temperature.
  * If initial guess dx from Newton step satisfies all constraints, returns 1.
  */
-const real_t MaximalPhysicalStepLength(real_t *x0, const real_t *dx,len_t iteration, std::vector<len_t> nontrivial_unknowns, FVM::UnknownQuantityHandler *unknowns, IonHandler *ionHandler, len_t &id_uqn){
+const real_t MaximalPhysicalStepLength(real_t *x0, const real_t *dx, len_t iteration, std::vector<len_t> nontrivial_unknowns, FVM::UnknownQuantityHandler *unknowns, IonHandler *ionHandler, len_t &id_uqn){
 	real_t maxStepLength = 1.0;
 	real_t threshold = 0.1;
 
@@ -557,5 +618,42 @@ void SolverNonLinear::SetDebugMode(
     this->savetimestep      = timestep;
     this->saveiteration     = iteration;
     this->savesystem        = savesystem;
+}
+
+
+/**
+ * Override switch to backup inverter.
+ */
+void SolverNonLinear::SwitchToBackupInverter() {
+    // Switch inverter to use
+    this->Solver::SwitchToBackupInverter();
+    // Restore solution to initial guess for time step
+    this->ResetSolution();
+}
+
+/**
+ * Write basic data from the solver to the output file.
+ * This data is mainly statistics about the solution.
+ *
+ * sf:   SFile object to use for writing.
+ * name: Name of group within file to store data in.
+ */
+void SolverNonLinear::WriteDataSFile(SFile *sf, const std::string& name) {
+    sf->CreateStruct(name);
+
+    int32_t type = (int32_t)OptionConstants::SOLVER_TYPE_NONLINEAR;
+    sf->WriteList(name+"/type", &type, 1);
+
+    // Number of iterations per time step
+    sf->WriteList(name+"/iterations", this->nIterations.data(), this->nIterations.size());
+
+    // Whether or not backup inverter was used for a given time step
+    len_t nubi = this->usedBackupInverter.size();
+    int32_t *ubi = new int32_t[nubi];
+    for (len_t i = 0; i < nubi; i++)
+        ubi[i] = this->usedBackupInverter[i] ? 1 : 0;
+
+    sf->WriteList(name+"/backupinverter", ubi, nubi);
+    delete [] ubi;
 }
 


### PR DESCRIPTION
This branch implements a possibility to switch from a "main" linear system solver to a "backup" linear system solver when the main solver fails for some reason. This has been implemented in response to the more advanced solvers sometimes failing to converge in certain scenarios. With these changes, DREAM can then switch to the very robust (but slow) PETSc LU solver, while using faster solvers whenever possible.

In addition to the backup solver, the signature of the ``SetJacobianBlock()`` and associated methods have been updated to return ``bool``, indicating whether method has set any elements (corresponding to checking if the term depends on the specified unknown with ID ``derivId``).