### PR TITLE
Hydrogen support

### DIFF
--- a/include/DREAM/Constants.hpp
+++ b/include/DREAM/Constants.hpp
@@ -17,6 +17,9 @@ namespace DREAM {
         //Elementary charge in C:
         static const real_t ec;
 
+		//Hydrogen mass in kg
+		static const real_t mH;
+
         //Deuterium mass in kg
         static const real_t mD; 
 

--- a/include/DREAM/IonHandler.hpp
+++ b/include/DREAM/IonHandler.hpp
@@ -29,9 +29,10 @@ namespace DREAM {
         static const real_t atomicMassInMu[nIonMass];
 
         std::vector<std::string> ionNames;
-        std::vector<std::string> tritiumNames;
-        len_t nTritium=0;
-        len_t *tritiumIndices;
+        std::vector<std::string> tritiumNames, hydrogenNames;
+        len_t nTritium=0, nHydrogen=0;
+        len_t *tritiumIndices, *hydrogenIndices;
+
 
         // DERIVED ION QUANTITIES
         real_t 
@@ -54,7 +55,12 @@ namespace DREAM {
         
     public:
 
-        IonHandler(FVM::RadialGrid *rg, FVM::UnknownQuantityHandler *u, const len_t *Z, len_t NZ, std::vector<std::string>& ionNames, std::vector<std::string>& tritiumName);
+        IonHandler(
+			FVM::RadialGrid *rg, FVM::UnknownQuantityHandler *u,
+			const len_t *Z, len_t NZ, std::vector<std::string>& ionNames,
+			std::vector<std::string>& tritiumNames,
+			std::vector<std::string>& hydrogenNames
+		);
         virtual ~IonHandler();
 
         void Initialize();
@@ -78,6 +84,7 @@ namespace DREAM {
         const len_t GetNTritiumIndices() const { return this->nTritium; }
 
         bool IsTritium(const len_t) const;
+		bool IsHydrogen(const len_t) const;
 
         const real_t GetIonDensityAtZ(len_t ir, len_t Z, len_t Z0) const;
         const real_t GetIonDensity(len_t ir, len_t iz, len_t Z0) const;

--- a/py/DREAM/DREAMIO.py
+++ b/py/DREAM/DREAMIO.py
@@ -225,6 +225,8 @@ def getData(f, key):
     elif f[key].dtype == 'object':  # New strings
         if f[key].shape == ():
             return f[key][()].decode()
+        elif type(f[key][:][0]) == str:
+            return f[key][:][0]
         else:
             return f[key][:][0].decode()
     else:

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -552,7 +552,7 @@ class Ions(UnknownQuantity):
 
         if len(tritiumnames) > 0:
             data['tritiumnames'] = tritiumnames
-        if (len(hydrogennames) > 0:
+        if len(hydrogennames) > 0:
             data['hydrogennames'] = hydrogennames
 
         if initial is not None:

--- a/py/DREAM/Settings/Output.py
+++ b/py/DREAM/Settings/Output.py
@@ -67,7 +67,7 @@ class Output:
         self.timingfile = bool(data['timingfile'])
 
         if 'savesettings' in data:
-            self.savesettings = data['savesettings']
+            self.savesettings = bool(data['savesettings'])
 
         self.verifySettings()
 

--- a/src/Constants.cpp
+++ b/src/Constants.cpp
@@ -15,6 +15,9 @@ const real_t Constants::ec = 1.60217662e-19;
 //Electron rest energy in eV:
 const real_t Constants::mc2inEV = 0.51099895000e6;
 
+//Hydrogen mass in kg
+const real_t Constants::mH = 1.67262192369e-27; 
+
 //Deuterium mass in kg
 const real_t Constants::mD = 3.3435837724e-27; 
 

--- a/src/IonHandler.cpp
+++ b/src/IonHandler.cpp
@@ -58,7 +58,7 @@ const real_t IonHandler::atomicMassInMu[nIonMass] =
  */
 IonHandler::IonHandler(
     FVM::RadialGrid *rg, FVM::UnknownQuantityHandler *u, const len_t *Z, len_t NZ,
-    vector<string>& names, vector<string>& tritium
+    vector<string>& names, vector<string>& tritium, vector<string>& hydrogen
 ) {
     rGrid = rg;
     unknowns = u;
@@ -70,9 +70,14 @@ IonHandler::IonHandler(
     niID = unknowns->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
 
     this->ionNames = names;
+
     this->tritiumNames = tritium;
     this->nTritium = tritium.size();
     this->tritiumIndices = new len_t[nTritium];
+
+	this->hydrogenNames = hydrogen;
+	this->nHydrogen = hydrogen.size();
+	this->hydrogenIndices = new len_t[nHydrogen];
 
     // Find index of tritum ions
     len_t ti = 0;
@@ -85,6 +90,18 @@ IonHandler::IonHandler(
         if (ti != t+1)
             throw FVM::FVMException("Species '%s' declared as tritium, but ion species has not been defined.", tritium[t].c_str());
     }
+	// Find index of hydrogen ions
+	len_t hi = 0;
+	for (len_t h = 0; h < hydrogen.size(); h++) {
+		for (len_t i = 0; i < names.size(); i++)
+			if (hydrogen[h] == names[i]) {
+				this->hydrogenIndices[hi++] = i;
+				break;
+			}
+		if (hi != h+1)
+			throw FVM::FVMException("Species '%s' declared as hydrogen, but ion species has not been defined.", hydrogen[h].c_str());
+	}
+
     Initialize();
 }
 
@@ -94,6 +111,7 @@ IonHandler::IonHandler(
 IonHandler::~IonHandler(){
     DeallocateAll();
     delete [] tritiumIndices;
+	delete [] hydrogenIndices;
 }
 
 
@@ -135,11 +153,16 @@ void IonHandler::Initialize() {
     mi = new real_t[nZ];
     for(len_t iz=0; iz<nZ; iz++){
         if(Zs[iz]==1){ // assume pure deuterium unless it is marked as tritium
-            bool isTritium = false;
+            bool isTritium = false, isHydrogen = false;
             for(len_t it=0; it<nTritium; it++)
                 if(iz==tritiumIndices[it])
                     isTritium = true;
-            mi[iz] = isTritium ? Constants::mT : Constants::mD;
+			for (len_t ih=0; ih<nHydrogen; ih++)
+				if (iz==hydrogenIndices[ih])
+					isHydrogen = true;
+            mi[iz] = isTritium ? Constants::mT : (
+						isHydrogen ? Constants::mH : Constants::mD
+			);
         } else if ( Zs[iz] > nIonMass ) // if heavier species than we store data for, assume simple linear scaling
             mi[iz] = 2.3*Zs[iz] * Constants::mu; 
         else // read from table
@@ -280,6 +303,19 @@ bool IonHandler::IsTritium(const len_t iIon) const {
             return true;
 
     return false;
+}
+
+
+/**
+ * Checks whether the ion with the given index is a hydrogen
+ * ion species.
+ */
+bool IonHandler::IsHydrogen(const len_t iIon) const {
+	for (len_t i = 0; i < this->nHydrogen; i++)
+		if (iIon == this->hydrogenIndices[i])
+			return true;
+	
+	return false;
 }
 
 

--- a/src/Settings/Equations/ions.cpp
+++ b/src/Settings/Equations/ions.cpp
@@ -48,6 +48,7 @@ void SimulationGenerator::DefineOptions_Ions(Settings *s) {
     s->DefineSetting(MODULENAME "/adv_interp_neutral/r_jac", "Type of interpolation method to use in the jacobian of the advection term", (int_t)OptionConstants::AD_INTERP_JACOBIAN_LINEAR);
     s->DefineSetting(MODULENAME "/adv_interp_neutral/fluxlimiterdamping", "Underrelaxation parameter for the neutral advection term that may be needed to achieve convergence with flux limiter methods", (real_t) 1.0);    
     s->DefineSetting(MODULENAME "/tritiumnames", "Names of the tritium ion species", (const string)"");
+    s->DefineSetting(MODULENAME "/hydrogennames", "Names of the hydrogen ion species", (const string)"");
     s->DefineSetting(MODULENAME "/ionization", "Model to use for ionization", (int_t) OptionConstants::EQTERM_IONIZATION_MODE_FLUID);
     s->DefineSetting(MODULENAME "/typeTi", "Model to use for ion heat equation", (int_t) OptionConstants::UQTY_T_I_NEGLECT);
 
@@ -125,8 +126,9 @@ void SimulationGenerator::ConstructEquation_Ions(EquationSystem *eqsys, Settings
         );
     }
 
-    // Get list of tritium species
+    // Get list of tritium and hydrogen species
     vector<string> tritiumNames = s->GetStringList(MODULENAME "/tritiumnames");
+	vector<string> hydrogenNames = s->GetStringList(MODULENAME "/hydrogennames");
 
     // Verify that exactly one type per ion species is given
     if (nZ != ntypes)
@@ -235,7 +237,7 @@ void SimulationGenerator::ConstructEquation_Ions(EquationSystem *eqsys, Settings
         MODULENAME, fluidGrid->GetRadialGrid(), s, nZ0_prescribed, "prescribed"
     );
 
-    IonHandler *ih = new IonHandler(fluidGrid->GetRadialGrid(), eqsys->GetUnknownHandler(), Z, nZ, ionNames, tritiumNames);
+    IonHandler *ih = new IonHandler(fluidGrid->GetRadialGrid(), eqsys->GetUnknownHandler(), Z, nZ, ionNames, tritiumNames, hydrogenNames);
     eqsys->SetIonHandler(ih);
 
     // Initialize ion equations

--- a/tests/cxx/tests/DREAM/IonRateEquation.cpp
+++ b/tests/cxx/tests/DREAM/IonRateEquation.cpp
@@ -25,7 +25,7 @@ const char ION_NAMES[N_IONS][3] = {"H","Be","Ne","Ar"};
 DREAM::IonHandler *IonRateEquation::GetIonHandler(
     DREAM::FVM::Grid *g, DREAM::FVM::UnknownQuantityHandler *uqh
 ) {
-    vector<string> tritiumNames(0);
+    vector<string> tritiumNames(0), hydrogenNames(0);
     vector<string> names(N_IONS);
     len_t *Z = new len_t[N_IONS];// The ion charge numbers must be provided to the IONHandler as a dynamically allocated array to avoid memory issues
     for (len_t i = 0; i < N_IONS; i++){
@@ -34,7 +34,7 @@ DREAM::IonHandler *IonRateEquation::GetIonHandler(
     }
 
     return new DREAM::IonHandler(
-        g->GetRadialGrid(), uqh, Z, N_IONS, names, tritiumNames
+        g->GetRadialGrid(), uqh, Z, N_IONS, names, tritiumNames, hydrogenNames
     );
 }
 

--- a/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp
+++ b/tests/cxx/tests/DREAM/MeanExcitationEnergy.cpp
@@ -93,7 +93,7 @@ DREAM::FVM::UnknownQuantityHandler *MeanExcitationEnergy::GetUnknownHandler(DREA
 DREAM::IonHandler *MeanExcitationEnergy::GetIonHandler(
     DREAM::FVM::Grid *g, DREAM::FVM::UnknownQuantityHandler *uqh, const len_t N_IONS, const len_t *Z_IONS
 ) {
-    vector<string> tritiumNames(0);
+    vector<string> tritiumNames(0), hydrogenNames(0);
     vector<string> names(N_IONS);
     len_t *Z = new len_t[N_IONS];// The ion charge numbers must be provided to the IONHandler as a dynamically allocated array to avoid memory issues
     for (len_t i = 0; i < N_IONS; i++){
@@ -102,7 +102,7 @@ DREAM::IonHandler *MeanExcitationEnergy::GetIonHandler(
     }
 
     return new DREAM::IonHandler(
-        g->GetRadialGrid(), uqh, Z, N_IONS, names, tritiumNames
+        g->GetRadialGrid(), uqh, Z, N_IONS, names, tritiumNames, hydrogenNames
     );
 }
 

--- a/tests/cxx/tests/DREAM/RunawayFluid.cpp
+++ b/tests/cxx/tests/DREAM/RunawayFluid.cpp
@@ -217,13 +217,13 @@ DREAM::FVM::UnknownQuantityHandler *RunawayFluid::GetUnknownHandlerSingleImpurit
 DREAM::IonHandler *RunawayFluid::GetIonHandler(
     DREAM::FVM::Grid *g, DREAM::FVM::UnknownQuantityHandler *uqh, const len_t N_IONS, const len_t *Z_IONS
 ) {
-    vector<string> tritiumNames(0);
+    vector<string> tritiumNames(0), hydrogenNames(0);
     vector<string> names(N_IONS);
     for (len_t i = 0; i < N_IONS; i++)
         names[i] = "";//ION_NAMES[i];
 
     return new DREAM::IonHandler(
-        g->GetRadialGrid(), uqh, Z_IONS, N_IONS, names, tritiumNames
+        g->GetRadialGrid(), uqh, Z_IONS, N_IONS, names, tritiumNames, hydrogenNames
     );
 }
 

--- a/tools/ADAS/data.py
+++ b/tools/ADAS/data.py
@@ -229,7 +229,8 @@ def load_element(element, year, cache=True, cachedir=None):
     data['Z'] = Z
 
     # Handle hydrogen isotope mass numbers specifically...
-    if element == 'D': data['A'] = 2
+    if element == 'H': data['A'] = 1
+    elif element == 'D': data['A'] = 2
     elif element == 'T': data['A'] = 3
     else: data['A'] = 2*Z
 


### PR DESCRIPTION
For STREAM we needed to differentiate between H, D and T. On this branch we therefore implement support for that by introducing a new flag ``hydrogen`` in the Python interface and an implementation which is analogous to the one for tritium.