### PR TITLE
Fix forgotten dependence of psi_p on psi_edge

### DIFF
--- a/include/DREAM/Settings/SimulationGenerator.hpp
+++ b/include/DREAM/Settings/SimulationGenerator.hpp
@@ -176,7 +176,7 @@ namespace DREAM {
 			const len_t, const len_t, const len_t
 		);
 		static void ConstructEquation_psi_init_nl(
-			EquationSystem*, const len_t, const len_t, const len_t
+			EquationSystem*, const len_t, const len_t, const len_t, const len_t
 		);
 
         static void ConstructEquation_n_re(EquationSystem*, Settings*, struct OtherQuantityHandler::eqn_terms*, FVM::Operator*);

--- a/src/EqsysInitializer.cpp
+++ b/src/EqsysInitializer.cpp
@@ -188,6 +188,12 @@ void EqsysInitializer::Execute(const real_t t0) {
         }
     }
 
+	// Non-linear equations to solve before finishing?
+	if (ssQty.size() > 0) {
+		this->NonLinearSolve(t0, ssQty);
+		ssQty.clear();
+	}
+
     // Verfiy that all unknown quantities have now been initialized
     this->VerifyAllInitialized();
 }

--- a/src/Settings/Equations/psi_p.cpp
+++ b/src/Settings/Equations/psi_p.cpp
@@ -89,7 +89,7 @@ void SimulationGenerator::ConstructEquation_psi_p(
 		(enum OptionConstants::uqty_E_field_eqn)s->GetInteger("eqsys/E_field/type");*/
 
 	ConstructEquation_psi_init_nl(
-		eqsys, id_psi_p, id_j_tot, id_I_p
+		eqsys, id_psi_p, id_j_tot, id_I_p, id_psi_edge
 	);
 	/*ConstructEquation_psi_init_integral(
 		eqsys, fluidGrid, id_psi_p, id_j_tot, id_I_p
@@ -110,7 +110,8 @@ void SimulationGenerator::ConstructEquation_psi_p(
  */
 void SimulationGenerator::ConstructEquation_psi_init_nl(
 	EquationSystem *eqsys,
-	const len_t id_psi_p, const len_t id_j_tot, const len_t id_I_p
+	const len_t id_psi_p, const len_t id_j_tot, const len_t id_I_p,
+	const len_t id_psi_edge
 ) {
     eqsys->initializer->AddRule(
         id_psi_p,
@@ -118,6 +119,7 @@ void SimulationGenerator::ConstructEquation_psi_init_nl(
 		nullptr,
         // Dependencies
         id_j_tot,
+		id_psi_edge,
         id_I_p,
 		EqsysInitializer::RUNAWAY_FLUID
     );


### PR DESCRIPTION
Apparently I had forgotten to make ``psi_p`` depend on ``psi_edge`` when the former is initialized by solving Ampère's law. In that case, ``psi_edge`` could be initialized *after* ``psi_p``, so that the values of ``psi_edge`` and ``psi_p`` would be inconsistent.