### PR TITLE
CSD3 setup scripts

### DIFF
--- a/setup/build.cam.sh
+++ b/setup/build.cam.sh
@@ -4,7 +4,7 @@
 # This script builds PETSc and DREAM on Cambridge CSD3 cluster (./build.cam.sh)
 # (https://docs.hpc.cam.ac.uk/hpc/index.html)
 #
-# Please load do ". environment.cam.sh" before running ./build.cam.sh (otherwise the initialization
+# Please do ". environment.cam.sh" before running ./build.cam.sh (otherwise the initialization
 # of conda fails).
 # The "environment.cam.sh" script will initialize DREAMPATH to its default value, and load
 # the required modules. petsc is installed locally in the shared RE directory, if you want
@@ -34,7 +34,7 @@ function install_petsc {
 
 function install_dream {
 	cd "$DREAMPATH" && rm -rf build && mkdir build && cd build &&
-	cmake .. -DPETSC_EXECUTABLE_RUNS=YES -DGSL_ROOT_DIR=/usr/local/Cluster-Apps/gsl/2.4/ -DMPI_CXX_COMPILER=/home/ir-fil1/rds/rds-ukaea-ap001/RE/petsc/arch-linux-c-opt/bin/ -DPETSC_DIR="$PETSC_DIR" -DPETSC_ARCH="$PETSC_ARCH" &&
+	cmake .. -DPETSC_EXECUTABLE_RUNS=YES -DGSL_ROOT_DIR=/usr/local/Cluster-Apps/gsl/2.4/ -DMPI_CXX_COMPILER=~/rds/rds-ukaea-ap001/RE/petsc/arch-linux-c-opt/bin/ -DPETSC_DIR="$PETSC_DIR" -DPETSC_ARCH="$PETSC_ARCH" &&
 	make -j8
 }
 

--- a/setup/build.cam.sh
+++ b/setup/build.cam.sh
@@ -1,0 +1,43 @@
+
+#!/bin/bash
+#
+# This script builds PETSc and DREAM on Cambridge CSD3 cluster (./build.cam.sh)
+# (https://docs.hpc.cam.ac.uk/hpc/index.html)
+#
+# Please load do ". environment.cam.sh" before running ./build.cam.sh (otherwise the initialization
+# of conda fails).
+# The "environment.cam.sh" script will initialize DREAMPATH to its default value, and load
+# the required modules. petsc is installed locally in the shared RE directory, if you want
+# to install your own version of petsc and DREAM, you can modify the paths in environment.cam.sh.
+# If left empty, it will download and compile it in your home directory.
+#
+# NOTE: When running DREAM, you will also want to source the "environment.cam.sh"
+# script beforehand.
+#
+# -------
+# Written by Alexandre Fil (2022-03-01)
+# 
+
+function install_petsc {
+	if [ -d "$PETSC_DIR" ]
+	then
+	    if [ "$(ls -A $PETSC_DIR)" ]; then
+		echo "PETSC is already installed in $PETSC_DIR"
+	    else
+		git clone -b release https://gitlab.com/petsc/petsc.git "$PETSC_DIR"
+		cd "$PETSC_DIR"
+		./configure --download-f2cblaslapack=1 --with-debugging=0 --COPTFLAGS="-O3 -march=native -mtune=native" --CXXOPTFLAGS="-O3 -march=native -mtune=native" --FOPTFLAGS="-O3 -march=native -mtune=native" --download-superlu --download-mpich=1 &&
+		make PETSC_DIR=$PETSC_DIR PETSC_ARCH=$PETSC_ARCH all
+	    fi
+	fi
+}
+
+function install_dream {
+	cd "$DREAMPATH" && rm -rf build && mkdir build && cd build &&
+	cmake .. -DPETSC_EXECUTABLE_RUNS=YES -DGSL_ROOT_DIR=/usr/local/Cluster-Apps/gsl/2.4/ -DMPI_CXX_COMPILER=/home/ir-fil1/rds/rds-ukaea-ap001/RE/petsc/arch-linux-c-opt/bin/ -DPETSC_DIR="$PETSC_DIR" -DPETSC_ARCH="$PETSC_ARCH" &&
+	make -j8
+}
+
+install_petsc
+install_dream
+

--- a/setup/environment.cam.sh
+++ b/setup/environment.cam.sh
@@ -17,7 +17,7 @@ fi
 module purge
 
 # Load required modules
-module load gcc/11
+module load gcc/11 slurm
 module load hdf5-1.10.1-gcc-5.4.0-z7bre2k
 module load cmake gsl/2.4
 module load python

--- a/setup/environment.cam.sh
+++ b/setup/environment.cam.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Set PETSc path (can be overridden by settings these variables explicitly)
+if [ -z "$PETSC_DIR" ]; then
+	export PETSC_DIR=~/rds/rds-ukaea-ap001/RE/petsc/
+fi
+if [ -z "$PETSC_ARCH" ]; then
+	export PETSC_ARCH=arch-linux-c-opt
+fi
+# Set DREAM path (based on location of this script)
+if [ -z "$DREAMPATH" ]; then
+    export DREAMPATH=~/rds/rds-ukaea-ap001/RE/DREAM
+fi
+
+# Modules needed for building and running DREAM
+# Clean up module environment
+module purge
+
+# Load required modules
+module load gcc/11
+module load hdf5-1.10.1-gcc-5.4.0-z7bre2k
+module load cmake gsl/2.4
+module load python
+
+#Active Python conda environment (needed for h5py)
+module load miniconda/3
+cd ~/rds/rds-ukaea-ap001/RE/
+conda init
+conda deactivate
+conda activate DREAM_PYTHON
+cd -


### PR DESCRIPTION
Environment and build scripts for the CSD3 cluster (Cambridge, UK). I had to use a conda environment to be able to install all required python packages on the cluster. I have tested that the code is running correctly with testDREAM.sh as well as examples/basic and Disruptions.