### PR TITLE
Adaptive time stepper based on ionization time

### DIFF
--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -138,7 +138,8 @@ enum linear_solver {
 /////////////////////////////////////
 enum timestepper_type {
     TIMESTEPPER_TYPE_CONSTANT=1,
-    TIMESTEPPER_TYPE_ADAPTIVE=2
+    TIMESTEPPER_TYPE_ADAPTIVE=2,
+	TIMESTEPPER_TYPE_IONIZATION=3
 };
 
 /////////////////////////////////////

--- a/include/DREAM/Settings/SimulationGenerator.hpp
+++ b/include/DREAM/Settings/SimulationGenerator.hpp
@@ -20,8 +20,9 @@
 #include "DREAM/Solver/SolverLinearlyImplicit.hpp"
 #include "DREAM/Solver/SolverNonLinear.hpp"
 #include "DREAM/TimeStepper/TimeStepper.hpp"
-#include "DREAM/TimeStepper/TimeStepperConstant.hpp"
 #include "DREAM/TimeStepper/TimeStepperAdaptive.hpp"
+#include "DREAM/TimeStepper/TimeStepperConstant.hpp"
+#include "DREAM/TimeStepper/TimeStepperIonization.hpp"
 #include "FVM/Grid/Grid.hpp"
 #include "FVM/Grid/PXiGrid/PXiMomentumGrid.hpp"
 #include "FVM/Grid/RadialGrid.hpp"
@@ -226,8 +227,9 @@ namespace DREAM {
         static void ConstructEquation_x_p_prescribed_constant_velocity(EquationSystem*, Settings*);
 
         // Routines for constructing time steppers
-        static TimeStepperConstant *ConstructTimeStepper_constant(Settings*, FVM::UnknownQuantityHandler*);
         static TimeStepperAdaptive *ConstructTimeStepper_adaptive(Settings*, FVM::UnknownQuantityHandler*, std::vector<len_t>*);
+        static TimeStepperConstant *ConstructTimeStepper_constant(Settings*, FVM::UnknownQuantityHandler*);
+        static TimeStepperIonization *ConstructTimeStepper_ionization(Settings*, FVM::UnknownQuantityHandler*);
 
         // Data loading routines
         static void DefineDataR(const std::string&, Settings*, const std::string& name="data");

--- a/include/DREAM/TimeStepper/TimeStepper.hpp
+++ b/include/DREAM/TimeStepper/TimeStepper.hpp
@@ -18,8 +18,10 @@ namespace DREAM {
             : unknowns(u) {}
         virtual ~TimeStepper() {}
 
+        virtual bool CheckNegative(const std::string&);
+        virtual void HandleException(FVM::FVMException&);
+
         virtual real_t CurrentTime() const = 0;
-        virtual void HandleException(FVM::FVMException&) = 0;
         virtual bool IsFinished() = 0;
         virtual bool IsSaveStep() = 0;
         virtual real_t NextTime() = 0;

--- a/include/DREAM/TimeStepper/TimeStepperConstant.hpp
+++ b/include/DREAM/TimeStepper/TimeStepperConstant.hpp
@@ -23,11 +23,9 @@ namespace DREAM {
         TimeStepperConstant(const real_t, const real_t, FVM::UnknownQuantityHandler*, const len_t nSaveSteps=0);
         TimeStepperConstant(const real_t, const len_t, FVM::UnknownQuantityHandler*, const len_t nSaveSteps=0);
 
-        bool CheckNegative(const std::string&);
         void InitSaveSteps();
 
         virtual real_t CurrentTime() const override;
-        virtual void HandleException(FVM::FVMException&) override;
         virtual bool IsFinished() override;
         virtual bool IsSaveStep() override;
         virtual real_t NextTime() override;

--- a/include/DREAM/TimeStepper/TimeStepperIonization.hpp
+++ b/include/DREAM/TimeStepper/TimeStepperIonization.hpp
@@ -16,7 +16,7 @@ namespace DREAM {
 		len_t id_n_cold;
 
 		len_t nr;
-		real_t *timescales;
+		real_t *timescales, *ncold;
 	public:
 		TimeStepperIonization(
 			const real_t tMax, const real_t dt0, const real_t dtMax,

--- a/include/DREAM/TimeStepper/TimeStepperIonization.hpp
+++ b/include/DREAM/TimeStepper/TimeStepperIonization.hpp
@@ -14,9 +14,12 @@ namespace DREAM {
 		real_t currentTime=0;
 		real_t tscale0 = 0, dt;
 		len_t id_n_cold;
+		len_t currentStep = 0;
 
 		len_t nr;
 		real_t *timescales, *ncold;
+		
+		const len_t PROGRESSBAR_LENGTH = 80;
 	public:
 		TimeStepperIonization(
 			const real_t tMax, const real_t dt0, const real_t dtMax,

--- a/include/DREAM/TimeStepper/TimeStepperIonization.hpp
+++ b/include/DREAM/TimeStepper/TimeStepperIonization.hpp
@@ -1,0 +1,39 @@
+#ifndef _DREAM_TIME_STEPPER_IONIZATION_HPP
+#define _DREAM_TIME_STEPPER_IONIZATION_HPP
+
+#include <vector>
+#include "DREAM/TimeStepper/TimeStepper.hpp"
+#include "FVM/UnknownQuantityHandler.hpp"
+
+namespace DREAM {
+	class TimeStepperIonization : public TimeStepper {
+	private:
+		real_t tMax;
+		real_t dt0, dtMax;
+
+		real_t currentTime=0;
+		real_t tscale0 = 0, dt;
+		len_t id_n_cold;
+
+		len_t nr;
+		real_t *timescales;
+	public:
+		TimeStepperIonization(
+			const real_t tMax, const real_t dt0, const real_t dtMax,
+			FVM::UnknownQuantityHandler*
+		);
+		~TimeStepperIonization();
+
+		virtual real_t CurrentTime() const { return this->currentTime; }
+		virtual bool IsFinished() override { return (this->currentTime >= this->tMax); }
+		virtual bool IsSaveStep() override { return true; }
+		virtual real_t NextTime() override;
+		virtual void ValidateStep() override;
+
+		real_t GetIonizationTimeScale();
+
+		virtual void PrintProgress() override;
+	};
+}
+
+#endif/*_DREAM_TIME_STEPPER_IONIZATION_HPP*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,10 @@ set(dream_core
     "${PROJECT_SOURCE_DIR}/src/OtherQuantityHandler.cpp"
     "${PROJECT_SOURCE_DIR}/src/PostProcessor.cpp"
     "${PROJECT_SOURCE_DIR}/src/Simulation.cpp"
+    "${PROJECT_SOURCE_DIR}/src/TimeStepper/TimeStepper.cpp"
     "${PROJECT_SOURCE_DIR}/src/TimeStepper/TimeStepperAdaptive.cpp"
     "${PROJECT_SOURCE_DIR}/src/TimeStepper/TimeStepperConstant.cpp"
+    "${PROJECT_SOURCE_DIR}/src/TimeStepper/TimeStepperIonization.cpp"
     "${PROJECT_SOURCE_DIR}/src/UnknownQuantityEquation.cpp"
 )
 set(dream_equations

--- a/src/Settings/TimeStepper.cpp
+++ b/src/Settings/TimeStepper.cpp
@@ -151,6 +151,9 @@ TimeStepperIonization *SimulationGenerator::ConstructTimeStepper_ionization(
 	real_t dt = s->GetReal(MODULENAME "/dt");
 	real_t dtmax = s->GetReal(MODULENAME "/dtmax");
 
+	if (dt <= 0)
+		throw SettingsException("TimeStepper ionization: Initial time step 'dt0' must be positive.");
+
 	return new TimeStepperIonization(tmax, dt, dtmax, u);
 }
 

--- a/src/Settings/TimeStepper.cpp
+++ b/src/Settings/TimeStepper.cpp
@@ -27,6 +27,7 @@ void SimulationGenerator::DefineOptions_TimeStepper(Settings *s) {
     s->DefineSetting(MODULENAME "/type", "Time step generator type", (int_t)OptionConstants::TIMESTEPPER_TYPE_CONSTANT);
     s->DefineSetting(MODULENAME "/tmax", "Maximum simulation time", (real_t)0.0);
     s->DefineSetting(MODULENAME "/dt", "Length of each time step", (real_t)0.0);
+	s->DefineSetting(MODULENAME "/dtmax", "Maximum allowed time step for the adaptive ionization time stepper.", (real_t)0);
     s->DefineSetting(MODULENAME "/nt", "Number of time steps to take", (int_t)0);
     s->DefineSetting(MODULENAME "/nsavesteps", "Number of time steps to save to output (downsampling)", (int_t)0);
     s->DefineSetting(MODULENAME "/verbose", "If true, generates excessive output", (bool)false);
@@ -55,6 +56,10 @@ void SimulationGenerator::ConstructTimeStepper(EquationSystem *eqsys, Settings *
         case OptionConstants::TIMESTEPPER_TYPE_ADAPTIVE:
             ts = ConstructTimeStepper_adaptive(s, u, nontrivials);
             break;
+
+		case OptionConstants::TIMESTEPPER_TYPE_IONIZATION:
+			ts = ConstructTimeStepper_ionization(s, u);
+			break;
 
         default:
             throw SettingsException(
@@ -130,5 +135,22 @@ TimeStepperAdaptive *SimulationGenerator::ConstructTimeStepper_adaptive(
     );
 
     return new TimeStepperAdaptive(tmax, dt, u, *nontrivials, cc, checkevery, verbose, conststep);
+}
+
+/**
+ * Construct a TimeStepperIonization object according to the
+ * provided settings.
+ *
+ * s: Settings object specifying how to construct the
+ *    TimeStepperIonization object.
+ */
+TimeStepperIonization *SimulationGenerator::ConstructTimeStepper_ionization(
+	Settings *s, FVM::UnknownQuantityHandler *u
+) {
+	real_t tmax = s->GetReal(MODULENAME "/tmax");
+	real_t dt = s->GetReal(MODULENAME "/dt");
+	real_t dtmax = s->GetReal(MODULENAME "/dtmax");
+
+	return new TimeStepperIonization(tmax, dt, dtmax, u);
 }
 

--- a/src/TimeStepper/TimeStepper.cpp
+++ b/src/TimeStepper/TimeStepper.cpp
@@ -1,0 +1,48 @@
+
+#include <string>
+#include "DREAM/IO.hpp"
+#include "DREAM/TimeStepper/TimeStepper.hpp"
+
+using namespace DREAM;
+
+
+/**
+ * Check if a given unknown contains negative elements.
+ */
+bool TimeStepper::CheckNegative(const std::string& name) {
+    len_t uqtyid = unknowns->GetUnknownID(name);
+
+    if (unknowns->HasUnknown(name)) {
+        FVM::UnknownQuantity *uqty = unknowns->GetUnknown(uqtyid);
+        const real_t *data = uqty->GetData();
+        for (len_t i = 0; i < uqty->NumberOfElements(); i++)
+            if (data[i] < 0)
+                return true;
+    }
+
+    return false;
+}
+
+/**
+ * This method is called when an exception was thrown while
+ * the next time step was being taken. In the constant time
+ * stepper, we choose to forward this exception and just indicate
+ * to the user that it might be due to the time step being too
+ * short.
+ *
+ * ex: The exception that was caught.
+ */
+void TimeStepper::HandleException(FVM::FVMException &ex) {
+    DREAM::IO::PrintError("TimeStepper: Exception caught during time stepping.");
+    DREAM::IO::PrintError("TimeStepper: Perhaps the exception could be avoided by decreasing the time step length?");
+
+//    if (CheckNegative(OptionConstants::UQTY_ION_SPECIES))
+//        DREAM::IO::PrintError("TimeStepper: Ion density 'n_i' is negative.");
+    if (CheckNegative(OptionConstants::UQTY_N_COLD))
+        DREAM::IO::PrintError("TimeStepper: Cold electron density 'n_cold' is negative.");
+    if (CheckNegative(OptionConstants::UQTY_T_COLD))
+        DREAM::IO::PrintError("TimeStepper: Cold electron temperature 'T_cold' is negative.");
+
+    throw ex;
+}
+

--- a/src/TimeStepper/TimeStepperConstant.cpp
+++ b/src/TimeStepper/TimeStepperConstant.cpp
@@ -30,23 +30,6 @@ TimeStepperConstant::TimeStepperConstant(
 }
 
 /**
- * Check if a given unknown contains negative elements.
- */
-bool TimeStepperConstant::CheckNegative(const std::string& name) {
-    len_t uqtyid = unknowns->GetUnknownID(name);
-
-    if (unknowns->HasUnknown(name)) {
-        FVM::UnknownQuantity *uqty = unknowns->GetUnknown(uqtyid);
-        const real_t *data = uqty->GetData();
-        for (len_t i = 0; i < uqty->NumberOfElements(); i++)
-            if (data[i] < 0)
-                return true;
-    }
-
-    return false;
-}
-
-/**
  * Returns the time of the most recently _completed_ time step.
  */
 real_t TimeStepperConstant::CurrentTime() const {
@@ -54,29 +37,6 @@ real_t TimeStepperConstant::CurrentTime() const {
         return this->t0;
     else
         return (this->t0 + (this->tIndex-1)*this->dt);
-}
-
-/**
- * This method is called when an exception was thrown while
- * the next time step was being taken. In the constant time
- * stepper, we choose to forward this exception and just indicate
- * to the user that it might be due to the time step being too
- * short.
- *
- * ex: The exception that was caught.
- */
-void TimeStepperConstant::HandleException(FVM::FVMException &ex) {
-    DREAM::IO::PrintError("TimeStepper: Exception caught during time stepping.");
-    DREAM::IO::PrintError("TimeStepper: Perhaps the exception could be avoided by decreasing the time step length?");
-
-//    if (CheckNegative(OptionConstants::UQTY_ION_SPECIES))
-//        DREAM::IO::PrintError("TimeStepper: Ion density 'n_i' is negative.");
-    if (CheckNegative(OptionConstants::UQTY_N_COLD))
-        DREAM::IO::PrintError("TimeStepper: Cold electron density 'n_cold' is negative.");
-    if (CheckNegative(OptionConstants::UQTY_T_COLD))
-        DREAM::IO::PrintError("TimeStepper: Cold electron temperature 'T_cold' is negative.");
-
-    throw ex;
 }
 
 /**

--- a/src/TimeStepper/TimeStepperIonization.cpp
+++ b/src/TimeStepper/TimeStepperIonization.cpp
@@ -107,6 +107,8 @@ void TimeStepperIonization::ValidateStep() {
 		this->currentTime = this->tMax;
 	else
 		this->currentTime += this->dt;
+	
+	this->currentStep++;
 
 	// Copy current value of n_cold
 	const real_t *n = this->unknowns->GetUnknownDataPrevious(this->id_n_cold);
@@ -118,7 +120,31 @@ void TimeStepperIonization::ValidateStep() {
  * Print the progress of the time stepper.
  */
 void TimeStepperIonization::PrintProgress() {
-	//cout << "t = " << CurrentTime() << "s, dt = " << this->dt << "s" << endl;
-	printf("t = %.3es, dt = %.3es\n", CurrentTime(), this->dt);
+	const len_t PERC_FMT_PREC = 2; // Precision (after decimal point) in percent
+	//                          100 . XX            %
+	const len_t PERC_FMT_LENGTH = 3+1+PERC_FMT_PREC+1;
+	const len_t EDGE_LENGTH = 1;
+	const len_t PROG_LENGTH =
+		PROGRESSBAR_LENGTH - 2*EDGE_LENGTH - PERC_FMT_LENGTH - 1;
+	
+	cout << "\r[";
+	real_t perc     = CurrentTime()/this->tMax;
+	len_t threshold = static_cast<len_t>(perc * PROG_LENGTH);
+
+	for (len_t i = 0; i < PROG_LENGTH; i++) {
+		if (i < threshold)
+			cout << '#';
+		else
+			cout << '-';
+	}
+
+	cout << "] ";
+	printf(
+		"%*.*f%% (step " LEN_T_PRINTF_FMT ", dt = %.5e)",
+		int(4+PERC_FMT_PREC), int(PERC_FMT_PREC),
+		perc*100.0, this->currentStep, this->dt
+	);
+
+	cout << flush;
 }
 

--- a/src/TimeStepper/TimeStepperIonization.cpp
+++ b/src/TimeStepper/TimeStepperIonization.cpp
@@ -28,12 +28,14 @@ TimeStepperIonization::TimeStepperIonization(
 	this->nr = u->GetUnknown(this->id_n_cold)->GetGrid()->GetNr();
 
 	this->timescales = new real_t[this->nr];
+	this->ncold = new real_t[this->nr];
 }
 
 /**
  * Destructor.
  */
 TimeStepperIonization::~TimeStepperIonization() {
+	delete [] this->ncold;
 	delete [] this->timescales;
 }
 
@@ -49,13 +51,14 @@ real_t TimeStepperIonization::GetIonizationTimeScale() {
 
 	FVM::UnknownQuantity *n_cold = this->unknowns->GetUnknown(this->id_n_cold);
 	const real_t *n  = n_cold->GetData();
-	const real_t *np = n_cold->GetDataPrevious();
 
-	real_t dt = this->currentTime - n_cold->GetPreviousTime();
-
-	// Evaluate time scale as "1 / (|dn/dt| / n)
-	for (len_t ir = 0; ir < this->nr; ir++)
-		timescales[ir] = n[ir] * dt / std::abs(n[ir]-np[ir]);
+	// Evaluate time scale as "1 / (|dn/dt| / n)"
+	for (len_t ir = 0; ir < this->nr; ir++) {
+		if (n[ir] != this->ncold[ir])
+			timescales[ir] = n[ir] * this->dt / std::abs(n[ir]-this->ncold[ir]);
+		else
+			timescales[ir] = std::numeric_limits<real_t>::infinity();
+	}
 	
 	// Find shortest time scale
 	real_t tscale = timescales[0];
@@ -63,7 +66,10 @@ real_t TimeStepperIonization::GetIonizationTimeScale() {
 		if (timescales[ir] < tscale)
 			tscale = timescales[ir];
 	
-	return tscale;
+	if (isinf(tscale))
+		return 0;
+	else
+		return tscale;
 }
 
 /**
@@ -71,16 +77,23 @@ real_t TimeStepperIonization::GetIonizationTimeScale() {
  */
 real_t TimeStepperIonization::NextTime() {
 	real_t timescale = GetIonizationTimeScale();
-	
-	if (this->tscale0 == 0) {
-		this->tscale0 = timescale;
+
+	if (timescale == 0) {
+		this->dt = this->dt0;
+	} else {
+		if (this->tscale0 == 0) {
+			this->tscale0 = timescale;
+		}
+
+		this->dt = (this->dt0 * timescale / this->tscale0);
+		if (this->dtMax > 0 && this->dt > this->dtMax)
+			this->dt = this->dtMax;
 	}
 
-	this->dt = (this->dt0 * timescale / this->tscale0);
-	if (this->dtMax > 0 && this->dt > this->dtMax)
-		this->dt = this->dtMax;
-
-	return this->currentTime+this->dt;
+	if ((this->currentTime+this->dt) > this->tMax)
+		return this->tMax;
+	else
+		return this->currentTime+this->dt;
 }
 
 /**
@@ -90,13 +103,22 @@ real_t TimeStepperIonization::NextTime() {
  * scale is always respected and re-run if it is not.
  */
 void TimeStepperIonization::ValidateStep() {
-	this->currentTime += this->dt;
+	if ((this->currentTime+this->dt) > this->tMax)
+		this->currentTime = this->tMax;
+	else
+		this->currentTime += this->dt;
+
+	// Copy current value of n_cold
+	const real_t *n = this->unknowns->GetUnknownDataPrevious(this->id_n_cold);
+	for (len_t ir = 0; ir < this->nr; ir++)
+		this->ncold[ir] = n[ir];
 }
 
 /**
  * Print the progress of the time stepper.
  */
 void TimeStepperIonization::PrintProgress() {
-	cout << "t = " << CurrentTime() << "s, dt = " << this->dt << "s" << endl;
+	//cout << "t = " << CurrentTime() << "s, dt = " << this->dt << "s" << endl;
+	printf("t = %.3es, dt = %.3es\n", CurrentTime(), this->dt);
 }
 

--- a/src/TimeStepper/TimeStepperIonization.cpp
+++ b/src/TimeStepper/TimeStepperIonization.cpp
@@ -1,0 +1,102 @@
+/**
+ * Implementation of an adaptive time stepper which gradually
+ * rescales the time step to ensure that the ionization time
+ * scale is (just barely) respected.
+ */
+
+#include <iostream>
+#include "DREAM/IO.hpp"
+#include "DREAM/Settings/OptionConstants.hpp"
+#include "DREAM/TimeStepper/TimeStepperIonization.hpp"
+
+
+using namespace DREAM;
+using namespace std;
+
+
+/**
+ * Constructor.
+ */
+TimeStepperIonization::TimeStepperIonization(
+	const real_t tMax, const real_t dt0, const real_t dtMax,
+	FVM::UnknownQuantityHandler *u
+) : TimeStepper(u), tMax(tMax), dt0(dt0), dtMax(dtMax) {
+	if (tMax < dt0)
+		throw TimeStepperException("TimeStepperIonization: Maximum time must be greater than initial time step.");
+	
+	this->id_n_cold = u->GetUnknownID(OptionConstants::UQTY_N_COLD);
+	this->nr = u->GetUnknown(this->id_n_cold)->GetGrid()->GetNr();
+
+	this->timescales = new real_t[this->nr];
+}
+
+/**
+ * Destructor.
+ */
+TimeStepperIonization::~TimeStepperIonization() {
+	delete [] this->timescales;
+}
+
+
+/**
+ * Evaluates the current ionization time scale. If the time
+ * scale cannot be evaluated (i.e. if n_cold is only known in
+ * a single time point), zero is returned.
+ */
+real_t TimeStepperIonization::GetIonizationTimeScale() {
+	if (this->currentTime == 0)
+		return 0;
+
+	FVM::UnknownQuantity *n_cold = this->unknowns->GetUnknown(this->id_n_cold);
+	const real_t *n  = n_cold->GetData();
+	const real_t *np = n_cold->GetDataPrevious();
+
+	real_t dt = this->currentTime - n_cold->GetPreviousTime();
+
+	// Evaluate time scale as "1 / (|dn/dt| / n)
+	for (len_t ir = 0; ir < this->nr; ir++)
+		timescales[ir] = n[ir] * dt / std::abs(n[ir]-np[ir]);
+	
+	// Find shortest time scale
+	real_t tscale = timescales[0];
+	for (len_t ir = 0; ir < this->nr; ir++)
+		if (timescales[ir] < tscale)
+			tscale = timescales[ir];
+	
+	return tscale;
+}
+
+/**
+ * Return the time for the next time step.
+ */
+real_t TimeStepperIonization::NextTime() {
+	real_t timescale = GetIonizationTimeScale();
+	
+	if (this->tscale0 == 0) {
+		this->tscale0 = timescale;
+	}
+
+	this->dt = (this->dt0 * timescale / this->tscale0);
+	if (this->dtMax > 0 && this->dt > this->dtMax)
+		this->dt = this->dtMax;
+
+	return this->currentTime+this->dt;
+}
+
+/**
+ * Validate the most recently taken time step. Currently, we
+ * don't do this in this time stepper, but in the future we
+ * could implement a check to ensure that the ionization time
+ * scale is always respected and re-run if it is not.
+ */
+void TimeStepperIonization::ValidateStep() {
+	this->currentTime += this->dt;
+}
+
+/**
+ * Print the progress of the time stepper.
+ */
+void TimeStepperIonization::PrintProgress() {
+	cout << "t = " << CurrentTime() << "s, dt = " << this->dt << "s" << endl;
+}
+


### PR DESCRIPTION
This pull request implements an adaptive time stepper which estimates the instantaneous ionization time scale and rescales the time step accordingly. The user specifies the initial time step ``dt0``, which is used for the very first time step. After the first time step has been completed, the ionization time scale can be evaluated for the first time, and this time scale, ``timescale0`` is used as the baseline. In subsequent, the ionization time scale ``timescale`` is evaluated, and the time step is estimated according to
```
dt = dt0 * timescale / timescale0
```
This has been tested on a TCV disruption case (in fluid mode), but will also be tested on an isotropic+kinetic RE simulation before being merged.

Documentation will also be added before final merge.