### PR TITLE
Fix issue #345

### DIFF
--- a/include/DREAM/Equations/Fluid/RadiatedPowerTerm.hpp
+++ b/include/DREAM/Equations/Fluid/RadiatedPowerTerm.hpp
@@ -30,6 +30,10 @@ namespace DREAM {
             bremsRel2;
             
         bool includePRB = true;
+
+		real_t *Prad;
+		real_t *Pion;
+
     protected:
         virtual len_t GetNumberOfWeightsElements() override 
             {return ionHandler->GetNzs() * grid->GetNCells();}
@@ -40,9 +44,21 @@ namespace DREAM {
         void SetWeights(const real_t*, real_t *w=nullptr);
         void SetDiffWeights(len_t derivId, len_t nMultiples, const real_t*);
 
+
     public:
         RadiatedPowerTerm(FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*, ADAS*, NIST*, AMJUEL*,enum OptionConstants::ion_opacity_mode*, bool);
-    };
+		~RadiatedPowerTerm();
+
+
+		const real_t* GetRadiationPower() const
+			{return Prad;}
+		const real_t* GetRateOfChangeBindingEnergy() const
+			{return Pion;}
+   };
+
+
+
+
 }
 
 

--- a/include/DREAM/OtherQuantityHandler.hpp
+++ b/include/DREAM/OtherQuantityHandler.hpp
@@ -43,6 +43,7 @@ namespace DREAM {
         struct eqn_terms {
             // Terms in the heat equation:
             DREAM::RadiatedPowerTerm *T_cold_radiation=nullptr;
+			DREAM::RadiatedPowerTerm *T_cold_binding_energy=nullptr;
             DREAM::OhmicHeatingTerm *T_cold_ohmic=nullptr;
             DREAM::CollisionalEnergyTransferKineticTerm *T_cold_fhot_coll=nullptr;
             DREAM::CollisionalEnergyTransferKineticTerm *T_cold_fre_coll=nullptr;

--- a/py/DREAM/Settings/OtherQuantities.py
+++ b/py/DREAM/Settings/OtherQuantities.py
@@ -31,6 +31,7 @@ class OtherQuantities:
         'fluid/Tcold_fre_coll',
         'fluid/Tcold_transport',
         'fluid/Tcold_radiation',
+        'fluid/Tcold_binding_energy',
 #        'fluid/Tcold_radiationFromNuS',
         'fluid/Tcold_ion_coll',
         'fluid/W_hot',

--- a/src/OtherQuantityHandler.cpp
+++ b/src/OtherQuantityHandler.cpp
@@ -479,12 +479,16 @@ void OtherQuantityHandler::DefineQuantities() {
         );
     if (tracked_terms->T_cold_radiation != nullptr)
         DEF_FL("fluid/Tcold_radiation", "Radiated power density [J s^-1 m^-3]",
-            real_t *ncold = this->unknowns->GetUnknownData(this->id_ncold);
-            real_t *vec = qd->StoreEmpty();
-            for(len_t ir=0; ir<this->fluidGrid->GetNr(); ir++)
-                vec[ir] = 0;
-            this->tracked_terms->T_cold_radiation->SetVectorElements(vec, ncold);
+            const real_t *Prad = this->tracked_terms->T_cold_radiation->GetRadiationPower();
+			qd->Store(Prad);
+        );	
+    if (tracked_terms->T_cold_radiation != nullptr)
+        DEF_FL("fluid/Tcold_binding_energy", "Rate of change in potential energy due to ionisation/recombination [J s^-1 m^-3]",
+            const real_t *Pion = this->tracked_terms->T_cold_radiation->GetRateOfChangeBindingEnergy();
+			qd->Store(Pion);
         );
+
+
     if (tracked_terms->T_cold_ion_coll != nullptr)
         DEF_FL("fluid/Tcold_ion_coll", "Collisional heating power density by ions [J s^-1 m^-3]",
             real_t *vec = qd->StoreEmpty();


### PR DESCRIPTION
Separates the rather misleadingly named OtherQuantity ``Tcold_radiation`` into two terms, namely the radiated power density under the same name ``Tcold_radiation`` and the rate of change in potential energy due to ionisation/recombination under ``Tcold_binding_energy`` (also a power density quantity).