### PR TITLE
Actually set w ( pitch-angle width factor) to zero if collision time …

### DIFF
--- a/include/DREAM/Equations/Fluid/SvenssonTransport.tcc
+++ b/include/DREAM/Equations/Fluid/SvenssonTransport.tcc
@@ -225,6 +225,7 @@ void DREAM::SvenssonTransport<T>::xiAverage(const real_t *coeffRXiP){
                 real_t w_factor;
                 if(tau_f<0 && ir==nr_f-1){
                     w_factor = 0.25;
+                    w = 0.0;
                 } else {
                     w_factor = 0.5 * w / (1.0 - exp( -2.0 * w ) );
                 }


### PR DESCRIPTION
…extrapolates to negative values at the last flux grid point