### PR TITLE
Automatic trapped/passing boundary xi grid

### DIFF
--- a/doc/sphinx/source/_static/figs/logo1.svg
+++ b/doc/sphinx/source/_static/figs/logo1.svg
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   id="svg8"
-   version="1.1"
-   viewBox="0 0 57.231476 29.135147"
+   width="57.231476mm"
    height="29.135147mm"
-   width="57.231476mm">
+   viewBox="0 0 57.231476 29.135147"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.1 (c4e8f9ed74, 2021-05-24)"
+   sodipodi:docname="logo1.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2">
     <rect
@@ -19,6 +23,30 @@
        y="74.457535"
        x="88.62281" />
   </defs>
+  <sodipodi:namedview
+     fit-margin-bottom="0"
+     fit-margin-right="0"
+     fit-margin-left="0"
+     fit-margin-top="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:window-height="1372"
+     inkscape:window-width="2560"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="80"
+     inkscape:cx="112.05357"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     inkscape:pagecheckerboard="0" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -27,13 +55,15 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      transform="translate(-80.077644,-65.842578)"
-     id="layer1">
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Lager 1">
     <g
        transform="translate(43.592362,-19.37561)"
        id="g897">
@@ -75,36 +105,119 @@
          rx="9"
          ry="11" />
     </g>
-    <text
-       style="font-style:normal;font-weight:normal;font-size:11.2889px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect835);fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
-       id="text833"
-       xml:space="preserve"><tspan
-         x="88.623047"
-         y="84.578422"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px">DREAM</tspan></tspan></text>
     <path
+       inkscape:transform-center-y="0.15819292"
+       inkscape:transform-center-x="0.16887975"
        d="m 89.357322,73.300208 -2.246187,-0.04033 -1.306625,1.827489 -0.655749,-2.148716 -2.141814,-0.677949 1.840912,-1.287644 -0.01709,-2.246484 1.793495,1.352908 2.131252,-0.710455 -0.732471,2.123787 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="false"
+       sodipodi:arg2="1.1047316"
+       sodipodi:arg1="0.47641306"
+       sodipodi:r2="1.6915118"
+       sodipodi:r1="3.3830235"
+       sodipodi:cy="71.748772"
+       sodipodi:cx="86.351013"
+       sodipodi:sides="5"
        id="path928"
-       style="opacity:1;fill:#f1f1bb;fill-opacity:1;stroke:none;stroke-width:1.32292" />
+       style="opacity:1;fill:#f1f1bb;fill-opacity:1;stroke:none;stroke-width:1.32292"
+       sodipodi:type="star" />
     <path
        transform="rotate(20,171.0025,83.894035)"
+       sodipodi:type="star"
        style="opacity:1;fill:#f1f1bb;fill-opacity:1;stroke:none;stroke-width:1.32292"
        id="path928-0"
-       d="m 110.68939,92.857421 -2.24619,-0.04033 -1.30662,1.827488 -0.65575,-2.148715 -2.14181,-0.677949 1.84091,-1.287644 -0.0171,-2.246484 1.79349,1.352908 2.13126,-0.710455 -0.73247,2.123787 z" />
+       sodipodi:sides="5"
+       sodipodi:cx="107.68308"
+       sodipodi:cy="91.305984"
+       sodipodi:r1="3.3830235"
+       sodipodi:r2="1.6915118"
+       sodipodi:arg1="0.47641306"
+       sodipodi:arg2="1.1047316"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 110.68939,92.857421 -2.24619,-0.04033 -1.30662,1.827488 -0.65575,-2.148715 -2.14181,-0.677949 1.84091,-1.287644 -0.0171,-2.246484 1.79349,1.352908 2.13126,-0.710455 -0.73247,2.123787 z"
+       inkscape:transform-center-x="0.12203413"
+       inkscape:transform-center-y="-0.20478092" />
     <path
        transform="rotate(60,104.27157,91.758754)"
+       sodipodi:type="star"
        style="opacity:1;fill:#f1f1bb;fill-opacity:1;stroke:none;stroke-width:1.32292"
        id="path928-4"
-       d="m 105.88404,95.403815 -2.24619,-0.04033 -1.30662,1.827489 -0.65575,-2.148715 -2.141815,-0.677949 1.840915,-1.287644 -0.0171,-2.246485 1.79349,1.352908 2.13126,-0.710455 -0.73248,2.123787 z" />
+       sodipodi:sides="5"
+       sodipodi:cx="102.87773"
+       sodipodi:cy="93.852379"
+       sodipodi:r1="3.3830235"
+       sodipodi:r2="1.6915118"
+       sodipodi:arg1="0.47641306"
+       sodipodi:arg2="1.1047316"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 105.88404,95.403815 -2.24619,-0.04033 -1.30662,1.827489 -0.65575,-2.148715 -2.141815,-0.677949 1.840915,-1.287644 -0.0171,-2.246485 1.79349,1.352908 2.13126,-0.710455 -0.73248,2.123787 z"
+       inkscape:transform-center-x="-0.049309538"
+       inkscape:transform-center-y="0.27579456" />
     <path
        transform="rotate(20,121.50924,89.243462)"
