### PR TITLE
bug fix for when used with the linear implicit solver

### DIFF
--- a/include/DREAM/Equations/Fluid/IonSpeciesTransientTerm.hpp
+++ b/include/DREAM/Equations/Fluid/IonSpeciesTransientTerm.hpp
@@ -3,7 +3,7 @@
 
 /**
  * Implementation of an equation term representing the
- * (backward euler) time derivative on an ion species 
+ * (backward euler) time derivative on an ion species
  * with index iz. (which can be scaled using scalefactor)
  */
 
@@ -20,7 +20,7 @@ namespace DREAM{
         real_t dt;
         real_t *xPrev;
     public:
-        IonSpeciesTransientTerm(FVM::Grid *g, len_t iz, const len_t id, real_t scaleFactor=1.0) 
+        IonSpeciesTransientTerm(FVM::Grid *g, len_t iz, const len_t id, real_t scaleFactor=1.0)
             : FVM::EquationTerm(g), unknownId(id), iz(iz), scaleFactor(scaleFactor){}
         virtual len_t GetNumberOfNonZerosPerRow() const override { return 1; }
         virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return 1; }
@@ -39,7 +39,7 @@ namespace DREAM{
                 mat->SetElement(iz*nr+ir,iz*nr+ir,scaleFactor/dt);
             if(rhs!=nullptr)
                 for(len_t ir=0; ir<nr; ir++)
-                    rhs[iz*nr+ir] -= scaleFactor/dt;
+                    rhs[iz*nr+ir] -= xPrev[iz*nr+ir] * scaleFactor / dt;
         }
         virtual void SetVectorElements(real_t *vec, const real_t *xi) override {
             for(len_t ir=0; ir<nr; ir++)


### PR DESCRIPTION
Problem identified!

The relevant equation term defined in `IonSpeciesTransientTerm.hpp`,  used when solving

$$
\frac{\text{d}W_i}{\text{d}t}=0,
$$

had a bug in its ´SetMatrixElement` (used with the linear implicit solver). It essentially solved the discretised equation

$$
\frac{W_i(t+\Delta t) - 1}{\Delta t} = 0,
$$

rather than the correct

$$
 \frac{W_i(t+\Delta t) - W_i(t)}{\Delta t} = 0.
$$

The former obviously yielded the solution $W_i=1$. This has now been corrected!