### PR TITLE
Fix bug with IonSpecies.getDensity()

### DIFF
--- a/py/DREAM/Output/IonSpecies.py
+++ b/py/DREAM/Output/IonSpecies.py
@@ -87,7 +87,7 @@ class IonSpecies:
 
         for ion in self.ionstates:
             if n is None:
-                n = ion.get(t=t)
+                n = np.copy(ion.get(t=t))
             else:
                 n += ion.get(t=t)
 


### PR DESCRIPTION
A bug in ``DREAM.Output.IonSpecies.getDensity()`` was reported in #200. This pull requests resolves that issue.