### PR TITLE
Store (input) settings in output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.h5
+.cache
 .gdb_history
 .vscode
 __pycache__

--- a/include/DREAM/EquationSystem.hpp
+++ b/include/DREAM/EquationSystem.hpp
@@ -13,6 +13,7 @@ namespace DREAM { class EquationSystem; }
 #include "DREAM/OtherQuantityHandler.hpp"
 #include "DREAM/PostProcessor.hpp"
 #include "DREAM/Settings/OptionConstants.hpp"
+#include "DREAM/Settings/Settings.hpp"
 #include "DREAM/Solver/Solver.hpp"
 #include "DREAM/TimeStepper/TimeStepper.hpp"
 #include "DREAM/UnknownQuantityEquation.hpp"
@@ -55,6 +56,7 @@ namespace DREAM {
         PostProcessor *postProcessor = nullptr;
         RunawayFluid *REFluid = nullptr;
         SPIHandler *SPI = nullptr;
+        Settings *settings = nullptr;
 
         AnalyticDistributionRE *distRE = nullptr;
         AnalyticDistributionHottail *distHT = nullptr;
@@ -77,7 +79,7 @@ namespace DREAM {
     public:
         EqsysInitializer *initializer=nullptr;
 
-        EquationSystem(FVM::Grid*, FVM::Grid*, enum OptionConstants::momentumgrid_type, FVM::Grid*, enum OptionConstants::momentumgrid_type, FVM::Grid*);
+        EquationSystem(FVM::Grid*, FVM::Grid*, enum OptionConstants::momentumgrid_type, FVM::Grid*, enum OptionConstants::momentumgrid_type, FVM::Grid*, Settings*);
         ~EquationSystem();
         FVM::Grid *GetScalarGrid() { return this->scalarGrid; }
         FVM::Grid *GetFluidGrid() { return this->fluidGrid; }
@@ -99,6 +101,7 @@ namespace DREAM {
         PostProcessor *GetPostProcessor() { return this->postProcessor; }
         RunawayFluid *GetREFluid() { return this->REFluid; }
         SPIHandler *GetSPIHandler() { return this->SPI; }
+        Settings *GetSettings() { return this->settings; }
 
         AnalyticDistributionRE *GetAnalyticREDistribution() { return this->distRE;}
         AnalyticDistributionHottail *GetAnalyticHottailDistribution() { return this->distHT;}

--- a/include/DREAM/OutputGenerator.hpp
+++ b/include/DREAM/OutputGenerator.hpp
@@ -16,6 +16,8 @@ namespace DREAM {
 		OtherQuantityHandler *oqty;
 		EquationSystem *eqsys;
 
+        bool savesettings = true;
+
 		virtual void SaveGrids(const std::string&, bool) = 0;
 		virtual void SaveIonMetaData(const std::string&) = 0;
 		virtual void SaveOtherQuantities(const std::string&) = 0;
@@ -24,7 +26,7 @@ namespace DREAM {
 		virtual void SaveTimings(const std::string&) = 0;
 		virtual void SaveUnknowns(const std::string&, bool) = 0;
 	public:
-		OutputGenerator(EquationSystem*);
+		OutputGenerator(EquationSystem*, bool savesettings=true);
         virtual ~OutputGenerator();
 
 		virtual void Save(bool current=false);

--- a/include/DREAM/OutputGeneratorSFile.hpp
+++ b/include/DREAM/OutputGeneratorSFile.hpp
@@ -23,8 +23,8 @@ namespace DREAM {
         void WriteCopyArray(SFile*, const std::string&, const real_t *const*, const len_t, const len_t);
         void WriteCopyMultiArray(SFile*, const std::string&, const real_t *const*, const sfilesize_t, const sfilesize_t[]);
 	public:
-		OutputGeneratorSFile(EquationSystem*, const std::string&);
-		OutputGeneratorSFile(EquationSystem*, SFile*);
+		OutputGeneratorSFile(EquationSystem*, const std::string&, bool savesettings=true);
+		OutputGeneratorSFile(EquationSystem*, SFile*, bool savesettings=true);
         virtual ~OutputGeneratorSFile();
 
         virtual void Save(bool current=false) override;

--- a/include/DREAM/Settings/SFile.hpp
+++ b/include/DREAM/Settings/SFile.hpp
@@ -20,6 +20,15 @@ namespace DREAM {
         static void LoadString(const std::string&, SFile*, Settings*);
         static void LoadIntegerArray(const std::string&, const len_t, SFile*, Settings*);
         static void LoadRealArray(const std::string&, const len_t, SFile*, Settings*);
+
+        static void CreateGroup(const std::string&, const std::string&, std::vector<std::string>&, SFile*);
+        static void SaveSettings(Settings*, SFile*, const std::string&);
+        static void SaveBool(const std::string&, bool, SFile*);
+        static void SaveInteger(const std::string&, int_t, SFile*);
+        static void SaveReal(const std::string&, real_t, SFile*);
+        static void SaveIntegerArray(const std::string&, const int_t*, const len_t, const len_t*, SFile*);
+        static void SaveRealArray(const std::string&, const real_t*, const len_t, const len_t*, SFile*);
+        static void SaveString(const std::string&, const std::string&, SFile*);
     };
 }
 

--- a/py/DREAM/DREAMOutput.py
+++ b/py/DREAM/DREAMOutput.py
@@ -125,7 +125,7 @@ class DREAMOutput:
 
         # Load settings for the run
         if 'settings' in od:
-            self.settings = DREAMSettings(settings=od['settings'])
+            self.settings = DREAMSettings(od['settings'])
 
         # Solver statistics
         if 'solver' in od:

--- a/py/DREAM/Settings/Output.py
+++ b/py/DREAM/Settings/Output.py
@@ -15,6 +15,7 @@ class Output:
         Constructor.
         """
         self.filename = filename
+        self.savesettings = True
         self.timingstdout = False
         self.timingfile = True
 
@@ -29,6 +30,16 @@ class Output:
         :param str filename: Name of output file to store simulation data to.
         """
         self.filename = filename
+
+
+    def setSaveSettings(self, save=True):
+        """
+        Specify whether or not to save a copy of the input settings to the
+        output file (enabled by default).
+
+        :param bool save: If ``True``, copy settings to the output file.
+        """
+        self.savesettings = save
 
 
     def setTiming(self, stdout=None, file=None):
@@ -55,6 +66,9 @@ class Output:
         self.timingstdout = bool(data['timingstdout'])
         self.timingfile = bool(data['timingfile'])
 
+        if 'savesettings' in data:
+            self.savesettings = data['savesettings']
+
         self.verifySettings()
 
 
@@ -70,6 +84,7 @@ class Output:
 
         data = {
             'filename': self.filename,
+            'savesettings': self.savesettings,
             'timingfile': self.timingfile,
             'timingstdout': self.timingstdout
         }
@@ -83,6 +98,8 @@ class Output:
         """
         if type(self.filename) != str:
             raise DREAMException("The output file name must be string.")
+        elif type(self.savesettings) != bool:
+            raise DREAMException("The option 'savesettings' must be a bool.")
         elif type(self.timingfile) != bool:
             raise DREAMException("The option 'timingfile' must be a bool.")
         elif type(self.timingstdout) != bool:

--- a/py/DREAM/Settings/ToleranceSettings.py
+++ b/py/DREAM/Settings/ToleranceSettings.py
@@ -36,6 +36,17 @@ class ToleranceSettings:
             raise DREAMException("Unrecognized type of parameter 'unknown': {}.".format(type(unknown)))
 
 
+    def getRelTol(self, unknown):
+        """
+        Returns the relative tolerance of the named unknown.
+        """
+        i = self.getIndex(unknown)
+        if i < 0:
+            return self.reltol
+        else:
+            return self.overrides[i]['reltol']
+
+
     def fromdict(self, data):
         """
         Load tolerance settings from a dictionary.

--- a/py/DREAM/interactive.py
+++ b/py/DREAM/interactive.py
@@ -37,6 +37,7 @@ def setup_interactive(do, glob):
     glob['grid']  = do.grid
     glob['other'] = do.other
     glob['solver'] = do.solver
+    glob['do'] = do
 
     print('Loaded {} unknowns ({})'.format(len(do.eqsys.keys()), do.getFileSize_s()))
     print(do.grid)

--- a/py/cli/debug.py
+++ b/py/cli/debug.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3 -i
+
+import argparse
+from DREAM import DREAMOutput, setup_interactive, who
+import numpy as np
+import os
+import sys
+
+
+def collect_single(name, output):
+    """
+    Collect data for the unknown quantity named 'name' from the list
+    of DREAMOutput objects 'output'.
+    """
+    data = []
+    for do in output:
+        v = do.eqsys[name].data[0,:]
+
+        data.append(v)
+
+    return np.array(data)
+
+
+def load_quantities(directory, timestep):
+    """
+    Load debug output from the named directory and assemble into a single
+    DREAMOutput object.
+    
+    :param pattern: String with the format
+    """
+    pattern = f'{directory}/debugout_{{}}_{{}}.h5'
+
+    do = DREAMOutput(pattern.format(timestep, 1))
+
+    # Load all output objects
+    dos = [do]
+    iteration = 1
+    while os.path.exists(pattern.format(timestep, iteration)):
+        dos.append(DREAMOutput(pattern.format(timestep, iteration)))
+        iteration += 1
+
+    # Extend main output object
+    do.grid.t = np.array(range(len(dos))) + 1
+    for variable, uqn in do.eqsys.unknowns.items():
+        data = collect_single(variable, dos)
+
+        attr = {'description': uqn.description, 'equation': uqn.description_eqn}
+        do.eqsys.setUnknown(name=variable, data=data, attr=attr)
+
+    # Close inputs (except 'do', which is index 0)
+    for i in range(1, len(dos)):
+        dos[i].close()
+
+    return do
+
+
+def create_argparser():
+    parser = argparse.ArgumentParser(description="DREAM Debug Output CLI")
+
+    parser.add_argument('-t', '--timestep', help="Timestep index to load", type=int, default=0)
+    parser.add_argument('directory', help="Name of directory containing debug output files to load", type=str, default=".")
+
+    return parser.parse_args()
+
+
+def determine_timestep(directory):
+    """
+    Determine which time step to load from the named directory.
+    """
+    pattern = f'{directory}/debugout_{{}}_{{}}.h5'
+    files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
+
+    for f in os.listdir(directory):
+        if f.startswith('debugout_') and f.endswith('.h5'):
+            return int(f.split('_')[1])
+
+    raise Exception("Failed to automatically determine which time step to load.")
+    
+
+def main():
+    args = create_argparser()
+
+    if args.timestep <= 0:
+        timestep = determine_timestep(args.directory)
+        print(f'Loading time step {timestep}')
+    else:
+        timestep = args.timestep
+
+    do = load_quantities(args.directory, timestep)
+    setup_interactive(do, glob=globals())
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/src/EquationSystem/EquationSystem.cpp
+++ b/src/EquationSystem/EquationSystem.cpp
@@ -22,10 +22,12 @@ using namespace std;
 EquationSystem::EquationSystem(
     FVM::Grid *emptygrid, FVM::Grid *rgrid,
     enum OptionConstants::momentumgrid_type ht_type, FVM::Grid *hottailGrid,
-    enum OptionConstants::momentumgrid_type re_type, FVM::Grid *runawayGrid
+    enum OptionConstants::momentumgrid_type re_type, FVM::Grid *runawayGrid,
+    Settings *s
 ) : scalarGrid(emptygrid), fluidGrid(rgrid),
     hottailGrid(hottailGrid), runawayGrid(runawayGrid),
-    hottailGrid_type(ht_type), runawayGrid_type(re_type) {
+    hottailGrid_type(ht_type), runawayGrid_type(re_type),
+    settings(s) {
     
     this->initializer = new EqsysInitializer(
         &this->unknowns, &this->unknown_equations,

--- a/src/OutputGenerator.cpp
+++ b/src/OutputGenerator.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "DREAM/OutputGenerator.hpp"
+#include "DREAM/Settings/Settings.hpp"
 
 
 using namespace DREAM;
@@ -37,6 +38,9 @@ void OutputGenerator::Save(bool current) {
 
     // Save ion metadata
     this->SaveIonMetaData("ionmeta");
+
+    // Save settings
+    this->SaveSettings("settings");
 
     // Save solver statistics
     this->SaveSolverData("solver");

--- a/src/OutputGenerator.cpp
+++ b/src/OutputGenerator.cpp
@@ -13,11 +13,12 @@ using namespace DREAM;
  * Constructor.
  */
 OutputGenerator::OutputGenerator(
-	EquationSystem *eqsys
+	EquationSystem *eqsys, bool savesettings
 ) : scalarGrid(eqsys->GetScalarGrid()), fluidGrid(eqsys->GetFluidGrid()),
     hottailGrid(eqsys->GetHotTailGrid()), runawayGrid(eqsys->GetRunawayGrid()),
     unknowns(eqsys->GetUnknownHandler()), ions(eqsys->GetIonHandler()),
-    oqty(eqsys->GetOtherQuantityHandler()), eqsys(eqsys) { }
+    oqty(eqsys->GetOtherQuantityHandler()), eqsys(eqsys),
+    savesettings(savesettings) { }
 
 OutputGenerator::~OutputGenerator() {}
 
@@ -40,7 +41,8 @@ void OutputGenerator::Save(bool current) {
     this->SaveIonMetaData("ionmeta");
 
     // Save settings
-    this->SaveSettings("settings");
+    if (this->savesettings)
+        this->SaveSettings("settings");
 
     // Save solver statistics
     this->SaveSolverData("solver");

--- a/src/OutputGeneratorSFile.cpp
+++ b/src/OutputGeneratorSFile.cpp
@@ -5,6 +5,8 @@
 
 #include <string>
 #include "DREAM/OutputGeneratorSFile.hpp"
+#include "DREAM/Settings/Settings.hpp"
+#include "DREAM/Settings/SFile.hpp"
 
 
 using namespace DREAM;
@@ -212,9 +214,10 @@ void OutputGeneratorSFile::SaveOtherQuantities(const std::string& name) {
 
 /**
  * Save settings used for this simulation
- * TODO TODO TODO
  */
-void OutputGeneratorSFile::SaveSettings(const std::string&) {
+void OutputGeneratorSFile::SaveSettings(const std::string& name) {
+    this->sf->CreateStruct(name);
+    SettingsSFile::SaveSettings(this->eqsys->GetSettings(), this->sf, name);
 }
 
 /**

--- a/src/OutputGeneratorSFile.cpp
+++ b/src/OutputGeneratorSFile.cpp
@@ -16,12 +16,14 @@ using namespace std;
  * Constructor.
  */
 OutputGeneratorSFile::OutputGeneratorSFile(
-	EquationSystem *eqsys, const std::string& filename
-) : OutputGenerator(eqsys), filename(filename) {}
+	EquationSystem *eqsys, const std::string& filename,
+    bool savesettings
+) : OutputGenerator(eqsys, savesettings), filename(filename) {}
 
 OutputGeneratorSFile::OutputGeneratorSFile(
-	EquationSystem *eqsys, SFile *sf
-) : OutputGenerator(eqsys), sf(sf) {}
+	EquationSystem *eqsys, SFile *sf,
+    bool savesettings
+) : OutputGenerator(eqsys, savesettings), sf(sf) {}
 
 /**
  * Destructor.

--- a/src/Settings/EquationSystem.cpp
+++ b/src/Settings/EquationSystem.cpp
@@ -62,7 +62,7 @@ EquationSystem *SimulationGenerator::ConstructEquationSystem(
     enum OptionConstants::momentumgrid_type re_type, FVM::Grid *runawayGrid,
     ADAS *adas, NIST *nist, AMJUEL *amjuel
 ) {
-    EquationSystem *eqsys = new EquationSystem(scalarGrid, fluidGrid, ht_type, hottailGrid, re_type, runawayGrid);
+    EquationSystem *eqsys = new EquationSystem(scalarGrid, fluidGrid, ht_type, hottailGrid, re_type, runawayGrid, s);
     struct OtherQuantityHandler::eqn_terms *oqty_terms = new OtherQuantityHandler::eqn_terms;
 
     // Timing information

--- a/src/Settings/SFile.cpp
+++ b/src/Settings/SFile.cpp
@@ -421,7 +421,7 @@ void DREAM::SettingsSFile::SaveIntegerArray(
     for (len_t i = 0; i < ndims; i++)
         _dims[i] = dims[i];
 
-    //sf->WriteMultiInt64Array(name, arr, ndims, _dims);
+    sf->WriteMultiInt64Array(name, arr, ndims, _dims);
 
     delete [] _dims;
 }

--- a/src/Settings/SFile.cpp
+++ b/src/Settings/SFile.cpp
@@ -289,15 +289,8 @@ void DREAM::SettingsSFile::SaveSettings(
         // Construct full name of setting
         string fullname = group + sname;
 
+        // Create non-existant groups in the file
         CreateGroup(sname, group, groups, sf);
-
-        // Should we create a new group?
-        /*auto slash = name.find('/');
-        if (slash != string::npos) {
-            string groupname = name.substr(0, slash);
-
-            if (std::find(groups.begin(), groups.end(), groupname) == 
-        }*/
 
         switch (set->type) {
             case Settings::SETTING_TYPE_BOOL:

--- a/src/Solver/SolverLinearlyImplicit.cpp
+++ b/src/Solver/SolverLinearlyImplicit.cpp
@@ -225,7 +225,7 @@ void SolverLinearlyImplicit::SaveDebugInfo(len_t it, FVM::Matrix *mat, const rea
                 outname += suffix;
             outname += ".h5";
 
-            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname);
+            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname, false);
             outgen->SaveCurrent();
             delete outgen;
         }

--- a/src/Solver/SolverLinearlyImplicit.cpp
+++ b/src/Solver/SolverLinearlyImplicit.cpp
@@ -225,7 +225,7 @@ void SolverLinearlyImplicit::SaveDebugInfo(len_t it, FVM::Matrix *mat, const rea
                 outname += suffix;
             outname += ".h5";
 
-            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname, false);
+            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname, true);
             outgen->SaveCurrent();
             delete outgen;
         }

--- a/src/Solver/SolverNonLinear.cpp
+++ b/src/Solver/SolverNonLinear.cpp
@@ -622,7 +622,7 @@ void SolverNonLinear::SaveDebugInfoAfter(
                 outname += suffix;
             outname += ".h5";
 
-            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname);
+            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname, false);
             outgen->SaveCurrent();
             delete outgen;
         }

--- a/src/Solver/SolverNonLinear.cpp
+++ b/src/Solver/SolverNonLinear.cpp
@@ -628,7 +628,7 @@ void SolverNonLinear::SaveDebugInfoAfter(
                 outname += suffix;
             outname += ".h5";
 
-            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname, false);
+            OutputGeneratorSFile *outgen = new OutputGeneratorSFile(this->eqsys, outname, true);
             outgen->SaveCurrent();
             delete outgen;
         }


### PR DESCRIPTION
For reproducibility, as well as for double-checking that DREAM actually respects settings, it would be useful to store a copy of the input settings in the output file produced by the kernel. This functionality is implemented in this branch. Settings in the output file are automatically loaded by the ``DREAMOutput`` object as a regular ``DREAMSettings`` object.

DREAM only stores settings which are actually used by the code to the output file. Settings which have not been touched by the kernel are left out, and it is therefore possible to verify that settings which are made are actually considered by the code.