### PR TITLE
Fix bug in DREAM::IO

### DIFF
--- a/include/DREAM/IO.hpp
+++ b/include/DREAM/IO.hpp
@@ -31,6 +31,7 @@ namespace DREAM {
 		static Simulation *simulation;
 
 		static void Init(Simulation*);
+		static void Deinit();
 
         static bool VerifyMessage(const message_t);
 

--- a/include/DREAM/Simulation.hpp
+++ b/include/DREAM/Simulation.hpp
@@ -29,7 +29,7 @@ namespace DREAM {
         ADAS *adas;
         AMJUEL *amjuel;
         NIST *nist;
-        EquationSystem *eqsys;
+        EquationSystem *eqsys=nullptr;
 		OutputGenerator *outgen=nullptr;
 
     public:

--- a/src/EquationSystem/EquationSystem.cpp
+++ b/src/EquationSystem/EquationSystem.cpp
@@ -310,6 +310,8 @@ void EquationSystem::Solve() {
         this->solver->PrintTimings();
         this->REFluid->PrintTimings();
     }
+
+	DREAM::IO::Deinit();
 }
 
 /**

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -33,6 +33,13 @@ void IO::Init(Simulation *sim) {
 }
 
 /**
+ * De-initialize the DREAM::IO interface.
+ */
+void IO::Deinit() {
+	IO::simulation = nullptr;
+}
+
+/**
  * Print a single new-line character in the 'Info' channel.
  */
 void IO::PrintInfo() {


### PR DESCRIPTION
A bug was introduced with the merge of the functionality to save warnings to the output file. The error was due to that, with the ``savewarnings`` branch, a new static variable ``DREAM::IO::simulation`` was introduced. When running multiple simulations in ``dreampyface``, this variable was not automatically reset at the start of each new run, and so it kept pointing to an old, deallocated simulation. When a warning was then emitted before ``DREAM::IO::Init()`` had been called (which is done at the end of ``SimulationGenerator::Process()``, which sets up all objects in the simulation), ``DREAM::IO::PrintWarning()`` would try to access the old deallocated ``Simulation`` object, leading to a segmentation fault.

The solution now introduced is to de-initialize ``DREAM::IO`` after solving the equation system, i.e. to set ``DREAM::IO::simulation = nullptr``. Since this object is only used for determining in which time step a warning is emitted, is only needed during the actually time stepping process and can then safely be set to a ``nullptr`` after time stepping has finished.