+       sodipodi:type="star"
        style="opacity:1;fill:#f1f1bb;fill-opacity:1;stroke:none;stroke-width:1.32292"
        id="path928-8"
-       d="m 124.51555,90.794898 -2.24619,-0.04033 -1.30662,1.827488 -0.65575,-2.148715 -2.14182,-0.677949 1.84091,-1.287644 -0.0171,-2.246484 1.79349,1.352908 2.13125,-0.710455 -0.73247,2.123787 z" />
+       sodipodi:sides="5"
+       sodipodi:cx="121.50924"
+       sodipodi:cy="89.243462"
+       sodipodi:r1="3.3830235"
+       sodipodi:r2="1.6915118"
+       sodipodi:arg1="0.47641306"
+       sodipodi:arg2="1.1047316"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 124.51555,90.794898 -2.24619,-0.04033 -1.30662,1.827488 -0.65575,-2.148715 -2.14182,-0.677949 1.84091,-1.287644 -0.0171,-2.246484 1.79349,1.352908 2.13125,-0.710455 -0.73247,2.123787 z"
+       inkscape:transform-center-x="0.12203397"
+       inkscape:transform-center-y="-0.20478208" />
     <path
        transform="rotate(80,83.460412,87.532891)"
+       sodipodi:type="star"
        style="opacity:1;fill:#f1f1bb;fill-opacity:1;stroke:none;stroke-width:1.32292"
        id="path928-88"
-       d="m 86.46672,89.084327 -2.246187,-0.04033 -1.306625,1.827488 -0.655749,-2.148715 -2.141814,-0.677949 1.840912,-1.287644 -0.01709,-2.246484 1.793496,1.352907 2.131252,-0.710454 -0.732471,2.123787 z" />
+       sodipodi:sides="5"
+       sodipodi:cx="83.460411"
+       sodipodi:cy="87.53289"
+       sodipodi:r1="3.3830235"
+       sodipodi:r2="1.6915118"
+       sodipodi:arg1="0.47641306"
+       sodipodi:arg2="1.1047316"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 86.46672,89.084327 -2.246187,-0.04033 -1.306625,1.827488 -0.655749,-2.148715 -2.141814,-0.677949 1.840912,-1.287644 -0.01709,-2.246484 1.793496,1.352907 2.131252,-0.710454 -0.732471,2.123787 z"
+       inkscape:transform-center-x="0.31081704"
+       inkscape:transform-center-y="0.012835266" />
+    <g
+       aria-label="DREAM"
+       id="text891"
+       style="font-style:normal;font-weight:normal;font-size:11.2889px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect835);fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         d="m 89.482944,76.497597 h 3.709682 q 1.09692,0 1.769403,0.297657 0.677996,0.297657 1.118968,0.854385 0.440973,0.556728 0.639411,1.295357 0.198437,0.738629 0.198437,1.565453 0,1.295357 -0.297656,2.011938 -0.292145,0.711068 -0.8158,1.196138 -0.523655,0.479558 -1.12448,0.63941 -0.821312,0.220487 -1.488283,0.220487 h -3.709682 z m 2.497007,1.830037 v 4.415239 h 0.61185 q 0.782726,0 1.113456,-0.170877 0.330729,-0.176389 0.518143,-0.606337 0.187413,-0.435461 0.187413,-1.405601 0,-1.284333 -0.418924,-1.758378 -0.418924,-0.474046 -1.389064,-0.474046 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px"
+         id="path962" />
+      <path
+         d="m 97.205482,84.578422 v -8.080825 h 4.161678 q 1.15755,0 1.7694,0.198438 0.61185,0.198438 0.98668,0.738629 0.37483,0.53468 0.37483,1.306382 0,0.672483 -0.28663,1.163065 -0.28664,0.48507 -0.78824,0.788239 -0.31971,0.192926 -0.87644,0.319705 0.44649,0.148828 0.65044,0.297657 0.1378,0.09922 0.39687,0.424436 0.26459,0.325217 0.35278,0.501606 l 1.20716,2.342668 h -2.82222 l -1.33394,-2.469447 q -0.25356,-0.479558 -0.452,-0.622874 -0.2701,-0.187414 -0.61185,-0.187414 h -0.220486 v 3.279735 z m 2.508032,-4.806602 h 1.052826 q 0.17087,0 0.66146,-0.110244 0.24804,-0.04961 0.40238,-0.253559 0.15986,-0.20395 0.15986,-0.468533 0,-0.391364 -0.24805,-0.600826 -0.24805,-0.209462 -0.93156,-0.209462 h -1.096916 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px"
+         id="path964" />
+      <path
+         d="m 104.88944,76.497597 h 6.69176 v 1.725306 h -4.18924 v 1.284333 h 3.88607 v 1.648135 h -3.88607 v 1.593014 h 4.3105 v 1.830037 h -6.81302 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px"
+         id="path966" />
+      <path
+         d="m 116.96107,83.244479 h -2.84428 l -0.39136,1.333943 h -2.55213 l 3.0372,-8.080825 h 2.72301 l 3.03719,8.080825 h -2.61276 z m -0.52366,-1.747354 -0.89297,-2.904907 -0.88746,2.904907 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px"
+         id="path968" />
+      <path
+         d="m 119.68408,76.497597 h 3.28524 l 1.2678,4.916846 1.26229,-4.916846 h 3.27422 v 8.080825 h -2.0395 v -6.162593 l -1.58199,6.162593 h -1.84657 l -1.57648,-6.162593 v 6.162593 h -2.04501 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px"
+         id="path970" />
+    </g>
   </g>
 </svg>

