### PR TITLE
Add 'energyloss_T_cold' in power balance plot

### DIFF
--- a/py/DREAM/Output/Temperature.py
+++ b/py/DREAM/Output/Temperature.py
@@ -37,6 +37,11 @@ class Temperature(FluidQuantity):
 
             labels.append(o[6:].replace(r'_', r'\_'))
 
+        if integrate and 'energyloss_T_cold' in self.output.other.scalar.keys():
+            o = self.output.other.scalar.energyloss_T_cold
+            ax = o.plot(ax=ax, show=show)
+            labels.append(o.name.replace(r'_', r'\_'))
+
         plt.legend(labels)
 
         if show:


### PR DESCRIPTION
This pull request adds ``scalar/energyloss_T_cold`` to the plot produced by ``T_cold.plotEnergyBalance()`` (i.e. the power balance for the entire (spatially integrated) plasma).