### PR TITLE
Fix bug when not using the LCFS term

### DIFF
--- a/include/DREAM/Equations/Fluid/LCFSLossRateTerm.hpp
+++ b/include/DREAM/Equations/Fluid/LCFSLossRateTerm.hpp
@@ -41,7 +41,11 @@ namespace DREAM {
         
     public:
     
-        LCFSLossRateTerm(FVM::Grid*, FVM::UnknownQuantityHandler*, FVM::Grid* /*operandGrid*/, real_t, real_t*, bool userGivenPsiEdge_t0=0, real_t PsiEdge_t0=0);
+        LCFSLossRateTerm(
+			FVM::Grid*, FVM::UnknownQuantityHandler*, FVM::Grid*
+			/*operandGrid*/, real_t, real_t*, bool userGivenPsiEdge_t0=0,
+			real_t PsiEdge_t0=0
+		);
         ~LCFSLossRateTerm();
         // USES REBUILD, SETVECTORELEMENT, SETJACOBIANBLOCK FROM PARENT CLASSES
         

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -104,7 +104,7 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         self.lcfs_loss = lcfs_loss
         self.lcfs_t_loss = np.array([0])
         self.lcfs_t_loss_r = np.array([0])
-        self.lcfs_user_input_psi = np.array([0])
+        self.lcfs_user_input_psi = False
         self.lcfs_psi_edge_t0 = np.array([0])
 
 
@@ -141,7 +141,7 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         self.verifySettingsPrescribedInitialData()
         
         
-    def setLCFSLossPsiEdget0(self, psi_edge_t0, user_input_active=1):
+    def setLCFSLossPsiEdget0(self, psi_edge_t0, user_input_active=True):
         """
         Sets the value of psi_p at the plasma edge at
         t = 0, used to determine the LCFS radial point.
@@ -300,10 +300,12 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         # Loss term
         if 'lcfs_loss' in data:
             self.lcfs_loss     = int(data['lcfs_loss'])
-            self.lcfs_user_input_psi     = int(data['lcfs_user_input_psi'])
-            self.lcfs_psi_edge_t0        = data['lcfs_psi_edge_t0']
-            self.lcfs_t_loss   = data['lcfs_t_loss']['x']
-            self.lcfs_t_loss_r = data['lcfs_t_loss']['r']
+
+            if self.lcfs_loss != LCFS_LOSS_MODE_DISABLED:
+                self.lcfs_user_input_psi     = bool(data['lcfs_user_input_psi'])
+                self.lcfs_psi_edge_t0        = data['lcfs_psi_edge_t0']
+                self.lcfs_t_loss   = data['lcfs_t_loss']['x']
+                self.lcfs_t_loss_r = data['lcfs_t_loss']['r']
 
         if 'flux' in data['compton']:
             if type(data['compton']['flux']) == dict:

--- a/src/Equations/Fluid/LCFSLossRateTerm.cpp
+++ b/src/Equations/Fluid/LCFSLossRateTerm.cpp
@@ -12,8 +12,13 @@ using namespace DREAM;
 /**
  * Constructor.
  */
-LCFSLossRateTerm::LCFSLossRateTerm(FVM::Grid *grid, FVM::UnknownQuantityHandler *unknowns, FVM::Grid *operandGrid, real_t sf, real_t* t_loss, bool userGivenPsiEdge_t0, real_t PsiEdge_t0) : 
-    RunawaySourceTerm(grid, unknowns), FVM::DiagonalComplexTerm(grid, unknowns, operandGrid), unknowns(unknowns), scaleFactor(sf), t_loss(t_loss), 
+LCFSLossRateTerm::LCFSLossRateTerm(
+	FVM::Grid *grid, FVM::UnknownQuantityHandler *unknowns,
+	FVM::Grid *operandGrid, real_t sf, real_t* t_loss,
+	bool userGivenPsiEdge_t0, real_t PsiEdge_t0
+) : RunawaySourceTerm(grid, unknowns),
+	FVM::DiagonalComplexTerm(grid, unknowns, operandGrid),
+	unknowns(unknowns), scaleFactor(sf), t_loss(t_loss), 
     userGivenPsiEdge_t0(userGivenPsiEdge_t0), psi_edge_t0(PsiEdge_t0), 
     id_psi(unknowns->GetUnknownID(OptionConstants::UQTY_POL_FLUX)) {
 
@@ -28,6 +33,8 @@ LCFSLossRateTerm::LCFSLossRateTerm(FVM::Grid *grid, FVM::UnknownQuantityHandler 
  */
 LCFSLossRateTerm::~LCFSLossRateTerm(){
     Deallocate();
+
+	delete [] this->t_loss;
 }           
 
 

--- a/src/Settings/RunawaySourceTerms.cpp
+++ b/src/Settings/RunawaySourceTerms.cpp
@@ -164,19 +164,33 @@ RunawaySourceTermHandler *SimulationGenerator::ConstructRunawaySourceTermHandler
      
     // Add LCFS loss term (add exception if (nr==1 and lcfs_mode != LCFS_LOSS_MODE_DISABLED)...)
     OptionConstants::eqterm_lcfs_loss_mode lcfs_mode = (enum OptionConstants::eqterm_lcfs_loss_mode)s->GetInteger(mod + "/lcfs_loss");
-    if (lcfs_mode != OptionConstants::EQTERM_LCFS_LOSS_MODE_DISABLED && grid->GetNr() == 1){
-        throw SettingsException(
-            "The LCFS loss term is not compatible with using only one radial grid point."
-        );
-    }
-    bool lcfs_user_input_psi = (len_t)s->GetInteger(mod + "/lcfs_user_input_psi");
-    real_t lcfs_psi_edge_t0 = s->GetReal(mod + "/lcfs_psi_edge_t0");
-    if(lcfs_mode == OptionConstants::EQTERM_LCFS_LOSS_MODE_FLUID){
-    	oqty_terms->lcfsLossRate_fluid = new LCFSLossRateTerm(grid, unknowns, fluidGrid, -1.0, LoadDataR("eqsys/n_re", grid->GetRadialGrid(), s, "lcfs_t_loss"), lcfs_user_input_psi, lcfs_psi_edge_t0);
-        rsth->AddSourceTerm(eqnSign + "n_re*lcfs_loss", oqty_terms->lcfsLossRate_fluid);
-    } else if (lcfs_mode == OptionConstants::EQTERM_LCFS_LOSS_MODE_KINETIC){
-        rsth->AddSourceTerm(eqnSign + "n_re*lcfs_loss", new LCFSLossRateTerm(grid, unknowns, runawayGrid, -1.0, LoadDataR("eqsys/n_re", grid->GetRadialGrid(), s, "lcfs_t_loss"), lcfs_user_input_psi, lcfs_psi_edge_t0));
-    }
+	if (lcfs_mode != OptionConstants::EQTERM_LCFS_LOSS_MODE_DISABLED) {
+		if (grid->GetNr() == 1){
+			throw SettingsException(
+				"The LCFS loss term is not compatible with using only one radial grid point."
+			);
+		}
+
+		bool lcfs_user_input_psi = (len_t)s->GetInteger(mod + "/lcfs_user_input_psi");
+		real_t lcfs_psi_edge_t0 = s->GetReal(mod + "/lcfs_psi_edge_t0");
+		real_t *lcfs_t_loss = LoadDataR("eqsys/n_re", grid->GetRadialGrid(), s, "lcfs_t_loss");
+
+		if(lcfs_mode == OptionConstants::EQTERM_LCFS_LOSS_MODE_FLUID){
+			oqty_terms->lcfsLossRate_fluid = new LCFSLossRateTerm(
+				grid, unknowns, fluidGrid, -1.0, lcfs_t_loss,
+				lcfs_user_input_psi, lcfs_psi_edge_t0
+			);
+			rsth->AddSourceTerm(eqnSign + "n_re*lcfs_loss", oqty_terms->lcfsLossRate_fluid);
+		} else if (lcfs_mode == OptionConstants::EQTERM_LCFS_LOSS_MODE_KINETIC){
+			rsth->AddSourceTerm(
+				eqnSign + "n_re*lcfs_loss",
+				new LCFSLossRateTerm(
+					grid, unknowns, runawayGrid, -1.0, lcfs_t_loss,
+					lcfs_user_input_psi, lcfs_psi_edge_t0
+				)
+			);
+		}
+	}
     
     
     return rsth;


### PR DESCRIPTION
A bug appeared which causes errors when loading settings from output files, and the LCFSLossRateTerm is not used in the simulation producing the output file. This commit fixes that bug.

It also fixes a number of smaller inconsistencies in the Python interface and Settings interface.