--- a/doc/sphinx/source/frontend/api/Settings/momentumgrid.rst
+++ b/doc/sphinx/source/frontend/api/Settings/momentumgrid.rst
@@ -45,88 +45,67 @@ perpendicular :math:`p_\perp` to the magnetic field).
 
    Describe the use of the custom momentum grids.
 
-.. todo::
+.. _ds-momentumgrid-trapped:
 
-   Describe the use of the ``setTrappedPassingBoundaryLayerGrid()`` method.
+Trapped/passing boundary
+------------------------
+In toroidal geometry, particles with
+:math:`|\xi_0| < \sqrt{1-B_{\rm min}/B_{\rm max}}` will be trapped and bounce
+back and forth in the magnetic field. Here, :math:`B_{\rm max}` is the maximum
+magnetic field strength experienced along the flux surface/orbit, and
+:math:`B_{\rm min}` is the minimum magnetic field strength, at which point the
+particle instantaneously has :math:`\xi = \xi_0`.
+
+To accurately resolve a distribution function in a toroidal magnetic, the set of
+points :math:`\xi_{0,{\rm T}}` referred to as the trapped-passing
+boundary---which separates the particles which are trapped from those that are
+passing in momentum space---must be resolved very accurately (i.e. we must place
+grid points very close to these points). DREAM provides a particular grid type
+for automatically locating the trapped-passing boundary and placing grid points
+in appropriate locations. To use this grid, call the method
+:py:meth:`DREAM.Settings.MomentumGrid.MomentumGrid.setTrappedPassingBoundaryLayerGrid`
+on the desired momentum grid.
+
+Since the grid is automatically assembled based on the location of the
+trapped-passing boundaries, there are limited options for the user to customize
+the grid spacing. The method 
+:py:meth:`DREAM.Settings.MomentumGrid.MomentumGrid.setTrappedPassingBoundaryLayerGrid`
+takes four arguments, and typically the user may at least want to specify the
+parameter ``dxiMax`` to indicate to DREAM the maximum allowed size of each grid
+cell. The user can also fine tune the spacing in the fully-trapped and
+fully-passing regions separately using the ``nxiPass`` and ``nxiTrap``
+parameters, which set (half) the number of grid points to place in each of the
+two regions. Finally, the parameter ``boundaryLayerWidth`` indicates how close
+points should be placed to the trapped-passing boundary points
+:math:`\xi_{0,{\rm T}}` in order to resolve them accurately, and should
+generally be a very small number. If the boundary layer width is too large,
+the solution can behave weirdly close to the trapped-passing boundary.
+
+.. note::
+
+   The original version of the method
+   :py:meth:`DREAM.Settings.MomentumGrid.MomentumGrid.setTrappedPassingBoundaryLayerGrid`
+   required the user to manually specify the location of the trapped-passing
+   boundary at every radius using the ``xi0Trapped`` parameter. In more recent
+   versions, however, the trapped-passing boundary can be automatically
+   calculated by DREAM during initialization. This is practically always the
+   desired behaviour, in which case ``xi0Trapped`` need not be specified.
+
+Example
+*******
+.. code-block:: python
+
+   ds = DREAMSettings()
+   ...
+   ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(dxiMax=1e-3, boundaryLayerWidth=1e-4)
 
 Object documentation
 --------------------
-.. py:class:: MomentumGrid
 
