### PR TITLE
Integrate kinetic activated sources in fluid mode

### DIFF
--- a/include/DREAM/Equations/Kinetic/TritiumSource.hpp
+++ b/include/DREAM/Equations/Kinetic/TritiumSource.hpp
@@ -2,6 +2,7 @@
 #define _DREAM_EQUATIONS_TRITIUM_SOURCE_HPP
 
 #include "DREAM/Equations/FluidSourceTerm.hpp"
+#include "DREAM/Equations/RunawayFluid.hpp"
 #include "DREAM/IonHandler.hpp"
 #include <limits>
 
@@ -20,10 +21,11 @@ namespace DREAM {
         real_t *sourceVec = nullptr;
         
         real_t *source;
-        real_t pc, scaleFactor;
+        real_t pLower, scaleFactor;
         len_t indT;
         
         SourceMode sourceMode;
+	RunawayFluid *REFluid;
 	
     protected:
         static real_t integrand(real_t, void * );
@@ -31,7 +33,7 @@ namespace DREAM {
         
         virtual real_t GetSourceFunctionJacobian(len_t ir, len_t i, len_t j, const len_t derivId) override;
     public:
-        TritiumSource(FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*, len_t, real_t, real_t, SourceMode sm = SOURCE_MODE_KINETIC);
+        TritiumSource(FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*, len_t, real_t, real_t, SourceMode sm = SOURCE_MODE_KINETIC, RunawayFluid* REFluid=nullptr);
         
         virtual real_t GetSourceFunction(len_t ir, len_t i, len_t j) override;
         

--- a/include/DREAM/OtherQuantityHandler.hpp
+++ b/include/DREAM/OtherQuantityHandler.hpp
@@ -68,7 +68,9 @@ namespace DREAM {
 			DREAM::ComptonSource *comptonSource_hottail=nullptr;
 			DREAM::ComptonSource *comptonSource_runaway=nullptr;
 			DREAM::ComptonSource *comptonSource_fluid=nullptr;
-			std::vector<DREAM::TritiumSource*> tritiumSource;
+			std::vector<DREAM::TritiumSource*> tritiumSource_hottail;
+			std::vector<DREAM::TritiumSource*> tritiumSource_runaway;
+			std::vector<DREAM::TritiumSource*> tritiumSource_fluid;
 			// Pitch angle advection due to time varying B
 			DREAM::TimeVaryingBTerm *f_hot_timevaryingb=nullptr;
 			DREAM::TimeVaryingBTerm *f_re_timevaryingb=nullptr;

--- a/py/DREAM/Settings/Equations/SPI.py
+++ b/py/DREAM/Settings/Equations/SPI.py
@@ -98,7 +98,7 @@ SHIFT_MODE_NEGLECT, TDrift = None, T0Drift = None, DeltaYDrift = None, RmDrift =
         self.T0Drift       = 0
         self.DeltaYDrift  = 0
         self.RmDrift       = -1
-        self.ZavgDriftArray= [0]
+        self.ZavgDriftArray= [0.]
         self.ZsDrift       = [0]
         self.isotopesDrift = [0]
 
@@ -455,7 +455,7 @@ SHIFT_MODE_NEGLECT, TDrift = None, T0Drift = None, DeltaYDrift = None, RmDrift =
             else:
                 self.nbrShiftGridCell = nbrShiftGridCell
         
-    def setShiftParamsAnalytical(self, shift = SHIFT_MODE_ANALYTICAL, TDrift=None, T0Drift=0, DeltaYDrift=0, RmDrift=-1, ZavgDriftArray=[0], ZsDrift=[0], isotopesDrift=[0], add=True):
+    def setShiftParamsAnalytical(self, shift = SHIFT_MODE_ANALYTICAL, TDrift=None, T0Drift=0, DeltaYDrift=0, RmDrift=-1, ZavgDriftArray=[0.], ZsDrift=[0], isotopesDrift=[0], add=True):
         """
         Specifies model parameters to be used for calculating the shift. Apart from the shift mode-argument, the parameters below apply to SHIFT_MODE_ANALYTICAL
         

--- a/src/Equations/Kinetic/TritiumSource.cpp
+++ b/src/Equations/Kinetic/TritiumSource.cpp
@@ -14,8 +14,9 @@ using namespace DREAM;
  * Constructor.
  */
 TritiumSource::TritiumSource(
-    FVM::Grid *kineticGrid, FVM::UnknownQuantityHandler *u, IonHandler *ions, len_t iIon, real_t pc, real_t scaleFactor, SourceMode sm
-) : FluidSourceTerm(kineticGrid, u), pc(pc), scaleFactor(scaleFactor), sourceMode(sm)
+    FVM::Grid *kineticGrid, FVM::UnknownQuantityHandler *u, IonHandler *ions, 
+    len_t iIon, real_t pLower, real_t scaleFactor, SourceMode sm, RunawayFluid *REFluid
+) : FluidSourceTerm(kineticGrid, u), pLower(pLower), scaleFactor(scaleFactor), sourceMode(sm), REFluid(REFluid)
 {
     SetName("TritiumSource");
     this->id_nT = unknowns->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
@@ -100,8 +101,8 @@ real_t TritiumSource::integrand(real_t p, void *){
  * Evaluates the constant (only grid dependent) source-shape function S(r,p)
  */
 real_t TritiumSource::EvaluateSource(len_t ir, len_t i, len_t) {
-    if(sourceMode == SOURCE_MODE_FLUID)
-        return scaleFactor*EvaluateTotalTritiumNumber(pc);
+    if(sourceMode == SOURCE_MODE_FLUID) 
+       return 0.;
     real_t tau_T = 3.888e8; // 4500 days, in seconds
 
     real_t pm = grid->GetMomentumGrid(ir)->GetP1_f(i);
@@ -130,6 +131,14 @@ real_t TritiumSource::EvaluateSource(len_t ir, len_t i, len_t) {
  * Returns the source at grid point (ir,i,j).
  */
 real_t TritiumSource::GetSourceFunction(len_t ir, len_t i, len_t j){
+    if(sourceMode == SOURCE_MODE_FLUID){
+        real_t pc = REFluid->GetEffectiveCriticalRunawayMomentum(ir);
+        if (pc == std::numeric_limits<real_t>::infinity())
+            return 0.;
+        if (pc < pLower)
+            pc = pLower;
+        return scaleFactor * EvaluateTotalTritiumNumber(pc);
+    }
     len_t offset = 0;
     for(len_t iir = 0; iir < ir; iir++)
         offset += n1[iir]*n2[iir];

--- a/src/Settings/Equations/f_hot.cpp
+++ b/src/Settings/Equations/f_hot.cpp
@@ -150,8 +150,8 @@ void SimulationGenerator::ConstructEquation_f_hot_kineq(
         FVM::Operator *Op_tritium = new FVM::Operator(hottailGrid);    
         const len_t *ti = eqsys->GetIonHandler()->GetTritiumIndices();
         for(len_t iT=0; iT<eqsys->GetIonHandler()->GetNTritiumIndices(); iT++){
-            oqty_terms->tritiumSource.push_back(new TritiumSource(hottailGrid, eqsys->GetUnknownHandler(), eqsys->GetIonHandler(), ti[iT], 0., -1.0));
-            Op_tritium->AddTerm(oqty_terms->tritiumSource[iT]);
+            oqty_terms->tritiumSource_hottail.push_back(new TritiumSource(hottailGrid, eqsys->GetUnknownHandler(), eqsys->GetIonHandler(), ti[iT], 0., -1.0));
+            Op_tritium->AddTerm(oqty_terms->tritiumSource_hottail[iT]);
         }
         len_t id_n_i = eqsys->GetUnknownHandler()->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
         eqsys->SetOperator(id_f_hot, id_n_i, Op_tritium);


### PR DESCRIPTION
If you use the fluid activated sources without any kinetic grids, the kinetic sources are now integrated. We get the same as rates as with the already implemented fluid sources. 

There is a small difference for the tritium source between the fluid and integrated kinetic sources, but the integrated kinetic source agrees with the theory (when integrating the formula by Martin-Solis from other.fluid.pCrit), which suggests that it is the Taylor expansion used in the fluid source that gives the discrepancy. Interestingly, the theory agrees better with the fluid source when instead integrating from other.fluid.pStar, but I checked several times and this should be wrong. 