### PR TITLE
Remove CMake version warning in FindPETSc.cmake

### DIFF
--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -22,7 +22,7 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
 
-cmake_policy(VERSION 3.3)
+cmake_policy(VERSION 3.12)
 
 set(PETSC_VALID_COMPONENTS
   C


### PR DESCRIPTION
Remove CMake version warning in the ``FindPETSc.cmake`` script.