-Methods
-+++++++
-
-.. py:method:: __init__(name, enabled=True, ttype=MOMENTUMGRID_TYPE_PXI, np=100, nxi=1, pmax=None)
-
-   Construct a new MomentumGrid object.
-
-   :param str name: Name of the momentum grid (either ``hottailgrid`` or ``runawaygrid``).
-   :param bool enabled: Whether or not the grid is to be used during the simulation.
-   :param int type: Type of momentum grid (currently, only ``MOMENTUMGRID_TYPE_PXI``, for spherical coordinates, is supported).
-   :param int np: Number of distribution grid points in the spherical coordinate :math:`p`.
-   :param int nxi: Number of distribution grid points in the spherical coordinate :math:`\xi`.
-   :param float pmax: Value of upper flux grid boundary, expressed in the spherical coordinate :math:`p`.
-
-.. py:method:: set(enabled=True, ttype=MOMENTUMGRID_TYPE_PXI, np=100, nxi=1, pmax=None)
-
-   Set all settings for this momentum grid in one go after creating the object.
-
-   :param bool enabled: Whether or not the grid is to be used during the simulation.
-   :param int type: Type of momentum grid (currently, only ``MOMENTUMGRID_TYPE_PXI``, for spherical coordinates, is supported).
-   :param int np: Number of distribution grid points in the spherical coordinate :math:`p`.
-   :param int nxi: Number of distribution grid points in the spherical coordinate :math:`\xi`.
-   :param float pmax: Value of upper flux grid boundary, expressed in the spherical coordinate :math:`p`.
-
-.. py:method:: setEnabled(enabled=True)
-
-   Specifies whether or not this momentum grid should be enabled and used
-   during the DREAM simulation.
-
-   :param bool enabled: Whether or not the grid is to be used during the simulation.
-
-.. py:method:: setNp(np)
-
-   Sets the number of points to use for the distribution grid in the spherical
-   coordinate :math:`p`.
-
-   :param int np: Number of grid points to use in the spherical coordinate :math:`p`.
-
-.. py:method:: setNxi(nxi)
-
-   Sets the number of points to use for the distribution grid in the spherical
-   coordinate :math:`\xi`.
-
-   :param int nxi: Number of grid points to use in the spherical coordinate :math:`\xi`.
-
-.. py:method:: setPmax(pmax)
-
-   Set the value of the upper boundary in the spherical momentum coordinate
-   :math:`p`. The value is assigned to the last point on the momentum flux grid.
-
-   :param float pmax: Value of the last momentum flux grid point.
-
-Attributes
-++++++++++
-
-.. py:attribute:: name
-
-   Name of grid. This must either be ``hottailgrid`` or ``runawaygrid``.
-
-.. py:attribute:: pgrid
-
-   Grid object for coordinate :math:`p`. This object specifies how to generate
-   the corresponding coordinate grid.
-
-.. py:attribute:: type
-
-   Momentum grid type. Either ``TYPE_PXI`` (for :math:`p/\xi` coordinates) or
-   ``TYPE_PPARPPERP`` (for :math:`p_\parallel/p_\perp` coordinates). At the
-   moment, only the former is supported.
-
-.. py:attribute:: xigrid
-
-   Grid object for coordinate :math:`\xi`. This object specifies how to generate
-   the corresponding coordinate grid.
+.. autoclass:: DREAM.Settings.MomentumGrid.MomentumGrid
+   :members:
+   :undoc-members:
+   :special-members: __init__, __contains__, __getitem__
 
 Examples
 --------

--- a/doc/sphinx/source/frontend/api/Settings/radialgrid.rst
+++ b/doc/sphinx/source/frontend/api/Settings/radialgrid.rst
@@ -125,6 +125,15 @@ parameter to the parameters of the radial grid described above in
 Analytic toroidal grid
 ----------------------
 
+.. note::
+
+   When using toroidal geometry, it is important to adjust the :math:`\xi`
+   grids for :math:`f_{\rm hot}` and/or :math:`f_{\rm re}` (if used) so that
+   the trapped/passing boundaries are sufficiently resovled.
+
+   Details about how to do this can be found at
+   :ref:`ds-momentumgrid-trapped`.
+
 DREAM implements an analytic five-parameter toroidal magnetic field. The model
 includes the three shaping parameters illustrated in the figure below, namely
 elongation :math:`\kappa(r)`, triangularity :math:`\delta(r)` and Shafranov
@@ -224,6 +233,10 @@ specified in DREAM:
    ds.radialgrid.setMinorRadius(a)
    ds.radialgrid.setNr(100)
 
+   # If kinetic grids are enabled, you should also do...
+   ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(dxiMax=1e-3)
+   ds.runawaygrid.setTrappedPassingBoundaryLayerGrid(dxiMax=1e-3)
+
 .. note::
 
    While this example gives all shape parameters explicitly, and most of them
@@ -236,6 +249,15 @@ specified in DREAM:
 
 Numeric toroidal grid
 ---------------------
+.. note::
+
+   When using toroidal geometry, it is important to adjust the :math:`\xi`
+   grids for :math:`f_{\rm hot}` and/or :math:`f_{\rm re}` (if used) so that
+   the trapped/passing boundaries are sufficiently resovled.
+
+   Details about how to do this can be found at
+   :ref:`ds-momentumgrid-trapped`.
+
 DREAM allows numerical magnetic fields obtained from, for example,
 Grad-Shafranov solvers such as EFIT or LIUQE, to be used to specify the
 geometry in simulations. Numerically specified magnetic fields are not subject

