### PR TITLE
Save warnings to output file

### DIFF
--- a/include/DREAM/IO.hpp
+++ b/include/DREAM/IO.hpp
@@ -2,6 +2,7 @@
 #define _DREAM_IO_HPP
 
 #include <string>
+#include <vector>
 
 namespace DREAM {
     class IO {
@@ -24,6 +25,8 @@ namespace DREAM {
             // [Must always come last]
             MESSAGE_LAST
         } message_t;
+
+		static std::vector<std::string> emitted_warning_messages;
 
         static bool VerifyMessage(const message_t);
 

--- a/include/DREAM/IO.hpp
+++ b/include/DREAM/IO.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include "DREAM/Simulation.hpp"
 
 namespace DREAM {
     class IO {
@@ -27,6 +28,9 @@ namespace DREAM {
         } message_t;
 
 		static std::vector<std::string> emitted_warning_messages;
+		static Simulation *simulation;
+
+		static void Init(Simulation*);
 
         static bool VerifyMessage(const message_t);
 

--- a/include/DREAM/IO.tcc
+++ b/include/DREAM/IO.tcc
@@ -1,5 +1,6 @@
 
 #include <string>
+#include <vector>
 #include "FVM/config.h"
 
 namespace DREAM {
@@ -48,12 +49,22 @@ void IO::PrintWarning(const IO::message_t id, const char *msg, Args&& ... args) 
     if (!IO::VerifyMessage(id))
         return;
 
+	// Generate warning string
+	int size = std::snprintf(nullptr, 0, msg, args ...) + 1;
+	if (size <= 0)
+		return;
+	char *buf = new char[size];
+	std::snprintf(buf, size, msg, args ...);
+	std::string smsg(buf);
+
+	emitted_warning_messages.push_back(smsg);
+
 #ifdef COLOR_TERMINAL
     fputs("\x1B[1;33m[WARNING]\x1B[0m ", stderr);
 #else
     fputs("[WARNING] ", stderr);
 #endif
-    fprintf(stderr, msg, std::forward<Args>(args) ...);
+    fputs(smsg.c_str(), stderr);
     fputc('\n', stderr);
 }
 

--- a/include/DREAM/IO.tcc
+++ b/include/DREAM/IO.tcc
@@ -57,6 +57,23 @@ void IO::PrintWarning(const IO::message_t id, const char *msg, Args&& ... args) 
 	std::snprintf(buf, size, msg, args ...);
 	std::string smsg(buf);
 
+	bool prepended = false;
+	if (IO::simulation != nullptr) {
+		EquationSystem *eqsys = IO::simulation->GetEquationSystem();
+		if (eqsys != nullptr) {
+			FVM::UnknownQuantityHandler *u = eqsys->GetUnknownHandler();
+			if (u != nullptr && u->Size() > 0) {
+				smsg = "At time step " +
+					std::to_string(u->GetUnknown(0)->GetNumberOfSavedSteps()+1) +
+					": " + smsg;
+				prepended = true;
+			}
+		}
+	}
+	
+	if (!prepended)
+		smsg = "During initialization: " + smsg;
+
 	emitted_warning_messages.push_back(smsg);
 
 #ifdef COLOR_TERMINAL

--- a/include/FVM/UnknownQuantity.hpp
+++ b/include/FVM/UnknownQuantity.hpp
@@ -47,6 +47,7 @@ namespace DREAM::FVM {
         const std::string& GetDescription() const { return this->description; }
         const std::string& GetEquationDescription() const { return this->description_eqn; }
         const std::string& GetName() const { return this->name; }
+		len_t GetNumberOfSavedSteps() const { return this->data->Size(); }
 
         bool HasChanged() const { return data->HasChanged(); }
         bool HasInitialValue() const { return data->HasInitialValue(); }

--- a/py/DREAM/Output/Solver.py
+++ b/py/DREAM/Output/Solver.py
@@ -16,7 +16,10 @@ class Solver:
         """
         self.solverdata = None
         self.output = output
+        self.warnings = []
 
+        if 'warnings' in solverdata:
+            self.warnings = solverdata['warnings'][:].split(';')[:-1]
 
 
     def __contains__(self, item):

--- a/py/DREAM/interactive.py
+++ b/py/DREAM/interactive.py
@@ -56,6 +56,11 @@ def setup_interactive(do, glob):
     print(do.grid)
     who()
 
+    if len(do.solver.warnings) > 0:
+        print(f'\nThe simulation has {len(do.solver.warnings)} warnings.')
+        for w in do.solver.warnings:
+            print(f'\x1B[1;33m[WARNING]\x1B[0m {w}')
+
 
 def who():
     """

--- a/src/EquationSystem/Save.cpp
+++ b/src/EquationSystem/Save.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <softlib/SFile.h>
 #include "DREAM/EquationSystem.hpp"
+#include "DREAM/IO.hpp"
 
 
 using namespace DREAM;
@@ -53,5 +54,12 @@ void EquationSystem::SaveSolverData(SFile *sf, const string& name) {
 
 	sf->WriteString(name + "/unknowns", unkn);
 	sf->WriteString(name + "/nontrivials", nontriv);
+
+	// Save emitted warning messages
+	string warnings;
+	for (auto s : IO::emitted_warning_messages)
+		warnings += s + ";";
+
+	sf->WriteString(name + "/warnings", warnings);
 }
 

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -2,6 +2,8 @@
  * Implementation of some screen I/O helper routines.
  */
 
+#include <string>
+#include <vector>
 #include <omp.h>
 #include "DREAM/IO.hpp"
 
@@ -16,6 +18,10 @@ bool IO::message_checklist[MESSAGE_LAST] = {false};
     const std::string IO::PRINT_YES = "YES";
     const std::string IO::PRINT_NO  = "NO";
 #endif
+
+/* Vector for storing warnings emitted during the simulation. */
+std::vector<std::string> IO::emitted_warning_messages = std::vector<std::string>();
+
 
 /**
  * Print a single new-line character in the 'Info' channel.

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <omp.h>
 #include "DREAM/IO.hpp"
+#include "DREAM/Simulation.hpp"
 
 
 using namespace DREAM;
@@ -21,7 +22,15 @@ bool IO::message_checklist[MESSAGE_LAST] = {false};
 
 /* Vector for storing warnings emitted during the simulation. */
 std::vector<std::string> IO::emitted_warning_messages = std::vector<std::string>();
+Simulation *IO::simulation = nullptr;
 
+
+/**
+ * Initialize the DREAM::IO interface.
+ */
+void IO::Init(Simulation *sim) {
+	IO::simulation = sim;
+}
 
 /**
  * Print a single new-line character in the 'Info' channel.

--- a/src/OutputGeneratorSFile.cpp
+++ b/src/OutputGeneratorSFile.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <string>
+#include <DREAM/IO.hpp>
 #include "DREAM/OutputGeneratorSFile.hpp"
 #include "DREAM/Settings/Settings.hpp"
 #include "DREAM/Settings/SFile.hpp"
@@ -46,6 +47,8 @@ void OutputGeneratorSFile::Save(bool current) {
     if (close) {
         this->sf->Close();
         delete this->sf;
+
+		IO::PrintInfo("Saved output file to '%s'.", this->filename.c_str());
     }
 }
 

--- a/src/Settings/Process.cpp
+++ b/src/Settings/Process.cpp
@@ -6,6 +6,7 @@
 #include "DREAM/ADAS.hpp"
 #include "DREAM/AMJUEL.hpp"
 #include "DREAM/EquationSystem.hpp"
+#include "DREAM/IO.hpp"
 #include "DREAM/NIST.hpp"
 #include "DREAM/OutputGeneratorSFile.hpp"
 #include "DREAM/Settings/Settings.hpp"
@@ -62,6 +63,8 @@ Simulation *SimulationGenerator::ProcessSettings(Settings *s) {
     sim->SetEquationSystem(eqsys);
 
     LoadOutput(s, sim);
+
+	IO::Init(sim);
 
     return sim;
 }


### PR DESCRIPTION
This pull request addresses issue #309.

Since warnings are often printed at the start of a simulation, they can easily be missed. This pull request implements functionality to save warnings to an output file, and have the interactive Python interface display those warnings when the output file is loaded.