### PR TITLE
Implement fix for #147

### DIFF
--- a/include/DREAM/Solver/SolverNonLinear.hpp
+++ b/include/DREAM/Solver/SolverNonLinear.hpp
@@ -94,7 +94,8 @@ namespace DREAM {
         virtual void PrintTimings() override;
         virtual void SaveTimings(SFile*, const std::string& path="") override;
 
-        void SaveDebugInfo(len_t, len_t);
+        void SaveDebugInfoBefore(len_t, len_t);
+        void SaveDebugInfoAfter(len_t, len_t);
         void SetDebugMode(bool, bool, bool, bool, bool, int_t, int_t, bool);
 
         virtual void SwitchToBackupInverter() override;


### PR DESCRIPTION
Make sure that the new solution vector "dx" obtained as debug output with the non-linear solver corresponds to the actual solution of the specified timestep/iteration, and not of the previous timestep/iteration. The old "SaveDebugInfo()" method has been divided into two separate methods which should be called before and after "Invert()" is called, respectively. This allows the residual and Jacobian to be evaluated and saved *before* inversion (in case the code crashes during inversion), while the new solution is evaluated after inversion.

Fix implemented in response to issue #147.