--- a/fvm/CMakeLists.txt
+++ b/fvm/CMakeLists.txt
@@ -83,6 +83,7 @@ set(fvm_grid
     "${PROJECT_SOURCE_DIR}/fvm/Grid/PXiGrid/XiCustomGridGenerator.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Grid/PXiGrid/XiUniformGridGenerator.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Grid/PXiGrid/XiUniformThetaGridGenerator.cpp"
+    "${PROJECT_SOURCE_DIR}/fvm/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Grid/RadialGrid.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Grid/RadialGridGenerator.cpp"
     "${PROJECT_SOURCE_DIR}/fvm/Grid/FluxSurfaceAverager.cpp"

--- a/fvm/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.cpp
+++ b/fvm/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.cpp
@@ -1,0 +1,131 @@
+/**
+ * This grid automatically sets up a xi grid based on the location
+ * of the trapped-passing boundaries at each radius.
+ */
+
+#include <algorithm>
+#include <vector>
+#include "FVM/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.hpp"
+
+
+using namespace DREAM::FVM::PXiGrid;
+using namespace std;
+
+/**
+ * Constructor.
+ *
+ * dxiMax:             Maximum allowed grid spacing dxi: if this spacing is
+ *                     exceeded after placing points on the trapped-passing
+ *                     boundary, will fill in the gap by adding one or more grid
+ *                     points (uniformly) in the gaps.
+ * nxiPass:            Number of grid cells in pitch to be contained between the
+ *                     largest xi0Trapped and xi0=+/-1.
+ * nxiTrap:            Number of grid cells in pitch to be contained between the
+ *                     (in absolute value) minimum xi0Trapped and xi0.
+ * boundaryLayerWidth: Width in pitch of the grid cell containing each
+ *                     trapped-passing boundary, typically << 1.
+ */
+XiTrappedPassingBoundaryLayerGridGenerator::XiTrappedPassingBoundaryLayerGridGenerator(
+    const real_t dxiMax, const len_t nxiPass, const len_t nxiTrap,
+    const real_t boundaryLayerWidth
+) : dxiMax(dxiMax), nxiPass(nxiPass), nxiTrap(nxiTrap),
+    boundaryLayerWidth(boundaryLayerWidth) {
+}
+
+/**
+ * Re-build the given momentum grid using this grid generator.
+ *
+ * mg: Momentum grid to re-build.
+ * rg: Radial grid on which this momentum grid lives.
+ */
+bool XiTrappedPassingBoundaryLayerGridGenerator::Rebuild(
+    const real_t, const len_t, MomentumGrid *mg, const RadialGrid *rg
+) {
+    const len_t nr = rg->GetNr();
+    const real_t *xi0Trapped = rg->GetXi0TrappedBoundary();
+    vector<real_t> xi_f;
+
+    // Locate max and min boundaries...
+    real_t xi0Trapped_max=0, xi0Trapped_min=1;
+    for (len_t ir = 0; ir < nr; ir++) {
+        if (xi0Trapped[ir] > xi0Trapped_max)
+            xi0Trapped_max = xi0Trapped[ir];
+        if (xi0Trapped[ir] < xi0Trapped_min)
+            xi0Trapped_min = xi0Trapped[ir];
+    }
+
+    // Insert passing region points [1, +xi0Trapped) and (-xi0Trapped, -1]...
+    for (len_t i = 0; i < nxiPass; i++) {
+        real_t x = 1 - i*(1-xi0Trapped_max) / nxiPass;
+        xi_f.push_back(+x);
+        xi_f.push_back(-x);
+    }
+
+    // Insert lowest part of trapped region (if any)
+    if (nxiTrap > 1 && xi0Trapped_min > 0) {
+        for (len_t i = 1; i < nxiTrap; i++) {
+            real_t x = i * xi0Trapped_min / nxiTrap;
+            xi_f.push_back(x);
+            xi_f.push_back(-x);
+        }
+    }
+
+    // Add xi=0
+    xi_f.push_back(0.0);
+
+    // Add cells around each trapped-passing boundary...
+    for (len_t ir = 0; ir < nr; ir++) {
+        if (xi0Trapped[ir] > 0) {
+            real_t xiAdd1 = xi0Trapped[ir] + 0.5*this->boundaryLayerWidth;
+            real_t xiAdd2 = xi0Trapped[ir] - 0.5*this->boundaryLayerWidth;
+
+            xi_f.push_back(-xiAdd1);
+            xi_f.push_back(xiAdd1);
+            xi_f.push_back(-xiAdd2);
+            xi_f.push_back(xiAdd2);
+        }
+    }
+
+    std::sort(xi_f.begin(), xi_f.end());
+
+    // Add additional points if the resulting spacing
+    // exceeds the desired dxiMax...
+    for (vector<real_t>::iterator it = xi_f.begin()+1; it != xi_f.end(); it++) {
+        real_t dxi = *it - *(it-1);
+        int_t N = (int_t)std::ceil(dxi / this->dxiMax);
+
+        if (N >= 1) {
+            real_t x1 = *(it-1), x2 = *it;
+            it -= 1;
+            for (int_t i = 1; i < N+1; i++)
+                it = xi_f.insert(it+1, x1 + i*(x2-x1)/(N+1));
+        }
+    }
+
+    // Set arrays...
+    this->nxi = xi_f.size()-1;
+    real_t
+        *_xi   = new real_t[this->nxi],
+        *_xi_f = new real_t[this->nxi+1],
+        *dxi   = new real_t[this->nxi],
+        *dxi_f = nullptr;
+
+    for (len_t i = 0; i < this->nxi+1; i++)
+        _xi_f[i] = xi_f[i];
+    for (len_t i = 0; i < this->nxi; i++)
+        dxi[i] = _xi_f[i+1] - _xi_f[i];
+    for (len_t i = 0; i < this->nxi; i++)
+        _xi[i] = 0.5*(_xi_f[i+1]+_xi_f[i]);
+
+    if (this->nxi > 1) {
+        dxi_f = new real_t[this->nxi-1];
+        for (len_t i = 0; i < this->nxi-1; i++)
+            dxi_f[i] = _xi[i+1] - _xi[i];
+    }
+
+    mg->InitializeP2("xi", this->nxi, _xi, _xi_f, dxi, dxi_f);
+
+    initialized = true;
+    return true;
+}
+

--- a/fvm/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.cpp
+++ b/fvm/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.cpp
@@ -94,11 +94,13 @@ bool XiTrappedPassingBoundaryLayerGridGenerator::Rebuild(
         real_t dxi = *it - *(it-1);
         int_t N = (int_t)std::ceil(dxi / this->dxiMax);
 
-        if (N >= 1) {
+        if (N > 1) {
             real_t x1 = *(it-1), x2 = *it;
             it -= 1;
             for (int_t i = 1; i < N+1; i++)
                 it = xi_f.insert(it+1, x1 + i*(x2-x1)/(N+1));
+
+            it++;
         }
     }
 

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -76,7 +76,8 @@ enum pxigrid_xitype {
     PXIGRID_XITYPE_BIUNIFORM=2,
     PXIGRID_XITYPE_UNIFORM_THETA=3,
     PXIGRID_XITYPE_BIUNIFORM_THETA=4,
-    PXIGRID_XITYPE_CUSTOM=5
+    PXIGRID_XITYPE_CUSTOM=5,
+    PXIGRID_XITYPE_TRAPPED=6
 };
 
 // Type of advection interpolation coefficient for jacobian

--- a/include/FVM/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.hpp
+++ b/include/FVM/Grid/PXiGrid/XiTrappedPassingBoundaryLayerGridGenerator.hpp
@@ -1,0 +1,32 @@
+#ifndef _DREAM_FVM_P_XI_GRID_XI_TRAPPED_PASSING_BOUNDARY_LAYER_GRID_GENERATOR_HPP
+#define _DREAM_FVM_P_XI_GRID_XI_TRAPPED_PASSING_BOUNDARY_LAYER_GRID_GENERATOR_HPP
+
+#include "FVM/FVMException.hpp"
+#include "FVM/Grid/MomentumGrid.hpp"
+#include "FVM/Grid/RadialGrid.hpp"
+#include "FVM/Grid/PXiGrid/XiGridGenerator.hpp"
+
+namespace DREAM::FVM::PXiGrid {
+    class XiTrappedPassingBoundaryLayerGridGenerator : public XiGridGenerator {
+    private:
+        real_t dxiMax;
+        len_t nxiPass, nxiTrap;
+        real_t boundaryLayerWidth;
+        
+        len_t nxi = 0;
+
+        bool initialized = false;
+    public:
+        XiTrappedPassingBoundaryLayerGridGenerator(
+            const real_t dxiMax=2, const len_t nxiPass=1, const len_t nxiTrap=1,
+            const real_t boundaryLayerWidth=1e-3
+        );
+
+        virtual len_t GetNxi() const override { return this->nxi; }
+
+        virtual bool NeedsRebuild(const real_t, const bool) override { return (!initialized); }
+        virtual bool Rebuild(const real_t, const len_t, MomentumGrid*, const RadialGrid*) override;
+    };
+}
+
+#endif/*_DREAM_FVM_P_XI_GRID_XI_TRAPPED_PASSING_BOUNDARY_LAYER_GRID_GENERATOR_HPP*/

--- a/media/logo1.svg
+++ b/media/logo1.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="57.231476mm"
    height="29.135147mm"
    viewBox="0 0 57.231476 29.135147"
    version="1.1"
    id="svg8"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)"
-   sodipodi:docname="logo1.svg">
+   inkscape:version="1.1 (c4e8f9ed74, 2021-05-24)"
+   sodipodi:docname="logo1.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2">
     <rect
@@ -29,23 +29,24 @@
      fit-margin-left="0"
      fit-margin-top="0"
      inkscape:window-maximized="1"
-     inkscape:window-y="32"
+     inkscape:window-y="0"
      inkscape:window-x="0"
-     inkscape:window-height="1018"
-     inkscape:window-width="1920"
+     inkscape:window-height="1372"
+     inkscape:window-width="2560"
      showgrid="false"
      inkscape:document-rotation="0"
      inkscape:current-layer="layer1"
      inkscape:document-units="mm"
-     inkscape:cy="80.019832"
-     inkscape:cx="112.09831"
+     inkscape:cy="80"
+     inkscape:cx="112.05357"
      inkscape:zoom="5.6"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base" />
+     id="base"
+     inkscape:pagecheckerboard="0" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -104,13 +105,6 @@
          rx="9"
          ry="11" />
     </g>
-    <text
-       style="font-style:normal;font-weight:normal;font-size:11.2889px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect835);fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
-       id="text833"
-       xml:space="preserve"><tspan
-         x="88.623047"
-         y="84.578422"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:11.2889px;font-family:Arial;-inkscape-font-specification:'Arial, Heavy';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:-1.05833px">DREAM</tspan></tspan></text>
     <path
        inkscape:transform-center-y="0.15819292"
        inkscape:transform-center-x="0.16887975"

--- a/py/DREAM/Settings/MomentumGrid.py
+++ b/py/DREAM/Settings/MomentumGrid.py
@@ -135,7 +135,9 @@ class MomentumGrid:
         singular points are well resolved.
 
         :param float xi0Trapped:            List of trapped-passing boundary pitches 
-                                            (contained in do.grid.xi0TrappedBoundary of an output object)
+                                            (contained in do.grid.xi0TrappedBoundary of an output object).
+                                            NEW: To automatically determine the trapped-passing boundary,
+                                            leave out this parameter (or set it explicitly to ``None``).
         :param float dxiMax:                Maximum allowed grid spacing dxi: if this spacing is exceeded after
                                             placing points on the trapped-passing boundary, will fill in the gaps
                                             by adding one or more grid points (uniformly) in the gaps

--- a/py/DREAM/Settings/MomentumGrid.py
+++ b/py/DREAM/Settings/MomentumGrid.py
@@ -128,7 +128,7 @@ class MomentumGrid:
         if xi_f is not None:
             self.xigrid.setCustomGridPoints(xi_f=xi_f)
 
-    def setTrappedPassingBoundaryLayerGrid(self, xi0Trapped, dxiMax=2, NxiPass=1, NxiTrap=1, boundaryLayerWidth=1e-3):
+    def setTrappedPassingBoundaryLayerGrid(self, xi0Trapped=None, dxiMax=2, NxiPass=1, NxiTrap=1, boundaryLayerWidth=1e-3):
         """
         Designs a custom pitch grid which places tight grid cells 
         straddling each trapped-passing boundary, so that these
@@ -146,32 +146,36 @@ class MomentumGrid:
         :param float boundaryLayerWidth:    Width in pitch of the grid cell containing each
                                             trapped-passing boundary, typically << 1
         """
-        if type(xi0Trapped)==list:
-            xi0Trapped = np.array(xi0Trapped)
-        xi0Trapped = np.sort(xi0Trapped)
+        if xi0Trapped is None:
+            self.xigrid.setTrappedPassingBoundaryLayerGrid(dxiMax=dxiMax, NxiPass=NxiPass, NxiTrap=NxiTrap, boundaryLayerWidth=boundaryLayerWidth)
+        else:
+            # Old method, which requires prior knowledge of 'xi0Trapped'
+            if type(xi0Trapped)==list:
+                xi0Trapped = np.array(xi0Trapped)
+            xi0Trapped = np.sort(xi0Trapped)
 
-        x0 = np.linspace( xi0Trapped.max(), 1, NxiPass+1 )[1:]
-        xi_f = np.array([-x0,x0])
-        if NxiTrap > 1 and xi0Trapped.min() > 0:
-            xTrap = np.linspace( 0, xi0Trapped.min(), NxiTrap+1 )[1:-1]
-            xi_f = np.append( xi_f, [-xTrap, xTrap] )
-        xi_f = np.append(xi_f, 0)
+            x0 = np.linspace( xi0Trapped.max(), 1, NxiPass+1 )[1:]
+            xi_f = np.array([-x0,x0])
+            if NxiTrap > 1 and xi0Trapped.min() > 0:
+                xTrap = np.linspace( 0, xi0Trapped.min(), NxiTrap+1 )[1:-1]
+                xi_f = np.append( xi_f, [-xTrap, xTrap] )
+            xi_f = np.append(xi_f, 0)
 
-        for i in range(xi0Trapped.size):
-            if xi0Trapped[i]>0:
-                xiAdd1 = xi0Trapped[i] + 0.5*boundaryLayerWidth
-                xiAdd2 = xi0Trapped[i] - 0.5*boundaryLayerWidth
-                xi_f = np.append(xi_f, [-xiAdd1, xiAdd1, -xiAdd2, xiAdd2])
+            for i in range(xi0Trapped.size):
+                if xi0Trapped[i]>0:
+                    xiAdd1 = xi0Trapped[i] + 0.5*boundaryLayerWidth
+                    xiAdd2 = xi0Trapped[i] - 0.5*boundaryLayerWidth
+                    xi_f = np.append(xi_f, [-xiAdd1, xiAdd1, -xiAdd2, xiAdd2])
 
-        # Add additional point if the resulting spacing exceeds the desired dxiMax
-        xi_f = np.sort(xi_f)
-        for i in range(xi_f.size-1):
-            dxi = xi_f[i+1] - xi_f[i]
-            N = int(np.floor( dxi/dxiMax ))
-            if N>=1:
-                xi_f = np.append(xi_f, np.linspace(xi_f[i], xi_f[i+1],N+2)[1:-1])
+            # Add additional point if the resulting spacing exceeds the desired dxiMax
+            xi_f = np.sort(xi_f)
+            for i in range(xi_f.size-1):
+                dxi = xi_f[i+1] - xi_f[i]
+                N = int(np.floor( dxi/dxiMax ))
+                if N>=1:
+                    xi_f = np.append(xi_f, np.linspace(xi_f[i], xi_f[i+1],N+2)[1:-1])
 
-        self.setCustomGrid(xi_f=np.sort(xi_f))
+            self.setCustomGrid(xi_f=np.sort(xi_f))
 
     def setXiType(self,ttype):
         """

--- a/tests/physics/trapping_conductivity/trapping_conductivity.py
+++ b/tests/physics/trapping_conductivity/trapping_conductivity.py
@@ -64,7 +64,8 @@ def gensettings(T, Z=300, EED=1e-6, n=5e19, yMax=5):
     ds.eqsys.j_ohm.setConductivityMode(JOhm.CONDUCTIVITY_MODE_SAUTER_COLLISIONLESS)
 
     # set non-uniform xi grid with cells stradding the trapped-passing boundaries
-    ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(xi0Trapped, dxiMax=0.1, boundaryLayerWidth=1e-4)
+    #ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(xi0Trapped, dxiMax=0.1, boundaryLayerWidth=1e-4)
+    ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(dxiMax=0.1, boundaryLayerWidth=1e-4)
     ds.hottailgrid.setNp(40)
     ds.hottailgrid.setPmax(pMax)
 
@@ -114,11 +115,11 @@ def runT(T):
 
     ds = gensettings(T=T, Z=300)
     #ds.save('settings_trapping_conductivity.h5')
-    do = DREAM.runiface(ds, quiet=True)
+    do = DREAM.runiface(ds, 'output_new_T{:d}.h5'.format(int(T)), quiet=False)
     jKinetic = do.eqsys.j_ohm[-1,:]
 
     ds.hottailgrid.setEnabled(False)
-    do = DREAM.runiface(ds,quiet=True)
+    do = DREAM.runiface(ds, quiet=True)
     jFluid = do.eqsys.j_ohm[-1,:]
 
     eps = do.grid.r[:] / R0

--- a/tests/physics/trapping_conductivity/trapping_conductivity.py
+++ b/tests/physics/trapping_conductivity/trapping_conductivity.py
@@ -64,8 +64,8 @@ def gensettings(T, Z=300, EED=1e-6, n=5e19, yMax=5):
     ds.eqsys.j_ohm.setConductivityMode(JOhm.CONDUCTIVITY_MODE_SAUTER_COLLISIONLESS)
 
     # set non-uniform xi grid with cells stradding the trapped-passing boundaries
-    #ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(xi0Trapped, dxiMax=0.1, boundaryLayerWidth=1e-4)
-    ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(dxiMax=0.1, boundaryLayerWidth=1e-4)
+    #ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(xi0Trapped, dxiMax=0.1, boundaryLayerWidth=1e-4)     # old method
+    ds.hottailgrid.setTrappedPassingBoundaryLayerGrid(dxiMax=0.1, boundaryLayerWidth=1e-4)      # new method
     ds.hottailgrid.setNp(40)
     ds.hottailgrid.setPmax(pMax)
 
@@ -115,7 +115,7 @@ def runT(T):
 
     ds = gensettings(T=T, Z=300)
     #ds.save('settings_trapping_conductivity.h5')
-    do = DREAM.runiface(ds, 'output_new_T{:d}.h5'.format(int(T)), quiet=False)
+    do = DREAM.runiface(ds, quiet=True)
     jKinetic = do.eqsys.j_ohm[-1,:]
 
     ds.hottailgrid.setEnabled(False)


### PR DESCRIPTION
This branch implements a new xi grid generator in the kernel which automatically constructs a xi grid that accurately resolves the trapped-passing boundary. The new grid supercedes the old ``setTrappedPassingBoundaryLayerGrid()`` in the Python interface, which required the trapped-passing boundary to be specified by the user. Now, the boundary calculated internally by DREAM is now used during initialization instead to avoid having to do a dummy DREAM simulation.