### PR TITLE
Adaptive current gradient-driven transport

### DIFF
--- a/doc/notes/HyperresistivityFromPerturbation.tex
+++ b/doc/notes/HyperresistivityFromPerturbation.tex
@@ -1,0 +1,92 @@
+\documentclass{notes}
+
+\usepackage[colorlinks=true]{hyperref}
+\usepackage[
+	backend=biber,
+	sorting=none,
+	style=authoryear,
+	citestyle=authoryear
+]{biblatex}
+\addbibresource{ref.bib}
+
+\newcommand{\citep}[1]{(\citename{#1}{author} \citefield{#1}{year})}
+
+\title{Hyperresistivity from magnetic perturbation}
+\author{Mathias Hoppe}
+\date{2024-11-18}
+
+\begin{document}
+	\maketitle
+
+	The thermal quench (TQ) of a disruption is typically associated with a major
+	transport event. In \DREAM, we can apply a number of different types of
+	transport to model such an event. Often we combine heat, ion and runaway
+	transport with a hyperdiffusive current density transport. Whereas the
+	strength of the first three is determined by a parameter $\delta B/B$ in
+	\DREAM, the latter uses a hyperresistivity parameter $\Lambda$. In reality,
+	the two are closely connected and so should preferably be connected in
+	simulations as well. In this document, we use \citep{Boozer2017} to
+	relate $\Lambda$ to the perturbation strength $\delta B/B$.
+
+	\cite{Boozer2017} gives the hyperresistivity parameter $\Lambda$ as
+	\begin{equation}
+		\Lambda =
+			\frac{1}{144}
+			\frac{\mu_0}{4\pi}
+			\frac{V_{\rm A}\psi_{\rm t}^2}{N_{\rm t}},
+	\end{equation}
+	where $V_{\rm A}=B/\sqrt{\mu_0\rho}$ is the Alfvén velocity,
+	$\psi_{\rm t}$ is the toroidal flux, and $N_{\rm t}$ the number of toroidal
+	turns needed for a stochastic field line to travel across the plasma. The
+	parameter $N_{\rm t}$ can be expressed in terms of $\delta B/B$ by noting
+	that $N_{\rm t} = L/2\pi R_{\rm m}$, where $L$ is the typical distance
+	travelled by a runaway electron before escaping the plasma. The parameter
+	$L=c\tau_{\rm re}$ can in turn be expressed in terms of the runaway
+	diffusion coefficient $D_{\rm re}$ via the scaling relation
+	$\tau_{\rm re}\sim a^2/D_{\rm re}$, where $a$ denotes the plasma minor
+	radius. With Rechester-Rosenbluth transport, the diffusion coefficient is
+	given by
+	\begin{equation}
+		D_{\rm re} = \pi qR_{\rm m}c\left(\frac{\delta B}{B}\right)^2.
+	\end{equation}
+	Hence,
+	\begin{equation}
+		N_{\rm t} = \frac{c a^2}{2\pi R_{\rm m} D_{\rm re}} =
+			\frac{a^2}{2\pi^2 q R_{\rm m}^2}\left(
+				\frac{B}{\delta B}
+			\right)^2,
+	\end{equation}
+	and the hyperresistivity parameter becomes
+	\begin{equation}\label{eq:Lambda}
+		\Lambda =
+			\frac{1}{144}
+			\frac{\mu_0}{4\pi}
+			V_{\rm A}\psi_{\rm t}^2
+			\frac{2\pi^2 qR_{\rm m}^2}{a^2}\left(
+				\frac{\delta B}{B}
+			\right)^2 =
+			%
+			\frac{\pi \mu_0 qR_{\rm m}^2 V_{\rm A}\psi_{\rm t}^2}{144a^2}
+			\left(
+				\frac{\delta B}{B}
+			\right)^2.
+	\end{equation}
+
+	In \DREAM, we also need to evaluate the jacobian matrix for the equation
+	system, and so we must evaluate the appropriate derivates of
+	equation~\eqref{eq:Lambda}. The only unknown quantity appearing in the
+	expression~\eqref{eq:Lambda} is $n_i=\sum_jn_i^{(j)}$, through $V_{\rm A}$,
+	(when taking $q\equiv 1$). The derivative of $\Lambda$ w.r.t.\ each ion
+	charge state density is
+	\begin{equation}
+		\frac{\partial\Lambda}{\partial n_i^{(j)}} =
+			\frac{\Lambda}{V_{\rm A}}\frac{\partial V_{\rm A}}{\partial n_i^{(j)}}
+		=
+		-\frac{\Lambda}{2V_{\rm A}}\frac{B}{\sqrt{\mu_0}\left(n_i^{(j)}\right)^{3/2}}
+		=
+		-\frac{\Lambda}{2n_i^{(j)}}.
+	\end{equation}
+
+	\addcontentsline{toc}{section}{References}
+	\printbibliography
+\end{document}

--- a/doc/notes/HyperresistivityFromPerturbation.tex
+++ b/doc/notes/HyperresistivityFromPerturbation.tex
@@ -33,16 +33,17 @@
 		\Lambda =
 			\frac{1}{144}
 			\frac{\mu_0}{4\pi}
-			\frac{V_{\rm A}\psi_{\rm t}^2}{N_{\rm t}},
+			\frac{V_{\rm A}\Psi_{\rm t}^2}{N_{\rm t}},
 	\end{equation}
 	where $V_{\rm A}=B/\sqrt{\mu_0\rho}$ is the Alfvén velocity,
-	$\psi_{\rm t}$ is the toroidal flux, and $N_{\rm t}$ the number of toroidal
-	turns needed for a stochastic field line to travel across the plasma. The
-	parameter $N_{\rm t}$ can be expressed in terms of $\delta B/B$ by noting
-	that $N_{\rm t} = L/2\pi R_{\rm m}$, where $L$ is the typical distance
-	travelled by a runaway electron before escaping the plasma. The parameter
-	$L=c\tau_{\rm re}$ can in turn be expressed in terms of the runaway
-	diffusion coefficient $D_{\rm re}$ via the scaling relation
+	$\Psi_{\rm t}$ is the total enclosed toroidal flux (equal to the toroidal
+	flux at the edge $\psi_{\rm t}(r=a)$), and $N_{\rm t}$ the number of
+	toroidal turns needed for a stochastic field line to travel across the
+	plasma. The parameter $N_{\rm t}$ can be expressed in terms of $\delta B/B$
+	by noting that $N_{\rm t} = L/2\pi R_{\rm m}$, where $L$ is the typical
+	distance travelled by a runaway electron before escaping the plasma. The
+	parameter $L=c\tau_{\rm re}$ can in turn be expressed in terms of the
+	runaway diffusion coefficient $D_{\rm re}$ via the scaling relation
 	$\tau_{\rm re}\sim a^2/D_{\rm re}$, where $a$ denotes the plasma minor
 	radius. With Rechester-Rosenbluth transport, the diffusion coefficient is
 	given by

--- a/doc/notes/Makefile
+++ b/doc/notes/Makefile
@@ -3,7 +3,7 @@ TEX=latexmk
 TEXF=-pdf -pdflatex="pdflatex" -outdir="pdf"
 BIB=biber
 
-all: adaptive_timestep ampere_faraday charge_states discretisation dreicer frozen-current heat-transport kinionz_approx magnetic_compression psi0psi1evaluation SPIcoordinates SPIDeltaSource SvenssonTransport theory trappedbc
+all: adaptive_timestep ampere_faraday charge_states discretisation dreicer frozen-current heat-transport kinionz_approx magnetic_compression psi0psi1evaluation RunawayTransportRechesterRosenbluth SPIcoordinates SPIDeltaSource SvenssonTransport theory trappedbc
 
 adaptive_timestep: adaptive_timestep.pdf
 
@@ -24,6 +24,8 @@ kinioniz_approx: kinioniz_approx.pdf
 magnetic_compression: magnetic_compression.pdf
 
 psi0psi1evaluation: psi0psi1evaluation.pdf
+
+RunawayTransportRechesterRosenbluth: RunawayTransportRechesterRosenbluth.pdf
 
 SPIcoordinates: SPIcoordinates.pdf
 

--- a/doc/notes/Makefile
+++ b/doc/notes/Makefile
@@ -3,7 +3,7 @@ TEX=latexmk
 TEXF=-pdf -pdflatex="pdflatex" -outdir="pdf"
 BIB=biber
 
-all: adaptive_timestep ampere_faraday charge_states discretisation dreicer frozen-current heat-transport HyperresistivityFromPerturbation kinionz_approx magnetic_compression psi0psi1evaluation RunawayTransportRechesterRosenbluth SPIcoordinates SPIDeltaSource SvenssonTransport theory trappedbc
+all: adaptive_timestep ampere_faraday charge_states discretisation dreicer frozen-current heat-transport HyperresistivityFromPerturbation kinioniz_approx magnetic_compression psi0psi1evaluation RunawayTransportRechesterRosenbluth SPIcoordinates SPIDeltaSource SvenssonTransport theory trappedbc
 
 adaptive_timestep: adaptive_timestep.pdf
 

--- a/doc/notes/Makefile
+++ b/doc/notes/Makefile
@@ -3,7 +3,7 @@ TEX=latexmk
 TEXF=-pdf -pdflatex="pdflatex" -outdir="pdf"
 BIB=biber
 
-all: adaptive_timestep ampere_faraday charge_states discretisation dreicer frozen-current heat-transport kinionz_approx magnetic_compression psi0psi1evaluation RunawayTransportRechesterRosenbluth SPIcoordinates SPIDeltaSource SvenssonTransport theory trappedbc
+all: adaptive_timestep ampere_faraday charge_states discretisation dreicer frozen-current heat-transport HyperresistivityFromPerturbation kinionz_approx magnetic_compression psi0psi1evaluation RunawayTransportRechesterRosenbluth SPIcoordinates SPIDeltaSource SvenssonTransport theory trappedbc
 
 adaptive_timestep: adaptive_timestep.pdf
 
@@ -18,6 +18,8 @@ dreicer: dreicer.pdf
 frozen-current: frozen-current.pdf
 
 heat-transport: heat-transport.pdf
+
+HyperresistivityFromPerturbation: HyperresistivityFromPerturbation.pdf
 
 kinioniz_approx: kinioniz_approx.pdf
 

--- a/doc/notes/RunawayTransportRechesterRosenbluth.tex
+++ b/doc/notes/RunawayTransportRechesterRosenbluth.tex
@@ -1,0 +1,124 @@
+\documentclass{notes}
+
+\title{Rechester-Rosenbluth-like transport for fluid runaways}
+\author{Mathias Hoppe}
+\date{2024-11-05}
+
+\newcommand{\Vp}{\mathcal{V}'}
+
+\begin{document}
+	\maketitle
+
+	Runaway transport in ergodic magnetic fields can be treated using the
+	Rechester-Rosenbluth model. This can already be done in \DREAM\ when the
+	runaways are treated kinetically. For fluid runaways, however, no model
+	is currently implemented in the code. In this document, we derive a
+	Rechester-Rosenbluth transport term for the runaway electron density
+	evolution equation.
+
+	\section*{Derivation}
+	The Rechester-Rosenbluth model prescribes a diffusion coefficient
+	\begin{equation}
+		\left\{D_{rr}\right\} = \pi q R_{\rm m}\left(
+			\frac{\delta B}{B}
+		\right)^2
+		v\left|\xi_0\right|
+		\left\{\frac{\xi}{\xi_0}\right\},
+	\end{equation}
+	where $q$ is the safety factor, $R_{\rm m}$ the plasma major radius,
+	$\delta B/B$ the magnetic perturbation magnitude, $v_\parallel$ the parallel
+	speed of the electron, and $\mathcal{H}$ a step function defined such that
+	\begin{equation}
+		\mathcal{H}\left(\xi_0\right) =
+		\begin{cases}
+			1, \quad &\left|\xi_0\right| > \xi_{\rm T}\\
+			0, \quad &\left|\xi_0\right|\leq \xi_{\rm T}
+		\end{cases}.
+	\end{equation}
+	The corresponding operator for the kinetic equation is
+	\begin{equation}\label{eq:dfre}
+		\frac{\partial f}{\partial t} =
+			\frac{1}{\Vp}\frac{\partial}{\partial r}\left(
+				\Vp \left\{D_{rr}\right\}\frac{\partial f}{\partial r}
+			\right),
+	\end{equation}
+	where $f$ is the distribution function. To obtain a transport operator for
+	the evolution equation of the runaway density, $n_{\rm re}$, we first assume
+	that $f$ describes only the runaway electrons, and that all runaway
+	electrons have momentum $p=p_{\rm re}$ (in normalized units) and pitch
+	$\xi_0=1$. Mathematically, $f$ then takes the form
+	\begin{equation}
+		f\equiv f_{\rm re}\left(p,\xi_0\right) =
+			\frac{V'}{\Vp}n_{\rm re}\delta\left(p-p_{\rm re}\right)
+				\delta\left(\xi_0-1\right).
+	\end{equation}
+	With $n_{\rm re}$ defined as the density moment of $f_{\rm re}$, we can then
+	find the time variation of $n_{\rm re}$ from equation~\eqref{eq:dfre} as
+	\begin{equation}
+		\int_0^\infty\dd p\int_{-1}^1\dd\xi_0\,\frac{\Vp}{V'}\frac{\partial f_{\rm re}}{\partial t} =
+		\int_0^\infty\dd p\int_{-1}^1\dd\xi_0\,\frac{1}{V'}\frac{\partial}{\partial r}\left(
+			\Vp \left\{D_{rr}\right\}\frac{\partial f_{\rm re}}{\partial r}
+		\right).
+	\end{equation}
+	On the LHS we can use the definition of $n_{\rm re}$ and obtain a partial
+	time derivative on $n_{\rm re}$. The RHS can in turn be re-ordered as
+	follows:
+	\begin{equation}\label{eq:momentRHS}
+		\begin{gathered}
+			\int_0^\infty\dd p\int_{-1}^1\dd\xi_0\,\frac{1}{V'}\frac{\partial}{\partial r}\left(
+				\Vp \left\{D_{rr}\right\}\frac{\partial f_{\rm re}}{\partial r}
+			\right) =
+			%
+			\frac{1}{V'}\frac{\partial}{\partial r}\left(
+				\int_0^\infty\dd p\int_{-1}^1\dd\xi_0\,
+				\Vp\left\{ D_{rr} \right\} \frac{\partial f_{\rm re}}{\partial r}
+			\right) =\\
+			%
+			=
+			\frac{1}{V'}\frac{\partial}{\partial r}\left[
+				\pi q R_{\rm m}\left(
+					\frac{\delta B}{B}
+				\right)^2
+				\int_0^\infty\dd p\int_{-1}^1\dd\xi_0\,
+				\Vp \frac{cp\left|\xi_0\right|}{\sqrt{1+p^2}}
+				\left\{\frac{\xi}{\xi_0}\right\}
+				\frac{\partial}{\partial r}\left(
+					\frac{V'}{\Vp}
+					n_{\rm re}
+					\delta\left(p-p_{\rm re}\right)
+					\delta\left(\xi_0-1\right)
+				\right)
+			\right].
+		\end{gathered}
+	\end{equation}
+	Before proceeding, we note that since
+	\begin{equation}
+		\xi = \pm\sqrt{1 - \frac{B}{B_{\rm min}}\left(1-\xi_0^2\right)},
+	\end{equation}
+	which for $\xi_0=1$ is identically $\xi=1$, the $\xi_0$ delta function
+	causes the factor in the bounce average to be one, so that the entire bounce
+	average evaluates to one. Allowing the delta functions to act on the other
+	factors, we find that
+	\begin{equation}
+		\eqref{eq:momentRHS} =
+			\frac{1}{V'}\frac{\partial}{\partial r}\left[
+				V'\pi q R_{\rm m}
+				\left(\frac{\delta B}{B}\right)^2
+				v_{\rm re}
+				\frac{\partial n_{\rm re}}{\partial r}
+			\right],
+	\end{equation}
+	where $v_{\rm re}=cp_{\rm re}/\sqrt{1+p_{\rm re}^2}\approx c$. We therefore
+	find that the runaway electron transport term becomes
+	\begin{equation}
+		\frac{\partial n_{\rm re}}{\partial t} =
+			\frac{1}{V'}\frac{\partial}{\partial r}\left[
+				V' D_{rr}^{(n)} \frac{\partial n_{\rm re}}{\partial r}
+			\right],
+	\end{equation}
+	with the diffusion coefficient
+	\begin{equation}
+		D_{rr}^{(n)} =
+			\pi q R_{\rm m}c\left(\frac{\delta B}{B}\right)^2.
+	\end{equation}
+\end{document}

--- a/doc/notes/ref.bib
+++ b/doc/notes/ref.bib
@@ -1,4 +1,14 @@
 
+@article {Boozer2017,
+    title = {Pivotal issues on relativistic electrons in ITER},
+    author = {A. H. Boozer},
+    journal = {Nuclear Fusion},
+    volume = {58},
+    pages = {036006},
+    issue = {3},
+    year = {2017},
+    doi = {10.1088/1741-4326/aaa1db}
+}
 @article {Daniel2019,
     title = {A fully implicit, scalable, conservative nonlinear relativisticFokker-Planck 0D-2P solver for runaway electrons},
     authors = {Daniel, Don and Taitano, William T. and Chac\'on, Luis},
@@ -17,4 +27,14 @@
     doi = "10.1016/j.cpc.2018.03.004",
     author = "E.J. du Toit and M.R. O’Brien and R.G.L. Vann",
     keywords = "Advection–diffusion, Fokker–Planck equation, Low-order positivity-preserving scheme"
+}
+@article {Nardon2023,
+    title = {On the origin of the plasma current spike during a tokamak disruption and its relation with magnetic stochasticity},
+    author = {E. Nardon and K. Särkimäki and F. Artola and S. Sadouni and t. J. team and J. Contributors},
+    journal = {Nuclear Fusion},
+    volume = {63},
+    pages = {056011},
+    issue = {5},
+	year = {2023},
+    doi = {10.1088/1741-4326/acc417}
 }

--- a/doc/notes/theory.tex
+++ b/doc/notes/theory.tex
@@ -1719,7 +1719,7 @@ Furthermore, Boozer gives [Pivotal issues..., Boozer, NF 58 (2018)]
 \begin{align}
 \Lambda = \frac{1}{144} \frac{\mu_0}{4\pi}\frac{V_A \Psi_t^2}{N_t},
 \end{align}
-where $V_A$ is the Alfven speed and the number of toroidal transits $N_t$ required for a magnetic field line to cover a stochastic region is [Theory of Tokamak Disruptions, Boozer PoP 19 (2012)]
+where $V_A$ is the Alfven speed, $\Psi_t$ is the total enclosed toroidal flux ($\Psi_t = \psi_t(r=a)$) and the number of toroidal transits $N_t$ required for a magnetic field line to cover a stochastic region is [Theory of Tokamak Disruptions, Boozer PoP 19 (2012)]
 \begin{align}
 \frac{1}{N_t} \sim \left(\frac{2\pi R_0}{\Delta r}\right)^2 q \left(\frac{\delta B}{B}\right)^2,
 \end{align}

--- a/doc/notes/theory.tex
+++ b/doc/notes/theory.tex
@@ -1717,7 +1717,7 @@ and finally
 \end{align}
 Furthermore, Boozer gives [Pivotal issues..., Boozer, NF 58 (2018)]
 \begin{align}
-\Lambda = \frac{1}{144} \frac{\mu_0}{4\pi}\frac{V_A \Psi_t^2}{N_t},
+\Lambda = \frac{1}{288} \frac{\mu_0}{4\pi}\frac{V_A \Psi_t^2}{N_t},
 \end{align}
 where $V_A$ is the Alfven speed, $\Psi_t$ is the total enclosed toroidal flux ($\Psi_t = \psi_t(r=a)$) and the number of toroidal transits $N_t$ required for a magnetic field line to cover a stochastic region is [Theory of Tokamak Disruptions, Boozer PoP 19 (2012)]
 \begin{align}

--- a/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
+++ b/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
@@ -1007,9 +1007,27 @@ Rechester-Rosenbluth diffusion operator is used, so that the user specifies the
 desired magnetic perturbation strength :math:`\delta B/B`.
 
 When the current density gradient exceeds the prescribed value,
-``grad_j_tot_max``, all transport operators are enabled until the current
-gradient is restored, or for at least ``min_duration`` seconds. After this, the
-transport coefficients are set to zero again.
+``grad_j_tot_max`` or ``grad_j_tot_max_norm``, all transport operators are
+enabled until the current gradient is restored, or for at least ``min_duration``
+seconds. After this, the transport coefficients are set to zero again.
+
+.. note::
+
+   The option ``grad_j_tot_max`` sets the absolute value of the current density
+   gradient threshold, while ``grad_j_tot_max_norm`` sets the value normalized
+   to the average value of ``j_tot`` and minor radius. Specifically, we have
+
+   .. math::
+
+      \text{grad_j_tot_max_norm} = \frac{a}{\left\langle j_{\rm tot}\right\rangle}\frac{\partial j_{\rm tot}}{\partial r}
+   
+   where
+
+   .. math::
+
+      \left\langle j_{\rm tot} \right\rangle = \frac{1}{V'}\int_0^a \mathrm{d}r\,V' j_{\rm tot}.
+
+   and :math:`a` is the plasma minor radius.
 
 Example
 *******
@@ -1023,6 +1041,8 @@ The adaptive MHD-like transport can either be set using the unified interface:
    ...
    # Maximum allowed gradient (dj/dr) in j_tot
    grad_j_tot_max = 3e6 # A/m^2
+   # ...or
+   grad_j_tot_max_norm = 10
    # Minimum duration of the transport event
    min_duration = 0.5e-3 # s
    # Magnetic perturbation amplitude (for n_re and W_cold transport)
@@ -1031,9 +1051,18 @@ The adaptive MHD-like transport can either be set using the unified interface:
    Lambda0 = 4e-3
 
    ds.eqsys.n_re.setAdaptiveMHDLikeTransport(
-       grad_j_tot_max=grad_j_tot_max, min_duration=min_duration,
-       dBB0=dBB0, Lambda0=Lambda0
+       dBB0=dBB0, Lambda0=Lambda0,
+       grad_j_tot_max=grad_j_tot_max,
+       min_duration=min_duration,
    )
+
+   # ...or with the normalized gradient instead:
+   ds.eqsys.n_re.setAdaptiveMHDLikeTransport(
+       dBB0=dBB0, Lambda0=Lambda0,
+       grad_j_tot_max_norm=grad_j_tot_max_norm,
+       min_duration=min_duration,
+   )
+
 
 Alternatively, the transport can be set separately for each quantity:
 

--- a/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
+++ b/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
@@ -988,8 +988,75 @@ unstable simulations, one may want to adjust the maximum diffusion coefficient:
        Ip_presc=Ip, D_I_max=200
    )
 
+Adaptive MHD-like transport
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+During the current quench of a disruption, ohmic current spikes may arise which
+heat the plasma locally and drive further ohmic current (as identified
+originally by
+`Putvinski et al (1997) <https://doi.org/10.1016/S0022-3115(97)80056-6>`_). Such
+solutions are generally undesirable, as in reality they would drive MHD 
+instabilities which rapidly destroy them.
 
+To emulate this behaviour also in DREAM, where MHD instabilities are otherwise
+not accounted for, a module is available which enables three types of transport
+when the total current density gradient :math:`j_{\rm tot}` exceeds a prescribed
+value: runaway density (:math:`n_{\rm re}`) transport, heat
+(:math:`W_{\rm cold}`) transport, and hyper-resistive diffusion
+(:math:`\psi_{\rm p}`). For :math:`n_{\rm re}` and :math:`W_{\rm cold}`, the
+Rechester-Rosenbluth diffusion operator is used, so that the user specifies the
+desired magnetic perturbation strength :math:`\delta B/B`.
 
+When the current density gradient exceeds the prescribed value,
+``grad_j_tot_max``, all transport operators are enabled until the current
+gradient is restored, or for at least ``min_duration`` seconds. After this, the
+transport coefficients are set to zero again.
+
+Example
+*******
+The adaptive MHD-like transport can either be set using the unified interface:
+
+.. code-block:: python
+
+   from DREAM import DREAMSettings
+
+   ds = DREAMSettings()
+   ...
+   # Maximum allowed gradient (dj/dr) in j_tot
+   grad_j_tot_max = 3e6 # A/m^2
+   # Minimum duration of the transport event
+   min_duration = 0.5e-3 # s
+   # Magnetic perturbation amplitude (for n_re and W_cold transport)
+   dBB0 = 1e-3
+   # Hyper-resistive diffusion coefficient
+   Lambda0 = 4e-3
+
+   ds.eqsys.n_re.setAdaptiveMHDLikeTransport(
+       grad_j_tot_max=grad_j_tot_max, min_duration=min_duration,
+       dBB0=dBB0, Lambda0=Lambda0
+   )
+
+Alternatively, the transport can be set separately for each quantity:
+
+.. code-block:: python
+
+   ...
+   # MHD-like hyper-resistive diffusion
+   ds.eqsys.psi_p.setHyperresistivityAdaptive(
+       grad_j_tot_max=grad_j_tot_max, Lambda0=Lambda0,
+       min_duration=min_duration
+   )
+
+   # MHD-like RE transport
+   ds.eqsys.n_re.transport.setMHDLikeRechesterRosenbluth(
+       dBB0=dBB0, grad_j_tot_max=grad_j_tot_max,
+       min_duration=min_duration
+   )
+
+   # MHD-like heat transport
+   ds.eqsys.T_cold.transport.setMHDLikeRechesterRosenbluth(
+       dBB0=dBB0, grad_j_tot_max=grad_j_tot_max,
+       min_duration=min_duration
+   )
 
 Class documentation
 -------------------

--- a/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
+++ b/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
@@ -1025,7 +1025,7 @@ seconds. After this, the transport coefficients are set to zero again.
 
    .. math::
 
-      \left\langle j_{\rm tot} \right\rangle = \frac{1}{V'}\int_0^a \mathrm{d}r\,V' j_{\rm tot}.
+      \left\langle j_{\rm tot} \right\rangle = \frac{1}{a}\int_0^a \mathrm{d}r\,j_{\rm tot}.
 
    and :math:`a` is the plasma minor radius.
 

--- a/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
+++ b/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
@@ -1002,14 +1002,17 @@ not accounted for, a module is available which enables three types of transport
 when the total current density gradient :math:`j_{\rm tot}` exceeds a prescribed
 value: runaway density (:math:`n_{\rm re}`) transport, heat
 (:math:`W_{\rm cold}`) transport, and hyper-resistive diffusion
-(:math:`\psi_{\rm p}`). For :math:`n_{\rm re}` and :math:`W_{\rm cold}`, the
-Rechester-Rosenbluth diffusion operator is used, so that the user specifies the
-desired magnetic perturbation strength :math:`\delta B/B`.
+(:math:`\psi_{\rm p}`). All operators are based on the Rechester-Rosenbluth
+transport model, and so the user must specify the desired magnetic perturbation
+strength :math:`\delta B/B`.
 
 When the current density gradient exceeds the prescribed value,
 ``grad_j_tot_max`` or ``grad_j_tot_max_norm``, all transport operators are
-enabled until the current gradient is restored, or for at least ``min_duration``
-seconds. After this, the transport coefficients are set to zero again.
+enabled until the current gradient is restored to user-prescribed level
+(90% of the original value by default). After this, the transport coefficients
+are set to zero again. The transport can either be applied to the full radial
+extent of the plasma, or just to a small region around the spike. This latter
+option is obtained by setting ``localized=True``.
 
 .. note::
 
@@ -1043,24 +1046,26 @@ The adaptive MHD-like transport can either be set using the unified interface:
    grad_j_tot_max = 3e6 # A/m^2
    # ...or
    grad_j_tot_max_norm = 10
-   # Minimum duration of the transport event
-   min_duration = 0.5e-3 # s
-   # Magnetic perturbation amplitude (for n_re and W_cold transport)
+   # Fraction of grad_j to reduce gradient to
+   suppression_level = 0.92
+   # Magnetic perturbation amplitude
    dBB0 = 1e-3
-   # Hyper-resistive diffusion coefficient
-   Lambda0 = 4e-3
+   # Localized transport around the spike?
+   localized=False
 
    ds.eqsys.n_re.setAdaptiveMHDLikeTransport(
-       dBB0=dBB0, Lambda0=Lambda0,
+       dBB0=dBB0,
        grad_j_tot_max=grad_j_tot_max,
-       min_duration=min_duration,
+       suppression_level=suppression_level,
+       localized=localized
    )
 
    # ...or with the normalized gradient instead:
    ds.eqsys.n_re.setAdaptiveMHDLikeTransport(
-       dBB0=dBB0, Lambda0=Lambda0,
+       dBB0=dBB0,
        grad_j_tot_max_norm=grad_j_tot_max_norm,
-       min_duration=min_duration,
+       suppression_level=suppression_level,
+       localized=localized
    )
 
 
@@ -1071,20 +1076,23 @@ Alternatively, the transport can be set separately for each quantity:
    ...
    # MHD-like hyper-resistive diffusion
    ds.eqsys.psi_p.setHyperresistivityAdaptive(
-       grad_j_tot_max=grad_j_tot_max, Lambda0=Lambda0,
-       min_duration=min_duration
+       dBB0=dBB0, grad_j_tot_max=grad_j_tot_max,
+       suppression_level=suppression_level,
+       localized=localized
    )
 
    # MHD-like RE transport
    ds.eqsys.n_re.transport.setMHDLikeRechesterRosenbluth(
        dBB0=dBB0, grad_j_tot_max=grad_j_tot_max,
-       min_duration=min_duration
+       suppression_level=suppression_level,
+       localized=localized
    )
 
    # MHD-like heat transport
    ds.eqsys.T_cold.transport.setMHDLikeRechesterRosenbluth(
        dBB0=dBB0, grad_j_tot_max=grad_j_tot_max,
-       min_duration=min_duration
+       suppression_level=suppression_level,
+       localized=localized
    )
 
 Class documentation

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -20,7 +20,6 @@ namespace DREAM {
 
 		len_t id_j_tot;
 
-		real_t volume = 0;
 		real_t javg = 0;
 
 		bool IsCurrentGradientExceeded(const len_t);

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -12,6 +12,7 @@ namespace DREAM {
 
 		// Maximum current density gradient
 		real_t grad_j_tot_max;
+		bool gradient_normalized = false;
 
 		bool transport_enabled = false;
 		real_t transport_enabled_t = 0;
@@ -19,16 +20,19 @@ namespace DREAM {
 
 		len_t id_j_tot;
 
+		real_t volume = 0;
+		real_t javg = 0;
+
+		bool IsCurrentGradientExceeded(const len_t);
 	public:
 		AdaptiveMHDLikeTransportTerm(
-			FVM::Grid*, FVM::UnknownQuantityHandler*, const real_t,
-			const real_t
+			FVM::Grid*, FVM::UnknownQuantityHandler*,
+			const real_t, bool, const real_t
 		);
 
 		bool CheckTransportEnabled(const real_t);
 
 		bool IsCurrentGradientExceeded();
-		bool IsCurrentGradientExceeded(const len_t);
 	};
 }
 

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -16,7 +16,6 @@ namespace DREAM {
 
 		bool transport_enabled = false;
 		real_t transport_enabled_t = 0;
-		real_t min_duration = 0;
 		bool localized = false;
 
 		len_t id_j_tot;
@@ -25,16 +24,19 @@ namespace DREAM {
 		real_t *mask = nullptr;
 
 		bool IsCurrentGradientExceeded(const len_t);
+		bool IsCurrentGradientSuppressed(const len_t);
 	public:
 		AdaptiveMHDLikeTransportTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, bool
+			const real_t, bool, bool
 		);
 		virtual ~AdaptiveMHDLikeTransportTerm();
 
 		bool CheckTransportEnabled(const real_t);
 
 		bool IsCurrentGradientExceeded();
+		bool IsCurrentGradientSuppressed();
+		real_t GetCurrentGradient(const len_t);
 		const real_t *GetMask() { return this->mask; }
 	};
 }

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -17,21 +17,25 @@ namespace DREAM {
 		bool transport_enabled = false;
 		real_t transport_enabled_t = 0;
 		real_t min_duration = 0;
+		bool localized = false;
 
 		len_t id_j_tot;
 
 		real_t javg = 0;
+		real_t *mask = nullptr;
 
 		bool IsCurrentGradientExceeded(const len_t);
 	public:
 		AdaptiveMHDLikeTransportTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t
+			const real_t, bool, const real_t, bool
 		);
+		virtual ~AdaptiveMHDLikeTransportTerm();
 
 		bool CheckTransportEnabled(const real_t);
 
 		bool IsCurrentGradientExceeded();
+		const real_t *GetMask() { return this->mask; }
 	};
 }
 

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -1,0 +1,34 @@
+#ifndef _DREAM_EQUATIONS_ADAPTIVE_MHD_LIKE_TRANSPORT_TERM_HPP
+#define _DREAM_EQUATIONS_ADAPTIVE_MHD_LIKE_TRANSPORT_TERM_HPP
+
+#include "FVM/Equation/EquationTerm.hpp"
+
+
+namespace DREAM {
+	class AdaptiveMHDLikeTransportTerm : public FVM::EquationTerm {
+	protected:
+		FVM::UnknownQuantityHandler *uqh;
+
+		// Maximum current density gradient
+		real_t grad_j_tot_max;
+
+		bool transport_enabled = false;
+		real_t transport_enabled_t = 0;
+		real_t min_duration = 0;
+
+		len_t id_j_tot;
+
+	public:
+		AdaptiveMHDLikeTransportTerm(
+			FVM::Grid*, FVM::UnknownQuantityHandler*, const real_t,
+			const real_t
+		);
+
+		bool CheckTransportEnabled(const real_t);
+
+		bool IsCurrentGradientExceeded();
+		bool IsCurrentGradientExceeded(const len_t);
+	};
+}
+
+#endif/*_DREAM_EQUATIONS_ADAPTIVE_MHD_LIKE_TRANSPORT_TERM_HPP*/

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -13,6 +13,7 @@ namespace DREAM {
 		// Maximum current density gradient
 		real_t grad_j_tot_max;
 		bool gradient_normalized = false;
+		real_t suppression_level = 0.9;
 
 		bool transport_enabled = false;
 		real_t transport_enabled_t = 0;
@@ -28,7 +29,7 @@ namespace DREAM {
 	public:
 		AdaptiveMHDLikeTransportTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, bool
+			const real_t, bool, const real_t, bool
 		);
 		virtual ~AdaptiveMHDLikeTransportTerm();
 

--- a/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
+++ b/include/DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp
@@ -5,8 +5,9 @@
 
 
 namespace DREAM {
-	class AdaptiveMHDLikeTransportTerm : public FVM::EquationTerm {
+	class AdaptiveMHDLikeTransportTerm {
 	protected:
+		FVM::Grid *grid;
 		FVM::UnknownQuantityHandler *uqh;
 
 		// Maximum current density gradient

--- a/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
@@ -22,7 +22,7 @@ namespace DREAM {
 	public:
 		AdaptiveHyperresistiveDiffusionTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*,
-			const real_t, bool, const real_t, bool
+			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~AdaptiveHyperresistiveDiffusionTerm();
 

--- a/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
@@ -22,7 +22,7 @@ namespace DREAM {
 	public:
 		AdaptiveHyperresistiveDiffusionTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*,
-			const real_t, bool, const real_t, const real_t, bool
+			const real_t, bool, const real_t, bool
 		);
 		virtual ~AdaptiveHyperresistiveDiffusionTerm();
 

--- a/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
@@ -3,6 +3,7 @@
 
 #include "DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp"
 #include "DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp"
+#include "DREAM/IonHandler.hpp"
 
 namespace DREAM {
 	class AdaptiveHyperresistiveDiffusionTerm
@@ -10,19 +11,23 @@ namespace DREAM {
 		  public HyperresistiveDiffusionTerm {
 	
 	protected:
-		real_t Lambda0;
-		real_t *Lambda;
+		IonHandler *ions;
+		real_t dBB0;
+		real_t *Lambda, *Lambda0, *dLambda;
+
+		len_t id_n_i;
 
 		virtual const real_t *EvaluateLambda(const real_t t) override;
 
 	public:
 		AdaptiveHyperresistiveDiffusionTerm(
-			FVM::Grid*, FVM::UnknownQuantityHandler*,
+			FVM::Grid*, FVM::UnknownQuantityHandler*, IonHandler*,
 			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~AdaptiveHyperresistiveDiffusionTerm();
 
 		virtual const real_t *GetLambda() const override { return this->Lambda; }
+		virtual void SetPartialDiffusionTerm(len_t, len_t) override;
 	};
 }
 

--- a/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		AdaptiveHyperresistiveDiffusionTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, const real_t, const real_t
+			const real_t, bool, const real_t, const real_t
 		);
 		virtual ~AdaptiveHyperresistiveDiffusionTerm();
 

--- a/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		AdaptiveHyperresistiveDiffusionTerm(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, const real_t
+			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~AdaptiveHyperresistiveDiffusionTerm();
 

--- a/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp
@@ -1,0 +1,29 @@
+#ifndef _DREAM_EQUATIONS_FLUID_ADAPTIVE_HYPERRESISTIVE_DIFFUSION_TERM_HPP
+#define _DREAM_EQUATIONS_FLUID_ADAPTIVE_HYPERRESISTIVE_DIFFUSION_TERM_HPP
+
+#include "DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp"
+#include "DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp"
+
+namespace DREAM {
+	class AdaptiveHyperresistiveDiffusionTerm
+		: public AdaptiveMHDLikeTransportTerm,
+		  public HyperresistiveDiffusionTerm {
+	
+	protected:
+		real_t Lambda0;
+		real_t *Lambda;
+
+		virtual const real_t *EvaluateLambda(const real_t t) override;
+
+	public:
+		AdaptiveHyperresistiveDiffusionTerm(
+			FVM::Grid*, FVM::UnknownQuantityHandler*,
+			const real_t, const real_t, const real_t
+		);
+		virtual ~AdaptiveHyperresistiveDiffusionTerm();
+
+		virtual const real_t *GetLambda() const override { return this->Lambda; }
+	};
+}
+
+#endif/*_DREAM_EQUATIONS_FLUID_ADAPTIVE_HYPERRESISTIVE_DIFFUSION_TERM_HPP*/

--- a/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		HeatTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, const real_t
+			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~HeatTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		HeatTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, const real_t, const real_t
+			const real_t, bool, const real_t, const real_t
 		);
 		virtual ~HeatTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		HeatTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, bool
+			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~HeatTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		HeatTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, const real_t, bool
+			const real_t, bool, const real_t, bool
 		);
 		virtual ~HeatTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp
@@ -1,0 +1,27 @@
+#ifndef _DREAM_EQUATIONS_FLUID_HEAT_TRANSPORT_RR_ADAPTIVE_MHD_LIKE_HPP
+#define _DREAM_EQUATIONS_FLUID_HEAT_TRANSPORT_RR_ADAPTIVE_MHD_LIKE_HPP
+
+#include "DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp"
+#include "DREAM/Equations/Fluid/HeatTransportRechesterRosenbluth.hpp"
+
+
+namespace DREAM {
+	class HeatTransportRRAdaptiveMHDLike :
+		public AdaptiveMHDLikeTransportTerm,
+		public HeatTransportRechesterRosenbluth {
+	protected:
+		real_t dBOverB;
+		real_t *dB = nullptr;
+
+		virtual const real_t *EvaluateDeltaBOverB(const real_t) override;
+
+	public:
+		HeatTransportRRAdaptiveMHDLike(
+			FVM::Grid*, FVM::UnknownQuantityHandler*,
+			const real_t, const real_t, const real_t
+		);
+		virtual ~HeatTransportRRAdaptiveMHDLike();
+	};
+}
+
+#endif/*_DREAM_EQUATIONS_FLUID_HEAT_TRANSPORT_ADAPTIVE_MHD_LIKE_HPP*/

--- a/include/DREAM/Equations/Fluid/HeatTransportRechesterRosenbluth.hpp
+++ b/include/DREAM/Equations/Fluid/HeatTransportRechesterRosenbluth.hpp
@@ -9,12 +9,9 @@
 
 namespace DREAM {
     class HeatTransportRechesterRosenbluth : public FVM::DiffusionTerm {
-    private:
-        enum OptionConstants::momentumgrid_type mgtype;
-        FVM::Interpolator1D *deltaBOverB;
-
+    protected:
+        FVM::Interpolator1D *deltaBOverB=nullptr;
         FVM::UnknownQuantityHandler *unknowns;
-
         real_t *dD=nullptr;
 
         // IDs of unknown quantities used by the operator...
@@ -23,9 +20,11 @@ namespace DREAM {
         void AllocateDiffCoeff();
         virtual void SetPartialDiffusionTerm(len_t, len_t) override;
 
+		virtual const real_t *EvaluateDeltaBOverB(const real_t t) { return this->deltaBOverB->Eval(t); }
+
     public:
-        HeatTransportRechesterRosenbluth(FVM::Grid*, enum OptionConstants::momentumgrid_type, FVM::Interpolator1D*, FVM::UnknownQuantityHandler*);
-        ~HeatTransportRechesterRosenbluth();
+        HeatTransportRechesterRosenbluth(FVM::Grid*, FVM::Interpolator1D*, FVM::UnknownQuantityHandler*);
+        virtual ~HeatTransportRechesterRosenbluth();
 
         virtual bool GridRebuilt() override;
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;

--- a/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
@@ -11,15 +11,16 @@ namespace DREAM {
     class HyperresistiveDiffusionTerm
         : public FVM::DiffusionTerm {
     private:
-        FVM::Interpolator1D *Lambda; 
+        FVM::Interpolator1D *Lambda=nullptr; 
 	
 	protected:
-		const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
+		virtual const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
 
     public:
         HyperresistiveDiffusionTerm(FVM::Grid*, FVM::Interpolator1D*);
+		virtual ~HyperresistiveDiffusionTerm();
         
-        const real_t *GetLambda() const { return Lambda->GetBuffer(); }
+        virtual const real_t *GetLambda() const { return Lambda->GetBuffer(); }
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
     };
 }

--- a/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
@@ -16,7 +16,7 @@ namespace DREAM {
 	protected:
 		virtual const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
 
-		void BuildCoefficient(const real_t, FVM::UnknownQuantityHandler*, const real_t*, const real_t**);
+		void BuildCoefficient(const real_t*, const real_t**);
 
     public:
         HyperresistiveDiffusionTerm(FVM::Grid*, FVM::Interpolator1D*);

--- a/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
@@ -12,6 +12,9 @@ namespace DREAM {
         : public FVM::DiffusionTerm {
     private:
         FVM::Interpolator1D *Lambda; 
+	
+	protected:
+		const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
 
     public:
         HyperresistiveDiffusionTerm(FVM::Grid*, FVM::Interpolator1D*);

--- a/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
@@ -16,6 +16,8 @@ namespace DREAM {
 	protected:
 		virtual const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
 
+		void BuildCoefficient(const real_t, FVM::UnknownQuantityHandler*, const real_t*, const real_t**);
+
     public:
         HyperresistiveDiffusionTerm(FVM::Grid*, FVM::Interpolator1D*);
 		virtual ~HyperresistiveDiffusionTerm();

--- a/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
@@ -16,7 +16,7 @@ namespace DREAM {
 	protected:
 		virtual const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
 
-		void BuildCoefficient(const real_t*, const real_t**);
+		void BuildCoefficient(const real_t*, real_t**);
 
     public:
         HyperresistiveDiffusionTerm(FVM::Grid*, FVM::Interpolator1D*);

--- a/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		RunawayTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, const real_t
+			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~RunawayTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		RunawayTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, const real_t, bool
+			const real_t, bool, const real_t, bool
 		);
 		virtual ~RunawayTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		RunawayTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, const real_t, const real_t
+			const real_t, bool, const real_t, const real_t
 		);
 		virtual ~RunawayTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
@@ -18,7 +18,7 @@ namespace DREAM {
 	public:
 		RunawayTransportRRAdaptiveMHDLike(
 			FVM::Grid*, FVM::UnknownQuantityHandler*,
-			const real_t, bool, const real_t, bool
+			const real_t, bool, const real_t, const real_t, bool
 		);
 		virtual ~RunawayTransportRRAdaptiveMHDLike();
 	};

--- a/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp
@@ -1,0 +1,27 @@
+#ifndef _DREAM_EQUATIONS_RUNAWAY_TRANSPORT_RR_ADAPTIVE_MHD_LIKE_HPP
+#define _DREAM_EQUATIONS_RUNAWAY_TRANSPORT_RR_ADAPTIVE_MHD_LIKE_HPP
+
+#include "DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp"
+#include "DREAM/Equations/RunawaySourceTerm.hpp"
+#include "DREAM/Equations/Fluid/RunawayTransportRechesterRosenbluth.hpp"
+
+namespace DREAM {
+	class RunawayTransportRRAdaptiveMHDLike :
+		public AdaptiveMHDLikeTransportTerm,
+		public RunawayTransportRechesterRosenbluth {
+	protected:
+		real_t dBOverB;
+		real_t *dB = nullptr;
+
+		virtual const real_t *EvaluateDeltaBOverB(const real_t) override;
+
+	public:
+		RunawayTransportRRAdaptiveMHDLike(
+			FVM::Grid*, FVM::UnknownQuantityHandler*,
+			const real_t, const real_t, const real_t
+		);
+		virtual ~RunawayTransportRRAdaptiveMHDLike();
+	};
+}
+
+#endif/*_DREAM_EQUATIONS_RUNAWAY_TRANSPORT_RR_ADAPTIVE_MHD_LIKE_HPP*/

--- a/include/DREAM/Equations/Fluid/RunawayTransportRechesterRosenbluth.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRechesterRosenbluth.hpp
@@ -1,0 +1,26 @@
+#ifndef _DREAM_EQUATIONS_FLUID_RUNAWAY_TRANSPORT_RECHESTER_ROSENBLUTH_HPP
+#define _DREAM_EQUATIONS_FLUID_RUNAWAY_TRANSPORT_RECHESTER_ROSENBLUTH_HPP
+
+#include "FVM/Equation/DiffusionTerm.hpp"
+#include "FVM/Grid/Grid.hpp"
+#include "FVM/Interpolator1D.hpp"
+#include "FVM/UnknownQuantityHandler.hpp"
+
+namespace DREAM {
+	class RunawayTransportRechesterRosenbluth : public FVM::DiffusionTerm {
+	protected:
+		FVM::Interpolator1D *dBB;
+
+		const real_t *EvaluateDeltaBOverB(const real_t t) { return dBB->Eval(t); }
+
+	public:
+		RunawayTransportRechesterRosenbluth(
+			FVM::Grid*, FVM::Interpolator1D*
+		);
+		virtual ~RunawayTransportRechesterRosenbluth();
+
+		virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*);
+	};
+}
+
+#endif/*_DREAM_EQUATIONS_FLUID_RUNAWAY_TRANSPORT_RECHESTER_ROSENBLUTH_HPP*/

--- a/include/DREAM/Equations/Fluid/RunawayTransportRechesterRosenbluth.hpp
+++ b/include/DREAM/Equations/Fluid/RunawayTransportRechesterRosenbluth.hpp
@@ -11,7 +11,7 @@ namespace DREAM {
 	protected:
 		FVM::Interpolator1D *dBB;
 
-		const real_t *EvaluateDeltaBOverB(const real_t t) { return dBB->Eval(t); }
+		virtual const real_t *EvaluateDeltaBOverB(const real_t t) { return dBB->Eval(t); }
 
 	public:
 		RunawayTransportRechesterRosenbluth(

--- a/include/DREAM/IonHandler.hpp
+++ b/include/DREAM/IonHandler.hpp
@@ -90,6 +90,7 @@ namespace DREAM {
         const real_t GetIonDensity(len_t ir, len_t iz, len_t Z0) const;
         const real_t* GetIonDensity(len_t ir, len_t iZ) const;
         const real_t GetTotalIonDensity(len_t ir, len_t iZ) const;
+		const real_t GetTotalIonMassDensity(len_t ir) const;
         const real_t GetTritiumDensity(len_t ir) const;
 
         // DERIVED QUANTITY GETTERS

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -352,6 +352,12 @@ enum eqterm_ionization_mode {                       // Ionization is modelled wi
     EQTERM_IONIZATION_MODE_FLUID_RE=4,              // approximation of the kinetic ionization rate assuming a mono-energetic RE distribution at 20mc, can be used in both fluid and kinetic mode
 };
 
+enum eqterm_hyperresistivity_mode {
+	EQTERM_HYPERRESISTIVITY_MODE_NEGLECT=1,			// No hyper-resistive term
+	EQTERM_HYPERRESISTIVITY_MODE_PRESCRIBED=2,		// Hyper-resistive term with prescribed diffusion coefficient Lambda = Lambda(t,r)
+	EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE=3			// Hyper-resistive term with adaptive diffusion coefficient
+};
+
 enum eqterm_particle_source_mode {                  // Equation used for S_particle (the kinetic particle source)
     EQTERM_PARTICLE_SOURCE_ZERO     = 1,            // S_particle = 0
     EQTERM_PARTICLE_SOURCE_IMPLICIT = 2,            // S_particle determined implicitly from density conservation

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -339,7 +339,8 @@ enum eqterm_transport_type {
 	EQTERM_TRANSPORT_RECHESTER_ROSENBLUTH=3,		// Diffusive transport with a Rechester-Rosenbluth coefficient
 	EQTERM_TRANSPORT_SVENSSON=4,					// Svensson transport model (only n_re)
 	EQTERM_TRANSPORT_FROZEN_CURRENT=5,				// Frozen current transport (only n_re)
-	EQTERM_TRANSPORT_MHD_LIKE=6						// MHD-like adaptive heat transport (only T_cold)
+	EQTERM_TRANSPORT_MHD_LIKE=6,					// MHD-like adaptive transport (n_re and T_cold)
+	EQTERM_TRANSPORT_MHD_LIKE_LOCAL=7				// MHD-like adaptive transport, applied locally (n_re and T_cold)
 };
 
 enum eqterm_frozen_current_mode {
@@ -364,7 +365,8 @@ enum eqterm_ionization_mode {                       // Ionization is modelled wi
 enum eqterm_hyperresistivity_mode {
 	EQTERM_HYPERRESISTIVITY_MODE_NEGLECT=1,			// No hyper-resistive term
 	EQTERM_HYPERRESISTIVITY_MODE_PRESCRIBED=2,		// Hyper-resistive term with prescribed diffusion coefficient Lambda = Lambda(t,r)
-	EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE=3			// Hyper-resistive term with adaptive diffusion coefficient
+	EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE=3,		// Hyper-resistive term with adaptive diffusion coefficient
+	EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL=4 	// Hyper-resistive term with adaptive diffusion coefficient, applied locally
 };
 
 enum eqterm_particle_source_mode {                  // Equation used for S_particle (the kinetic particle source)

--- a/include/DREAM/Settings/OptionConstants.enum.hpp
+++ b/include/DREAM/Settings/OptionConstants.enum.hpp
@@ -333,6 +333,15 @@ enum eqterm_compton_mode {
     EQTERM_COMPTON_MODE_KINETIC=3,                  // Kinetic Compton source
 };
 
+enum eqterm_transport_type {
+	EQTERM_TRANSPORT_NONE=1,						// No transport
+	EQTERM_TRANSPORT_PRESCRIBED=2,					// Prescribed advection-diffusion coefficient(s)
+	EQTERM_TRANSPORT_RECHESTER_ROSENBLUTH=3,		// Diffusive transport with a Rechester-Rosenbluth coefficient
+	EQTERM_TRANSPORT_SVENSSON=4,					// Svensson transport model (only n_re)
+	EQTERM_TRANSPORT_FROZEN_CURRENT=5,				// Frozen current transport (only n_re)
+	EQTERM_TRANSPORT_MHD_LIKE=6						// MHD-like adaptive heat transport (only T_cold)
+};
+
 enum eqterm_frozen_current_mode {
 	EQTERM_FROZEN_CURRENT_MODE_DISABLED=1,			// Disable the frozen current mode transport
 	EQTERM_FROZEN_CURRENT_MODE_CONSTANT=2,			// Assume momentum-independent radial transport
@@ -426,7 +435,8 @@ enum eqterm_hottail_mode {                          // Mode used for hottail run
 enum eqterm_lcfs_loss_mode {                        // Loss term
     EQTERM_LCFS_LOSS_MODE_DISABLED = 1,
     EQTERM_LCFS_LOSS_MODE_FLUID = 2,
-    EQTERM_LCFS_LOSS_MODE_KINETIC = 3};
+    EQTERM_LCFS_LOSS_MODE_KINETIC = 3
+};
 
 enum eqterm_tritium_mode {                        // Tritium generation is...
     EQTERM_TRITIUM_MODE_NEGLECT = 1,              // neglected

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -27,7 +27,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
 
         self.hyperresistivity_grad_j_tot_max = None
         self.hyperresistivity_gradient_normalized = False
-        self.hyperresistivity_Lambda0 = None
+        self.hyperresistivity_dBB0 = None
         self.hyperresistivity_min_duration = None
 
 
@@ -49,7 +49,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
 
 
     def setHyperresistivityAdaptive(
-        self, Lambda0, grad_j_tot_max=None,
+        self, dBB0, grad_j_tot_max=None,
         grad_j_tot_max_norm=None, min_duration=0.5e-3,
         localized=False
     ):
@@ -59,7 +59,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         term is applied until the current density drops below the threshold,
         and at least for ``min_duration`` seconds.
 
-        :param Lambda0:             Value of hyperresistivity to apply.
+        :param dBB0:                Value of hyperresistivity to apply.
         :param grad_j_tot_max:      Maximum current density gradient which must be exceeded for the term to be triggered.
         :param grad_j_tot_max_norm: Maximum current density gradient (normalized to average current density) which must be exceeded.
         :param min_duration:        Minimum duration of the hyperresistive term (in seconds).
@@ -79,7 +79,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         else:
             raise EquationException("One of 'grad_j_tot_max' and 'grad_j_tot_max_norm' must be specified.")
 
-        self.hyperresistivity_Lambda0 = Lambda0
+        self.hyperresistivity_dBB0 = dBB0
         self.hyperresistivity_min_duration = min_duration
 
 
@@ -95,8 +95,8 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
                 self.hyperresistivity_Lambda_x = hyp['Lambda']['x']
                 self.hyperresistivity_Lambda_r = hyp['Lambda']['r']
                 self.hyperresistivity_Lambda_t = hyp['Lambda']['t']
-            elif 'Lambda0' in hyp:
-                self.hyperresistivity_Lambda0 = float(hyp['Lambda0'])
+            elif 'dBB0' in hyp:
+                self.hyperresistivity_dBB0 = float(hyp['dBB0'])
                 self.hyperresistivity_grad_j_tot_max = float(hyp['grad_j_tot_max'])
                 self.hyperresistivity_gradient_normalized = bool(hyp['gradient_normalized'])
                 self.hyperresistivity_min_duration = float(hyp['min_duration'])
@@ -116,7 +116,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
                 't': self.hyperresistivity_Lambda_t
             }
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE or self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL:
-            hypres['Lambda0'] = self.hyperresistivity_Lambda0
+            hypres['dBB0'] = self.hyperresistivity_dBB0
             hypres['grad_j_tot_max'] = self.hyperresistivity_grad_j_tot_max
             hypres['gradient_normalized'] = self.hyperresistivity_gradient_normalized
             hypres['min_duration'] = self.hyperresistivity_min_duration
@@ -133,8 +133,8 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_PRESCRIBED:
             self._verifySettingsPrescribedData('psi_p hyperresistivity', data=self.hyperresistivity_Lambda_x, radius=self.hyperresistivity_Lambda_r, times=self.hyperresistivity_Lambda_t)
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE or self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL:
-            if not np.isscalar(self.hyperresistivity_Lambda0):
-                raise EquationException(f"The hyperresistivity parameter 'Lambda0' must be a scalar. Current value: {self.hyperresistivity_Lambda0}.")
+            if not np.isscalar(self.hyperresistivity_dBB0):
+                raise EquationException(f"The hyperresistivity parameter 'dBB0' must be a scalar. Current value: {self.hyperresistivity_dBB0}.")
             if not np.isscalar(self.hyperresistivity_grad_j_tot_max):
                 raise EquationException(f"The hyperresistivity parameter 'grad_j_tot_max' must be a scalar. Current value: {self.hyperresistivity_grad_j_tot_max}.")
             if not np.isscalar(self.hyperresistivity_min_duration):

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -4,6 +4,12 @@ from . PrescribedParameter import PrescribedParameter
 from . UnknownQuantity import UnknownQuantity
 from .. TransportSettings import TransportSettings
 
+
+HYPERRESISTIVITY_TYPE_NEGLECT = 1
+HYPERRESISTIVITY_TYPE_PRESCRIBED = 2
+HYPERRESISTIVITY_TYPE_ADAPTIVE = 3
+
+
 class PoloidalFlux(UnknownQuantity,PrescribedParameter):
     
     def __init__(self, settings):
@@ -12,10 +18,14 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         """
         super().__init__(settings=settings)
 
-        self.hyperresistivity_enabled = False
+        self.hyperresistivity_type = HYPERRESISTIVITY_TYPE_PRESCRIBED
         self.hyperresistivity_Lambda_x = None
         self.hyperresistivity_Lambda_r = None
         self.hyperresistivity_Lambda_t = None
+
+        self.hyperresistivity_grad_j_tot_max = None
+        self.hyperresistivity_Lambda0 = None
+        self.hyperresistivity_min_duration = None
 
 
     def fromdict(self, data):
@@ -24,12 +34,16 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         """
         if 'hyperresistivity' in data:
             hyp = data['hyperresistivity']
-            self.hyperresistivity_enabled = bool(hyp['enabled'])
+            self.hyperresistivity_type = int(hyp['type'])
 
             if 'Lambda' in hyp:
                 self.hyperresistivity_Lambda_x = hyp['Lambda']['x']
                 self.hyperresistivity_Lambda_r = hyp['Lambda']['r']
                 self.hyperresistivity_Lambda_t = hyp['Lambda']['t']
+            elif 'Lambda0' in hyp:
+                self.hyperresistivity_Lambda0 = float(hyp['Lambda0'])
+                self.hyperresistivity_grad_j_tot_max = float(hyp['grad_j_tot_max'])
+                self.hyperresistivity_min_duration = float(hyp['min_duration'])
 
 
     def setHyperresistivity(self, Lambda, radius=None, times=None):
@@ -43,10 +57,29 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         """
         d, r, t = self._setPrescribedData(data=Lambda, radius=radius, times=times)
 
-        self.hyperresistivity_enabled = True
+        self.hyperresistivity_type = HYPERRESISTIVITY_TYPE_PRESCRIBED
         self.hyperresistivity_Lambda_x = d
         self.hyperresistivity_Lambda_r = r
         self.hyperresistivity_Lambda_t = t
+
+
+    def setHyperresistivityAdaptive(
+        self, grad_j_tot_max, Lambda0, min_duration=0.5e-3
+    ):
+        """
+        Enable the adaptive hyperresistive diffusion term, which triggers when
+        the current density gradient grows above a given threshold locally. The
+        term is applied until the current density drops below the threshold,
+        and at least for ``min_duration`` seconds.
+
+        :param grad_j_tot_max: Maximum current density gradient which must be exceeded for the term to be triggered.
+        :param Lambda0:        Value of hyperresistivity to apply.
+        :param min_duration:   Minimum duration of the hyperresistive term (in seconds).
+        """
+        self.hyperresistivity_type = HYPERRESISTIVITY_TYPE_ADAPTIVE
+        self.hyperresistivity_grad_j_tot_max = grad_j_tot_max
+        self.hyperresistivity_Lambda0 = Lambda0
+        self.hyperresistivity_min_duration = min_duration
 
 
     def todict(self):
@@ -56,16 +89,20 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         """
         data = {
             'hyperresistivity': {
-                'enabled': self.hyperresistivity_enabled
+                'type': self.hyperresistivity_type
             }
         }
 
-        if self.hyperresistivity_enabled:
+        if self.hyperresistivity_type == HYPERRESISTIVITY_TYPE_PRESCRIBED:
             data['hyperresistivity']['Lambda'] = {
                 'x': self.hyperresistivity_Lambda_x,
                 'r': self.hyperresistivity_Lambda_r,
                 't': self.hyperresistivity_Lambda_t
             }
+        elif self.hyperresistivity_type == HYPERRESISTIVITY_TYPE_ADAPTIVE:
+            data['hyperresistivity']['Lambda0'] = self.hyperresistivity_Lambda0
+            data['hyperresistivity']['grad_j_tot_max'] = self.hyperresistivity_grad_j_tot_max
+            data['hyperresistivity']['min_duration'] = self.hyperresistivity_min_duration
 
         return data
 
@@ -74,7 +111,18 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         """
         Verify that the settings of this unknown are correctly set.
         """
-        if self.hyperresistivity_enabled:
+        if self.hyperresistivity_type == HYPERRESISTIVITY_TYPE_NEGLECT:
+            pass
+        elif self.hyperresistivity_type == HYPERRESISTIVITY_TYPE_PRESCRIBED:
             self._verifySettingsPrescribedData('psi_p hyperresistivity', data=self.hyperresistivity_Lambda_x, radius=self.hyperresistivity_Lambda_r, times=self.hyperresistivity_Lambda_t)
+        elif self.hyperresistivity_type == HYPERRESISTIVITY_TYPE_ADAPTIVE:
+            if not np.isscalar(self.hyperresistivity_Lambda0):
+                raise EquationException(f"The hyperresistivity parameter 'Lambda0' must be a scalar. Current value: {self.hyperresistivity_Lambda0}.")
+            if not np.isscalar(self.hyperresistivity_grad_j_tot_max):
+                raise EquationException(f"The hyperresistivity parameter 'Lambda0' must be a scalar. Current value: {self.hyperresistivity_grad_j_tot_max}.")
+            if not np.isscalar(self.hyperresistivity_min_duration):
+                raise EquationException(f"The hyperresistivity parameter 'Lambda0' must be a scalar. Current value: {self.hyperresistivity_min_duration}.")
+        else:
+            raise EquationException(f"Invalid option for hyperresistivity type: {self.hyperresistivity_type}.")
 
 

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -115,7 +115,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
                 'r': self.hyperresistivity_Lambda_r,
                 't': self.hyperresistivity_Lambda_t
             }
-        elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE:
+        elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE or self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL:
             hypres['Lambda0'] = self.hyperresistivity_Lambda0
             hypres['grad_j_tot_max'] = self.hyperresistivity_grad_j_tot_max
             hypres['gradient_normalized'] = self.hyperresistivity_gradient_normalized

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -8,6 +8,7 @@ from .. TransportSettings import TransportSettings
 HYPERRESISTIVITY_MODE_NEGLECT = 1
 HYPERRESISTIVITY_MODE_PRESCRIBED = 2
 HYPERRESISTIVITY_MODE_ADAPTIVE = 3
+HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL = 4
 
 
 class PoloidalFlux(UnknownQuantity,PrescribedParameter):
@@ -49,7 +50,8 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
 
     def setHyperresistivityAdaptive(
         self, Lambda0, grad_j_tot_max=None,
-        grad_j_tot_max_norm=None, min_duration=0.5e-3
+        grad_j_tot_max_norm=None, min_duration=0.5e-3,
+        localized=False
     ):
         """
         Enable the adaptive hyperresistive diffusion term, which triggers when
@@ -61,8 +63,12 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         :param grad_j_tot_max:      Maximum current density gradient which must be exceeded for the term to be triggered.
         :param grad_j_tot_max_norm: Maximum current density gradient (normalized to average current density) which must be exceeded.
         :param min_duration:        Minimum duration of the hyperresistive term (in seconds).
+        :param localized:           Apply localized transport.
         """
-        self.hyperresistivity_mode = HYPERRESISTIVITY_MODE_ADAPTIVE
+        if localized:
+            self.hyperresistivity_mode = HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL
+        else:
+            self.hyperresistivity_mode = HYPERRESISTIVITY_MODE_ADAPTIVE
 
         if grad_j_tot_max:
             self.hyperresistivity_grad_j_tot_max = grad_j_tot_max

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -132,7 +132,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
             pass
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_PRESCRIBED:
             self._verifySettingsPrescribedData('psi_p hyperresistivity', data=self.hyperresistivity_Lambda_x, radius=self.hyperresistivity_Lambda_r, times=self.hyperresistivity_Lambda_t)
-        elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE:
+        elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE or self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL:
             if not np.isscalar(self.hyperresistivity_Lambda0):
                 raise EquationException(f"The hyperresistivity parameter 'Lambda0' must be a scalar. Current value: {self.hyperresistivity_Lambda0}.")
             if not np.isscalar(self.hyperresistivity_grad_j_tot_max):

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -28,6 +28,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         self.hyperresistivity_grad_j_tot_max = None
         self.hyperresistivity_gradient_normalized = False
         self.hyperresistivity_dBB0 = None
+        self.hyperresistivity_suppression_level = 0.9
 
 
     def setHyperresistivity(self, Lambda, radius=None, times=None):
@@ -50,7 +51,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
     def setHyperresistivityAdaptive(
         self, dBB0, grad_j_tot_max=None,
         grad_j_tot_max_norm=None,
-        localized=False
+        localized=False, suppression_level=0.9
     ):
         """
         Enable the adaptive hyperresistive diffusion term, which triggers when
@@ -78,6 +79,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
             raise EquationException("One of 'grad_j_tot_max' and 'grad_j_tot_max_norm' must be specified.")
 
         self.hyperresistivity_dBB0 = dBB0
+        self.hyperresistivity_suppression_level = suppression_level
 
 
     def fromdict(self, data):
@@ -96,6 +98,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
                 self.hyperresistivity_dBB0 = float(hyp['dBB0'])
                 self.hyperresistivity_grad_j_tot_max = float(hyp['grad_j_tot_max'])
                 self.hyperresistivity_gradient_normalized = bool(hyp['gradient_normalized'])
+                self.hyperresistivity_suppression_level = float(hyp['suppression_level'])
 
 
     def todict(self):
@@ -115,6 +118,7 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
             hypres['dBB0'] = self.hyperresistivity_dBB0
             hypres['grad_j_tot_max'] = self.hyperresistivity_grad_j_tot_max
             hypres['gradient_normalized'] = self.hyperresistivity_gradient_normalized
+            hypres['suppression_level'] = self.hyperresistivity_suppression_level 
 
         return { 'hyperresistivity': hypres }
 
@@ -132,6 +136,8 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
                 raise EquationException(f"The hyperresistivity parameter 'dBB0' must be a scalar. Current value: {self.hyperresistivity_dBB0}.")
             if not np.isscalar(self.hyperresistivity_grad_j_tot_max):
                 raise EquationException(f"The hyperresistivity parameter 'grad_j_tot_max' must be a scalar. Current value: {self.hyperresistivity_grad_j_tot_max}.")
+            if not np.isscalar(self.hyperresistivity_suppression_level):
+                raise EquationException(f"The hyperresistivity parameter 'suppression_level' must be a scalar. Current value: {self.hyperresistivity_suppression_level}.")
         else:
             raise EquationException(f"Invalid option for hyperresistivity mode: {self.hyperresistivity_mode}.")
 

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -288,19 +288,30 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         self.advectionInterpolation.setMethod(ad_int=ad_int, ad_jac=ad_jac, fluxlimiterdamping=fluxlimiterdamping)
     
 
-    def setAdaptiveMHDLikeTransport(self, grad_j_tot_max, dBB0, Lambda0, min_duration=0.5e-3):
+    def setAdaptiveMHDLikeTransport(
+        self, dBB0, Lambda0, grad_j_tot_max=None,
+        grad_j_tot_max_norm=None, min_duration=0.5e-3
+    ):
         """
         Enable adaptive MHD-like transport on ``n_re``, ``psi_p`` and ``T_cold``
         simultaneously.
         """
+        kwargs = {}
+        if grad_j_tot_max:
+            kwargs['grad_j_tot_max'] = grad_j_tot_max
+        elif grad_j_tot_max_norm:
+            kwargs['grad_j_tot_max_norm'] = grad_j_tot_max_norm
+        else:
+            raise EquationException("One of 'grad_j_tot_max' and 'grad_j_tot_max_norm' must be specified.")
+
         self.transport.setMHDLikeRechesterRosenbluth(
-            dBB0=dBB0, grad_j_tot_max=grad_j_tot_max, min_duration=min_duration
+            dBB0=dBB0, min_duration=min_duration, **kwargs
         )
         self.settings.eqsys.T_cold.transport.setMHDLikeRechesterRosenbluth(
-            dBB0=dBB0, grad_j_tot_max=grad_j_tot_max, min_duration=min_duration
+            dBB0=dBB0, min_duration=min_duration, **kwargs
         )
         self.settings.eqsys.psi_p.setHyperresistivityAdaptive(
-            Lambda0=Lambda0, grad_j_tot_max=grad_j_tot_max, min_duration=min_duration
+            Lambda0=Lambda0, min_duration=min_duration, **kwargs
         )
 
 

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -297,6 +297,8 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         Enable adaptive MHD-like transport on ``n_re``, ``psi_p`` and ``T_cold``
         simultaneously.
         """
+
+        
         kwargs = {}
         if grad_j_tot_max:
             kwargs['grad_j_tot_max'] = grad_j_tot_max
@@ -314,6 +316,7 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         self.settings.eqsys.psi_p.setHyperresistivityAdaptive(
             Lambda0=Lambda0, min_duration=min_duration, localized=localized, **kwargs
         )
+
 
 
     def fromdict(self, data):

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -297,8 +297,6 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         Enable adaptive MHD-like transport on ``n_re``, ``psi_p`` and ``T_cold``
         simultaneously.
         """
-
-        
         kwargs = {}
         if grad_j_tot_max:
             kwargs['grad_j_tot_max'] = grad_j_tot_max
@@ -314,7 +312,7 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
             dBB0=dBB0, min_duration=min_duration, localized=localized, **kwargs
         )
         self.settings.eqsys.psi_p.setHyperresistivityAdaptive(
-            Lambda0=Lambda0, min_duration=min_duration, localized=localized, **kwargs
+            dBB0=dBB0, min_duration=min_duration, localized=localized, **kwargs
         )
 
 

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -266,12 +266,14 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         """
         self.negative_re = negative_re
         
+
     def setExtrapolateDreicer(self, extrapolateDreicer=False):
         """
         Extrapolates the result from the neural network for small electric fields
         such that the Dreicer generation rate is continuous and has continuous derivative.
         """
         self.extrapolateDreicer = extrapolateDreicer
+
 
     def setAdvectionInterpolationMethod(self, ad_int=AD_INTERP_CENTRED,
         ad_jac=AD_INTERP_JACOBIAN_FULL, fluxlimiterdamping=1.0):
@@ -284,6 +286,22 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         :param float fluxlimiterdamping: Damping parameter used to under-relax the interpolation coefficients during non-linear iterations (should be between 0 and 1).
         """
         self.advectionInterpolation.setMethod(ad_int=ad_int, ad_jac=ad_jac, fluxlimiterdamping=fluxlimiterdamping)
+    
+
+    def setAdaptiveMHDLikeTransport(self, grad_j_tot_max, dBB0, Lambda0, min_duration=0.5e-3):
+        """
+        Enable adaptive MHD-like transport on ``n_re``, ``psi_p`` and ``T_cold``
+        simultaneously.
+        """
+        self.transport.setMHDLikeRechesterRosenbluth(
+            dBB0=dBB0, grad_j_tot_max=grad_j_tot_max, min_duration=min_duration
+        )
+        self.settings.eqsys.T_cold.transport.setMHDLikeRechesterRosenbluth(
+            dBB0=dBB0, grad_j_tot_max=grad_j_tot_max, min_duration=min_duration
+        )
+        self.settings.eqsys.psi_p.setHyperresistivityAdaptive(
+            Lambda0=Lambda0, grad_j_tot_max=grad_j_tot_max, min_duration=min_duration
+        )
 
 
     def fromdict(self, data):

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -289,7 +289,7 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
     
 
     def setAdaptiveMHDLikeTransport(
-        self, dBB0, Lambda0, grad_j_tot_max=None,
+        self, dBB0, grad_j_tot_max=None,
         grad_j_tot_max_norm=None, min_duration=0.5e-3,
         localized=False
     ):

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -290,7 +290,8 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
 
     def setAdaptiveMHDLikeTransport(
         self, dBB0, Lambda0, grad_j_tot_max=None,
-        grad_j_tot_max_norm=None, min_duration=0.5e-3
+        grad_j_tot_max_norm=None, min_duration=0.5e-3,
+        localized=False
     ):
         """
         Enable adaptive MHD-like transport on ``n_re``, ``psi_p`` and ``T_cold``
@@ -305,13 +306,13 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
             raise EquationException("One of 'grad_j_tot_max' and 'grad_j_tot_max_norm' must be specified.")
 
         self.transport.setMHDLikeRechesterRosenbluth(
-            dBB0=dBB0, min_duration=min_duration, **kwargs
+            dBB0=dBB0, min_duration=min_duration, localized=localized, **kwargs
         )
         self.settings.eqsys.T_cold.transport.setMHDLikeRechesterRosenbluth(
-            dBB0=dBB0, min_duration=min_duration, **kwargs
+            dBB0=dBB0, min_duration=min_duration, localized=localized, **kwargs
         )
         self.settings.eqsys.psi_p.setHyperresistivityAdaptive(
-            Lambda0=Lambda0, min_duration=min_duration, **kwargs
+            Lambda0=Lambda0, min_duration=min_duration, localized=localized, **kwargs
         )
 
 

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -304,7 +304,7 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
 
     def setAdaptiveMHDLikeTransport(
         self, dBB0, grad_j_tot_max=None,
-        grad_j_tot_max_norm=None,
+        grad_j_tot_max_norm=None, suppression_level=0.9,
         localized=False
     ):
         """
@@ -320,13 +320,13 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
             raise EquationException("One of 'grad_j_tot_max' and 'grad_j_tot_max_norm' must be specified.")
 
         self.transport.setMHDLikeRechesterRosenbluth(
-            dBB0=dBB0, localized=localized, **kwargs
+            dBB0=dBB0, localized=localized, suppression_level=suppression_level, **kwargs
         )
         self.settings.eqsys.T_cold.transport.setMHDLikeRechesterRosenbluth(
-            dBB0=dBB0, localized=localized, **kwargs
+            dBB0=dBB0, localized=localized, suppression_level=suppression_level, **kwargs
         )
         self.settings.eqsys.psi_p.setHyperresistivityAdaptive(
-            dBB0=dBB0, localized=localized, **kwargs
+            dBB0=dBB0, localized=localized, suppression_level=suppression_level, **kwargs
         )
 
 

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -101,6 +101,7 @@ class TransportSettings:
         self.mhdlike_dBB0 = None
         self.mhdlike_grad_j_tot_max = None
         self.mhdlike_gradient_normalized = False
+        self.mhdlike_suppression_level = 0.9
 
         # Frozen current mode transport
         self.frozen_current_mode = FROZEN_CURRENT_MODE_DISABLED
@@ -289,7 +290,7 @@ class TransportSettings:
     def setMHDLikeRechesterRosenbluth(
         self, dBB0, grad_j_tot_max=None,
         grad_j_tot_max_norm=None,
-        localized=False
+        localized=False, suppression_level=0.9
     ):
         """
         Enable the MHD-like Rechester-Rosenbluth heat transport model.
@@ -300,6 +301,7 @@ class TransportSettings:
             self.type = TRANSPORT_MHD_LIKE
 
         self.mhdlike_dBB0 = dBB0
+        self.mhdlike_suppression_level = suppression_level
 
         if grad_j_tot_max:
             self.mhdlike_grad_j_tot_max = grad_j_tot_max
@@ -400,6 +402,7 @@ class TransportSettings:
         self.mhdlike_dBB0 = None
         self.mhdlike_grad_j_tot_max = None
         self.mhdlike_gradient_normalized = False
+        self.mhdlike_suppression_level = 0.9
 
         if 'type' in data:
             self.type = data['type']
@@ -474,6 +477,7 @@ class TransportSettings:
             self.mhdlike_dBB0 = float(data['mhdlike_dBB0'])
             self.mhdlike_grad_j_tot_max = float(data['mhdlike_grad_j_tot_max'])
             self.mhdlike_gradient_normalized = bool(data['mhdlike_gradient_normalized'])
+            self.mhdlike_suppression_level = float(data['mhdlike_suppression_level'])
 
         if 'frozen_current_mode' in data:
             self.frozen_current_mode = int(data['frozen_current_mode'])
@@ -584,6 +588,7 @@ class TransportSettings:
             data['mhdlike_dBB0'] = self.mhdlike_dBB0
             data['mhdlike_grad_j_tot_max'] = self.mhdlike_grad_j_tot_max
             data['mhdlike_gradient_normalized'] = 1 if self.mhdlike_gradient_normalized else 0
+            data['mhdlike_suppression_level'] = self.mhdlike_suppression_level
 
         data['frozen_current_mode'] = self.frozen_current_mode
         data['D_I_min'] = self.frozen_current_D_I_min

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -99,6 +99,7 @@ class TransportSettings:
         # MHD-like Rechester-Rosenbluth (diffusive) heat transport
         self.mhdlike_dBB0 = None
         self.mhdlike_grad_j_tot_max = None
+        self.mhdlike_gradient_normalized = False
         self.mhdlike_min_duration = None
 
         # Frozen current mode transport
@@ -285,15 +286,26 @@ class TransportSettings:
         self.dBB   = dBB
 
 
-    def setMHDLikeRechesterRosenbluth(self, dBB0, grad_j_tot_max, min_duration=0.5e-3):
+    def setMHDLikeRechesterRosenbluth(
+        self, dBB0, grad_j_tot_max=None,
+        grad_j_tot_max_norm=None, min_duration=0.5e-3
+    ):
         """
         Enable the MHD-like Rechester-Rosenbluth heat transport model.
         """
         self.type = TRANSPORT_MHD_LIKE
 
         self.mhdlike_dBB0 = dBB0
-        self.mhdlike_grad_j_tot_max = grad_j_tot_max
         self.mhdlike_min_duration = min_duration
+
+        if grad_j_tot_max:
+            self.mhdlike_grad_j_tot_max = grad_j_tot_max
+            self.mhdlike_gradient_normalized = False
+        elif grad_j_tot_max_norm:
+            self.mhdlike_grad_j_tot_max = grad_j_tot_max_norm
+            self.mhdlike_gradient_normalized = True
+        else:
+            raise EquationException("One of 'grad_j_tot_max' and 'grad_j_tot_max_norm' must be specified.")
 
 
     def setFrozenCurrentMode(self, mode, Ip_presc, Ip_presc_t=0, D_I_min=0, D_I_max=1000):
@@ -384,6 +396,7 @@ class TransportSettings:
 
         self.mhdlike_dBB0 = None
         self.mhdlike_grad_j_tot_max = None
+        self.mhdlike_gradient_normalized = False
         self.mhdlike_min_duration = None
 
         if 'type' in data:
@@ -458,6 +471,7 @@ class TransportSettings:
         if 'mhdlike_dBB0' in data:
             self.mhdlike_dBB0 = float(data['mhdlike_dBB0'])
             self.mhdlike_grad_j_tot_max = float(data['mhdlike_grad_j_tot_max'])
+            self.mhdlike_gradient_normalized = bool(data['mhdlike_gradient_normalized'])
             self.mhdlike_min_duration = float(data['mhdlike_min_duration'])
 
         if 'frozen_current_mode' in data:
@@ -568,6 +582,7 @@ class TransportSettings:
         if self.type == TRANSPORT_MHD_LIKE and self.mhdlike_dBB0 is not None:
             data['mhdlike_dBB0'] = self.mhdlike_dBB0
             data['mhdlike_grad_j_tot_max'] = self.mhdlike_grad_j_tot_max
+            data['mhdlike_gradient_normalized'] = 1 if self.mhdlike_gradient_normalized else 0
             data['mhdlike_min_duration'] = self.mhdlike_min_duration
 
         data['frozen_current_mode'] = self.frozen_current_mode

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -607,6 +607,8 @@ class TransportSettings:
         elif self.type == TRANSPORT_FROZEN_CURRENT:
             self.verifyFrozenCurrent()
             self.verifyBoundaryCondition()
+        elif self.type == TRANSPORT_MHD_LIKE:
+            self.verifyBoundaryCondition()
         else:
             raise TransportException("Unrecognized transport type: {}".format(self.type))
 

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -584,7 +584,7 @@ class TransportSettings:
                 't': self.dBB_t
             }
 
-        if self.type == TRANSPORT_MHD_LIKE and self.mhdlike_dBB0 is not None:
+        if self.type == TRANSPORT_MHD_LIKE or self.type == TRANSPORT_MHD_LIKE_LOCAL and self.mhdlike_dBB0 is not None:
             data['mhdlike_dBB0'] = self.mhdlike_dBB0
             data['mhdlike_grad_j_tot_max'] = self.mhdlike_grad_j_tot_max
             data['mhdlike_gradient_normalized'] = 1 if self.mhdlike_gradient_normalized else 0

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -11,6 +11,7 @@ TRANSPORT_RECHESTER_ROSENBLUTH = 3
 TRANSPORT_SVENSSON = 4
 TRANSPORT_FROZEN_CURRENT = 5
 TRANSPORT_MHD_LIKE = 6
+TRANSPORT_MHD_LIKE_LOCAL = 7
 
 INTERP3D_NEAREST     = 0
 INTERP3D_LINEAR      = 1
@@ -288,12 +289,16 @@ class TransportSettings:
 
     def setMHDLikeRechesterRosenbluth(
         self, dBB0, grad_j_tot_max=None,
-        grad_j_tot_max_norm=None, min_duration=0.5e-3
+        grad_j_tot_max_norm=None, min_duration=0.5e-3,
+        localized=False
     ):
         """
         Enable the MHD-like Rechester-Rosenbluth heat transport model.
         """
-        self.type = TRANSPORT_MHD_LIKE
+        if localized:
+            self.type = TRANSPORT_MHD_LIKE_LOCAL
+        else:
+            self.type = TRANSPORT_MHD_LIKE
 
         self.mhdlike_dBB0 = dBB0
         self.mhdlike_min_duration = min_duration

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -629,6 +629,8 @@ class TransportSettings:
             self.verifyBoundaryCondition()
         elif self.type == TRANSPORT_MHD_LIKE:
             self.verifyBoundaryCondition()
+        elif self.type == TRANSPORT_MHD_LIKE_LOCAL:
+            self.verifyBoundaryCondition()
         else:
             raise TransportException("Unrecognized transport type: {}".format(self.type))
 

--- a/py/DREAM/Settings/TransportSettings.py
+++ b/py/DREAM/Settings/TransportSettings.py
@@ -10,6 +10,7 @@ TRANSPORT_PRESCRIBED = 2
 TRANSPORT_RECHESTER_ROSENBLUTH = 3
 TRANSPORT_SVENSSON = 4
 TRANSPORT_FROZEN_CURRENT = 5
+TRANSPORT_MHD_LIKE = 6
 
 INTERP3D_NEAREST     = 0
 INTERP3D_LINEAR      = 1
@@ -94,6 +95,11 @@ class TransportSettings:
         self.dBB   = None
         self.dBB_t = None
         self.dBB_r = None
+
+        # MHD-like Rechester-Rosenbluth (diffusive) heat transport
+        self.mhdlike_dBB0 = None
+        self.mhdlike_grad_j_tot_max = None
+        self.mhdlike_min_duration = None
 
         # Frozen current mode transport
         self.frozen_current_mode = FROZEN_CURRENT_MODE_DISABLED
@@ -279,6 +285,17 @@ class TransportSettings:
         self.dBB   = dBB
 
 
+    def setMHDLikeRechesterRosenbluth(self, dBB0, grad_j_tot_max, min_duration=0.5e-3):
+        """
+        Enable the MHD-like Rechester-Rosenbluth heat transport model.
+        """
+        self.type = TRANSPORT_MHD_LIKE
+
+        self.mhdlike_dBB0 = dBB0
+        self.mhdlike_grad_j_tot_max = grad_j_tot_max
+        self.mhdlike_min_duration = min_duration
+
+
     def setFrozenCurrentMode(self, mode, Ip_presc, Ip_presc_t=0, D_I_min=0, D_I_max=1000):
         """
         Enable the frozen current mode and specify the target plasma current.
@@ -365,6 +382,10 @@ class TransportSettings:
         self.dBB_r = None
         self.dBB_t = None
 
+        self.mhdlike_dBB0 = None
+        self.mhdlike_grad_j_tot_max = None
+        self.mhdlike_min_duration = None
+
         if 'type' in data:
             self.type = data['type']
 
@@ -433,6 +454,11 @@ class TransportSettings:
             self.dBB   = data['dBB']['x']
             self.dBB_r = data['dBB']['r']
             self.dBB_t = data['dBB']['t']
+
+        if 'mhdlike_dBB0' in data:
+            self.mhdlike_dBB0 = float(data['mhdlike_dBB0'])
+            self.mhdlike_grad_j_tot_max = float(data['mhdlike_grad_j_tot_max'])
+            self.mhdlike_min_duration = float(data['mhdlike_min_duration'])
 
         if 'frozen_current_mode' in data:
             self.frozen_current_mode = int(data['frozen_current_mode'])
@@ -538,6 +564,11 @@ class TransportSettings:
                 'r': self.dBB_r,
                 't': self.dBB_t
             }
+
+        if self.type == TRANSPORT_MHD_LIKE and self.mhdlike_dBB0 is not None:
+            data['mhdlike_dBB0'] = self.mhdlike_dBB0
+            data['mhdlike_grad_j_tot_max'] = self.mhdlike_grad_j_tot_max
+            data['mhdlike_min_duration'] = self.mhdlike_min_duration
 
         data['frozen_current_mode'] = self.frozen_current_mode
         data['D_I_min'] = self.frozen_current_D_I_min

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(dream_equations
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/KineticEquationTermIntegratedOverMomentum.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/MaxwellianCollisionalEnergyTransferTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/RadiatedPowerTerm.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/RunawayTransportRechesterRosenbluth.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/IonisationHeatingTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/CollisionalEnergyTransferKineticTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/SvenssonTransport.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(dream_core
     "${PROJECT_SOURCE_DIR}/src/UnknownQuantityEquation.cpp"
 )
 set(dream_equations
+    "${PROJECT_SOURCE_DIR}/src/Equations/AdaptiveMHDLikeTransportTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/AnalyticDistributionHottail.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/AnalyticDistributionRE.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/CollisionQuantityHandler.cpp"
@@ -43,6 +44,7 @@ set(dream_equations
     "${PROJECT_SOURCE_DIR}/src/Equations/FluidSourceTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/FrozenCurrentCoefficient.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/REPitchDistributionAveragedBACoeff.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/AmperesLawBoundaryAtRMax.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/CollisionalEnergyTransferKineticTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/ComptonRateTerm.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ set(dream_equations
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/MaxwellianCollisionalEnergyTransferTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/RadiatedPowerTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/RunawayTransportRechesterRosenbluth.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/IonisationHeatingTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/CollisionalEnergyTransferKineticTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/SvenssonTransport.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(dream_equations
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/FreeElectronDensityTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/HeatTransportDiffusion.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/HeatTransportRechesterRosenbluth.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/HotTailCurrentDensityFromDistributionFunction.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/HottailRateTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/HottailRateTermHighZ.cpp"

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -17,10 +17,11 @@ using namespace DREAM;
 AdaptiveMHDLikeTransportTerm::AdaptiveMHDLikeTransportTerm(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	bool localized
+	const real_t suppression_level,	bool localized
 ) : grid(grid), uqh(uqh),
 	grad_j_tot_max(grad_j_tot_max),
 	gradient_normalized(gradient_normalized),
+	suppression_level(suppression_level),
 	localized(localized),
 	id_j_tot(uqh->GetUnknownID(OptionConstants::UQTY_J_TOT)) {
 	
@@ -146,7 +147,7 @@ bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientSuppressed() {
  */
 bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientSuppressed(const len_t ir) {
 	real_t gradj = this->GetCurrentGradient(ir);
-	return (std::abs(gradj) <= this->grad_j_tot_max*0.9);
+	return (std::abs(gradj) <= this->grad_j_tot_max*this->suppression_level);
 }
 
 

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -95,8 +95,11 @@ bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientExceeded() {
 				this->mask[ir] = 0;
 		} else
 			// Apply uniformly everywhere
-			this->mask[ir] = 1;
-			if (e) exceeded = true;
+			if (e) {
+				this->mask[ir] = 1;
+				exceeded = true;
+			} else
+				this->mask[ir] = 0;
 	}
 	
 	return exceeded;

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -100,8 +100,10 @@ bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientExceeded(const len_t ir) {
 	else
 		gradj = (j_tot[ir]-j_tot[ir-1]) / dr_f[ir-1];
 	
-	if (this->gradient_normalized)
-		gradj /= this->javg;
+	if (this->gradient_normalized) {
+		const real_t a = this->grid->GetRadialGrid()->GetMinorRadius();
+		gradj *= a / this->javg;
+	}
 	
 	return (std::abs(gradj) >= this->grad_j_tot_max);
 }

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -79,12 +79,14 @@ bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientExceeded() {
 	const len_t nr = this->grid->GetNr();
 	bool exceeded = false;
 
-	for (len_t ir = 0; ir < nr && !exceeded; ir++) {
+	for (len_t ir = 0; ir < nr; ir++) {
+		
 		bool e = this->IsCurrentGradientExceeded(ir);
 
-		if (this->localized) {
+		if (this->localized) {	
 			if (e) {
 				this->mask[ir] = 1;
+				
 				if (ir > 0)
 					this->mask[ir-1] = 1;
 				if (ir < nr-1)
@@ -96,6 +98,7 @@ bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientExceeded() {
 		} else
 			// Apply uniformly everywhere
 			this->mask[ir] = 1;
+			if (e) exceeded = true;
 	}
 	
 	return exceeded;

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -22,15 +22,7 @@ AdaptiveMHDLikeTransportTerm::AdaptiveMHDLikeTransportTerm(
 	grad_j_tot_max(grad_j_tot_max),
 	gradient_normalized(gradient_normalized),
 	min_duration(min_duration),
-	id_j_tot(uqh->GetUnknownID(OptionConstants::UQTY_J_TOT)) {
-	
-	// Evaluate plasma volume
-	const real_t *dr = grid->GetRadialGrid()->GetDr();
-	const real_t *Vp = grid->GetVpVol();
-	this->volume = 0;
-	for (len_t ir = 0; ir < grid->GetNr(); ir++)
-		this->volume += Vp[ir] * dr[ir];
-}
+	id_j_tot(uqh->GetUnknownID(OptionConstants::UQTY_J_TOT)) {}
 
 
 /**
@@ -43,12 +35,12 @@ bool AdaptiveMHDLikeTransportTerm::CheckTransportEnabled(const real_t t) {
 	if (this->gradient_normalized) {
 		const real_t *j_tot = this->uqh->GetUnknownDataPrevious(this->id_j_tot);
 		const real_t *dr = grid->GetRadialGrid()->GetDr();
-		const real_t *Vp = grid->GetVpVol();
+		const real_t a = grid->GetRadialGrid()->GetMinorRadius();
 		this->javg = 0;
 		for (len_t ir = 0; ir < grid->GetNr(); ir++)
-			this->javg += j_tot[ir] * Vp[ir] * dr[ir];
+			this->javg += j_tot[ir] * dr[ir];
 
-		this->javg /= this->volume;
+		this->javg /= a;
 	}
 
 	if (this->transport_enabled) {

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -17,7 +17,7 @@ using namespace DREAM;
 AdaptiveMHDLikeTransportTerm::AdaptiveMHDLikeTransportTerm(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, const real_t min_duration
-) : EquationTerm(grid), uqh(uqh),
+) : grid(grid), uqh(uqh),
 	grad_j_tot_max(grad_j_tot_max), min_duration(min_duration),
 	id_j_tot(uqh->GetUnknownID(OptionConstants::UQTY_J_TOT)) {}
 

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -146,7 +146,7 @@ bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientSuppressed() {
  */
 bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientSuppressed(const len_t ir) {
 	real_t gradj = this->GetCurrentGradient(ir);
-	return (std::abs(gradj) <= this->grad_j_tot_max*0.1);
+	return (std::abs(gradj) <= this->grad_j_tot_max*0.9);
 }
 
 

--- a/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
+++ b/src/Equations/AdaptiveMHDLikeTransportTerm.cpp
@@ -1,0 +1,84 @@
+/**
+ * The 'AdaptiveMHDLikeTransportTerm' is an abstract class which can be used
+ * for the implementation of transport processes which are induced by MHD.
+ */
+
+#include <cmath>
+#include "DREAM/Equations/AdaptiveMHDLikeTransportTerm.hpp"
+#include "DREAM/Settings/OptionConstants.hpp"
+
+
+using namespace DREAM;
+
+
+/**
+ * Constructor.
+ */
+AdaptiveMHDLikeTransportTerm::AdaptiveMHDLikeTransportTerm(
+	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
+	const real_t grad_j_tot_max, const real_t min_duration
+) : EquationTerm(grid), uqh(uqh),
+	grad_j_tot_max(grad_j_tot_max), min_duration(min_duration),
+	id_j_tot(uqh->GetUnknownID(OptionConstants::UQTY_J_TOT)) {}
+
+
+/**
+ * Check if the transport should be enabled. This routine returns
+ * true from when the current density gradient exceeds the threshold
+ * value, until the gradient has been sufficiently reduced, or for
+ * at least 'min_duration' seconds.
+ */
+bool AdaptiveMHDLikeTransportTerm::CheckTransportEnabled(const real_t t) {
+	if (this->transport_enabled) {
+		// Disable transport?
+		// (we disable transport if 'min_duration' has been exceeded,
+		// AND the current density gradient remains high)
+		real_t dt = t - this->transport_enabled_t;
+		if (dt > this->min_duration)
+			this->transport_enabled = IsCurrentGradientExceeded();
+	} else {
+		// Enable transport
+		this->transport_enabled = IsCurrentGradientExceeded();
+		this->transport_enabled_t = t;
+	}
+
+	return this->transport_enabled;
+}
+
+
+/**
+ * Checks whether the current density gradient is
+ * exceeded anywhere on the grid.
+ */
+bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientExceeded() {
+	const len_t nr = this->grid->GetNr();
+	bool exceeded = false;
+
+	for (len_t ir = 0; ir < nr && !exceeded; ir++)
+		exceeded = this->IsCurrentGradientExceeded(ir);
+	
+	return exceeded;
+}
+
+
+/**
+ * Checks whether the current density gradient is
+ * exceeded in the specified radial grid point.
+ *
+ * ir: Radial grid point to check current density gradient in.
+ */
+bool AdaptiveMHDLikeTransportTerm::IsCurrentGradientExceeded(const len_t ir) {
+	const real_t *j_tot = this->uqh->GetUnknownDataPrevious(this->id_j_tot);
+	const real_t *dr_f = this->grid->GetRadialGrid()->GetDr_f();
+
+	// Calculate backward derivatives, except at ir = 0
+	real_t gradj;
+	if (ir == 0)
+		gradj = (j_tot[1]-j_tot[0]) / dr_f[0];
+	else
+		gradj = (j_tot[ir]-j_tot[ir-1]) / dr_f[ir-1];
+	
+	return (std::abs(gradj) >= this->grad_j_tot_max);
+}
+
+

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -1,0 +1,51 @@
+/**
+ * Implementation of the hyperresistive diffusion term with an adaptive
+ * diffusion coefficient.
+ */
+
+#include "DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp"
+
+
+using namespace DREAM;
+
+
+/**
+ * Constructor.
+ */
+AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
+	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
+	const real_t grad_j_tot_max, const real_t Lambda0,
+	const real_t min_duration
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, min_duration),
+	HyperresistiveDiffusionTerm(grid, nullptr), Lambda0(Lambda0) {
+	
+	this->Lambda = new real_t[grid->GetNr()];
+}
+
+
+/**
+ * Destructor.
+ */
+AdaptiveHyperresistiveDiffusionTerm::~AdaptiveHyperresistiveDiffusionTerm() {
+	delete [] this->Lambda;
+}
+
+
+/**
+ * Return the diffusion coefficient.
+ *
+ * t: Time to evaluate the coefficient at.
+ */
+const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t) {
+	real_t v = 0;
+	if (this->CheckTransportEnabled(t))
+		v = this->Lambda0;
+	
+	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
+	for (len_t ir = 0; ir < nr; ir++)
+		this->Lambda[ir] = v;
+	
+	return this->Lambda;
+}
+
+

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -77,11 +77,10 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 				// Total enclosed toroidal flux
 				real_t psit = rg->GetToroidalFlux_f(nr);
 
-
-				this->Lambda0[ir] =
+				
+				this->Lambda0[ir] = 
 					M_PI * Constants::mu0 * qR0 * R0 * V_A * (psit*psit)
 					/ (288*a*a)* this->dBB0*this->dBB0;
-					printf("Lambda0[%d] = %e\n", ir, this->Lambda0[ir]);
 			}
 		}
 	}

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -77,10 +77,11 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 				// Total enclosed toroidal flux
 				real_t psit = rg->GetToroidalFlux_f(nr);
 
+
 				this->Lambda0[ir] =
 					M_PI * Constants::mu0 * qR0 * R0 * V_A * (psit*psit)
-					/ (288*a*a)
-					* this->dBB0*this->dBB0;
+					/ (288*a*a)* this->dBB0*this->dBB0;
+					printf("Lambda0[%d] = %e\n", ir, this->Lambda0[ir]);
 			}
 		}
 	}
@@ -97,9 +98,9 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 	for (len_t iZs = 0; iZs < nZs; iZs++) {
 		for (len_t ir = 0; ir < nr+1; ir++) {
 			if (ir < nr)
-				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*n_i[iZs*(nr+1) + ir]);
+				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*n_i[iZs*nr + ir]);
 			else
-				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*n_i[iZs*(nr+1) + nr-1]);
+				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*n_i[iZs*nr + nr-1]);
 		}
 	}
 	

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -3,6 +3,7 @@
  * diffusion coefficient.
  */
 
+#include "DREAM/Constants.hpp"
 #include "DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp"
 
 
@@ -13,13 +14,17 @@ using namespace DREAM;
  * Constructor.
  */
 AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
-	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
+	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh, IonHandler *ions,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t Lambda0, const real_t min_duration, bool localized
+	const real_t dBB0, const real_t min_duration, bool localized
 ) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration, localized),
-	HyperresistiveDiffusionTerm(grid, nullptr), Lambda0(Lambda0) {
+	HyperresistiveDiffusionTerm(grid, nullptr), ions(ions), dBB0(dBB0) {
 	
+	this->Lambda0 = new real_t[grid->GetNr()];
 	this->Lambda = new real_t[grid->GetNr()];
+	this->dLambda = new real_t[grid->GetNr() * ions->GetNzs()];
+
+	this->id_n_i = uqh->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
 }
 
 
@@ -28,6 +33,8 @@ AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
  */
 AdaptiveHyperresistiveDiffusionTerm::~AdaptiveHyperresistiveDiffusionTerm() {
 	delete [] this->Lambda;
+	delete [] this->Lambda0;
+	delete [] this->dLambda;
 }
 
 
@@ -37,15 +44,68 @@ AdaptiveHyperresistiveDiffusionTerm::~AdaptiveHyperresistiveDiffusionTerm() {
  * t: Time to evaluate the coefficient at.
  */
 const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t) {
-	real_t v = 0;
-	if (this->CheckTransportEnabled(t))
-		v = this->Lambda0;
+	FVM::RadialGrid *rg = this->AdaptiveMHDLikeTransportTerm::grid->GetRadialGrid();
+	const len_t nr = rg->GetNr();
+
+	if (this->CheckTransportEnabled(t)) {
+		const real_t R0 = rg->GetR0();
+
+		if (isinf(R0)) {
+			// In toroidal geometry, Lambda = inf
+			for (len_t ir = 0; ir < nr; ir++)
+				this->Lambda0[ir] = 100;
+		} else {
+			real_t qR0 = R0;
+			// NOTE: Taking the average B is not entirely consistent, as
+			// technically the entire coefficient Lambda should be flux-surface
+			// averaged. However, taking dB/B as a constant, the coefficient
+			// should evaluate to
+			//
+			//   <Lambda> = ... * <V_A> = ... * <B>.
+			//
+			for (len_t ir = 0; ir < nr; ir++) {
+				real_t Bavg = rg->GetFSA_B(ir) * rg->GetBmin(ir);
+				real_t V_A = Bavg / (sqrt(Constants::mu0) * this->ions->GetTotalIonMassDensity(ir));
+				real_t a = rg->GetMinorRadius();
+				real_t psit = rg->GetToroidalFlux(ir);
+
+				this->Lambda0[ir] =
+					M_PI * Constants::mu0 * qR0 * R0 * V_A * (psit*psit)
+					/ (144*a*a)
+					* this->dBB0*this->dBB0;
+			}
+		}
+	}
 	
-	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
 	for (len_t ir = 0; ir < nr; ir++)
-		this->Lambda[ir] = v * this->mask[ir];
+		this->Lambda[ir] = Lambda0[ir] * this->mask[ir];
+
+	// Set ion density derivative of Lambda
+	const len_t nZs = this->ions->GetNzs();
+	const real_t *n_i = uqh->GetUnknownData(this->id_n_i);
+	for (len_t iZs = 0; iZs < nZs; iZs++) {
+		for (len_t ir = 0; ir < nr; ir++) {
+			this->dLambda[iZs*nr + ir] = -this->Lambda[ir] / (2*n_i[iZs*nr + ir]);
+		}
+	}
 	
 	return this->Lambda;
+}
+
+
+/**
+ * Evaluate the partial derivative of Drr.
+ */
+void AdaptiveHyperresistiveDiffusionTerm::SetPartialDiffusionTerm(
+	len_t derivId, len_t nMultiples
+) {
+	if (derivId != this->id_n_i)
+		return;
+	
+	ResetDifferentiationCoefficients();
+
+	for (len_t iZs = 0; iZs < nMultiples; iZs++)
+		this->BuildCoefficient(this->dLambda + iZs*nr, this->ddrr + iZs*nr);
 }
 
 

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -14,9 +14,9 @@ using namespace DREAM;
  */
 AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
-	const real_t grad_j_tot_max, const real_t Lambda0,
-	const real_t min_duration
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, min_duration),
+	const real_t grad_j_tot_max, bool gradient_normalized,
+	const real_t Lambda0, const real_t min_duration
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration),
 	HyperresistiveDiffusionTerm(grid, nullptr), Lambda0(Lambda0) {
 	
 	this->Lambda = new real_t[grid->GetNr()];

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -67,7 +67,8 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 				real_t Bavg = rg->GetFSA_B(ir) * rg->GetBmin(ir);
 				real_t V_A = Bavg / (sqrt(Constants::mu0) * this->ions->GetTotalIonMassDensity(ir));
 				real_t a = rg->GetMinorRadius();
-				real_t psit = rg->GetToroidalFlux(ir);
+				// Total enclosed toroidal flux
+				real_t psit = rg->GetToroidalFlux(nr-1);
 
 				this->Lambda0[ir] =
 					M_PI * Constants::mu0 * qR0 * R0 * V_A * (psit*psit)

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -68,7 +68,7 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 				real_t V_A = Bavg / (sqrt(Constants::mu0) * this->ions->GetTotalIonMassDensity(ir));
 				real_t a = rg->GetMinorRadius();
 				// Total enclosed toroidal flux
-				real_t psit = rg->GetToroidalFlux(nr-1);
+				real_t psit = rg->GetToroidalFlux_f(nr);
 
 				this->Lambda0[ir] =
 					M_PI * Constants::mu0 * qR0 * R0 * V_A * (psit*psit)

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -15,8 +15,8 @@ using namespace DREAM;
 AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t Lambda0, const real_t min_duration
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration),
+	const real_t Lambda0, const real_t min_duration, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration, localized),
 	HyperresistiveDiffusionTerm(grid, nullptr), Lambda0(Lambda0) {
 	
 	this->Lambda = new real_t[grid->GetNr()];
@@ -43,7 +43,7 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 	
 	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
 	for (len_t ir = 0; ir < nr; ir++)
-		this->Lambda[ir] = v;
+		this->Lambda[ir] = v * this->mask[ir];
 	
 	return this->Lambda;
 }

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -16,8 +16,8 @@ using namespace DREAM;
 AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh, IonHandler *ions,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t dBB0, bool localized
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, localized),
+	const real_t dBB0, const real_t suppression_level, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, suppression_level, localized),
 	HyperresistiveDiffusionTerm(grid, nullptr), ions(ions), dBB0(dBB0) {
 	
 	this->Lambda0 = new real_t[grid->GetNr()+1];

--- a/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
@@ -15,8 +15,8 @@ using namespace DREAM;
 HeatTransportRRAdaptiveMHDLike::HeatTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t min_duration, const real_t dBOverB
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration),
+	const real_t min_duration, const real_t dBOverB, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration, localized),
 	HeatTransportRechesterRosenbluth(grid, nullptr, uqh),
 	dBOverB(dBOverB) {
 
@@ -43,7 +43,7 @@ const real_t *HeatTransportRRAdaptiveMHDLike::EvaluateDeltaBOverB(const real_t t
 	
 	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
 	for (len_t ir = 0; ir < nr; ir++)
-		this->dB[ir] = v;
+		this->dB[ir] = v * this->mask[ir];
 	
 	return this->dB;
 }

--- a/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
@@ -15,8 +15,8 @@ using namespace DREAM;
 HeatTransportRRAdaptiveMHDLike::HeatTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t min_duration, const real_t dBOverB, bool localized
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration, localized),
+	const real_t dBOverB, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, localized),
 	HeatTransportRechesterRosenbluth(grid, nullptr, uqh),
 	dBOverB(dBOverB) {
 

--- a/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
@@ -1,0 +1,51 @@
+/**
+ * Adaptive MHD-like heat transport, using a Rechester-Rosenbluth
+ * diffusion coefficient.
+ */
+
+#include "DREAM/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.hpp"
+
+
+using namespace DREAM;
+
+
+/**
+ * Constructor.
+ */
+HeatTransportRRAdaptiveMHDLike::HeatTransportRRAdaptiveMHDLike(
+	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
+	const real_t grad_j_tot_max, const real_t min_duration,
+	const real_t dBOverB
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, min_duration),
+	HeatTransportRechesterRosenbluth(grid, nullptr, uqh),
+	dBOverB(dBOverB) {
+
+	this->dB = new real_t[grid->GetNr()];
+}
+
+
+/**
+ * Destructor.
+ */
+HeatTransportRRAdaptiveMHDLike::~HeatTransportRRAdaptiveMHDLike() {
+	if (this->dB != nullptr)
+		delete [] this->dB;
+}
+
+
+/**
+ * Evaluate dB/B.
+ */
+const real_t *HeatTransportRRAdaptiveMHDLike::EvaluateDeltaBOverB(const real_t t) {
+	real_t v = 0;
+	if (this->CheckTransportEnabled(t))
+		v = this->dBOverB;
+	
+	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
+	for (len_t ir = 0; ir < nr; ir++)
+		this->dB[ir] = v;
+	
+	return this->dB;
+}
+
+

--- a/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
@@ -15,8 +15,8 @@ using namespace DREAM;
 HeatTransportRRAdaptiveMHDLike::HeatTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t dBOverB, bool localized
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, localized),
+	const real_t dBOverB, const real_t suppression_level, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, suppression_level, localized),
 	HeatTransportRechesterRosenbluth(grid, nullptr, uqh),
 	dBOverB(dBOverB) {
 

--- a/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/HeatTransportRRAdaptiveMHDLike.cpp
@@ -14,9 +14,9 @@ using namespace DREAM;
  */
 HeatTransportRRAdaptiveMHDLike::HeatTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
-	const real_t grad_j_tot_max, const real_t min_duration,
-	const real_t dBOverB
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, min_duration),
+	const real_t grad_j_tot_max, bool gradient_normalized,
+	const real_t min_duration, const real_t dBOverB
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration),
 	HeatTransportRechesterRosenbluth(grid, nullptr, uqh),
 	dBOverB(dBOverB) {
 

--- a/src/Equations/Fluid/HeatTransportRechesterRosenbluth.cpp
+++ b/src/Equations/Fluid/HeatTransportRechesterRosenbluth.cpp
@@ -16,9 +16,9 @@ using namespace DREAM;
  * Constructor.
  */
 HeatTransportRechesterRosenbluth::HeatTransportRechesterRosenbluth(
-    FVM::Grid *grid, enum OptionConstants::momentumgrid_type mgtype,
+    FVM::Grid *grid,
     FVM::Interpolator1D *dB_B, FVM::UnknownQuantityHandler *unknowns
-) : FVM::DiffusionTerm(grid), mgtype(mgtype), deltaBOverB(dB_B) {
+) : FVM::DiffusionTerm(grid), deltaBOverB(dB_B) {
 
     SetName("HeatTransportRechesterRosenbluth");
 
@@ -36,7 +36,8 @@ HeatTransportRechesterRosenbluth::HeatTransportRechesterRosenbluth(
  * Destructor.
  */
 HeatTransportRechesterRosenbluth::~HeatTransportRechesterRosenbluth() {
-    delete this->deltaBOverB;
+	if (this->deltaBOverB != nullptr)
+		delete this->deltaBOverB;
     delete [] this->dD;
 }
 
@@ -67,7 +68,7 @@ bool HeatTransportRechesterRosenbluth::GridRebuilt() {
 void HeatTransportRechesterRosenbluth::Rebuild(
     const real_t t, const real_t, FVM::UnknownQuantityHandler *unknowns
 ) {
-    const real_t *dB_B = this->deltaBOverB->Eval(t);
+    const real_t *dB_B = this->EvaluateDeltaBOverB(t);
     const len_t nr = this->grid->GetNr();
     const real_t mc2 = Constants::mc2inEV;
 

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -23,7 +23,7 @@ HyperresistiveDiffusionTerm::HyperresistiveDiffusionTerm(
  */
 void HyperresistiveDiffusionTerm::Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler *){
     FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
-    const real_t *Lmbd  = this->Lambda->Eval(t);
+    const real_t *Lmbd  = this->EvaluateLambda(t);
 
     // XXX: here we assume that all radii have the same momentum grids
     const len_t np1 = n1[0], np2 = n2[0];

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -33,7 +33,6 @@ HyperresistiveDiffusionTerm::~HyperresistiveDiffusionTerm() {
 void HyperresistiveDiffusionTerm::Rebuild(
 	const real_t t, const real_t, FVM::UnknownQuantityHandler*
 ) {
-    //FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
     const real_t *Lmbd  = this->EvaluateLambda(t);
 	this->BuildCoefficient(Lmbd, this->drr);
 }
@@ -71,7 +70,6 @@ void HyperresistiveDiffusionTerm::BuildCoefficient(
 
         for (len_t j = 0; j < np2; j++) 
             for (len_t i = 0; i < np1; i++) 
-                //Drr(ir, i, j) += drr;
 				diffusion_coeff[ir][j*np1 + i] += drr;
     }
 }

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -18,6 +18,15 @@ HyperresistiveDiffusionTerm::HyperresistiveDiffusionTerm(
     SetName("HyperresistiveDiffusionTerm");
 }
 
+
+/**
+ * Destructor.
+ */
+HyperresistiveDiffusionTerm::~HyperresistiveDiffusionTerm() {
+	if (this->Lambda != nullptr)
+		delete this->Lambda;
+}
+
 /**
  * Build the coefficients of this diffusion term.
  */

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -30,10 +30,14 @@ HyperresistiveDiffusionTerm::~HyperresistiveDiffusionTerm() {
 /**
  * Build the coefficients of this diffusion term.
  */
-void HyperresistiveDiffusionTerm::Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler *){
-    FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
+void HyperresistiveDiffusionTerm::Rebuild(
+	const real_t t, const real_t, FVM::UnknownQuantityHandler *unknowns
+) {
+    //FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
     const real_t *Lmbd  = this->EvaluateLambda(t);
+	this->BuildCoefficient(t, unknowns, Lmbd, this->drr);
 
+	/*
     // XXX: here we assume that all radii have the same momentum grids
     const len_t np1 = n1[0], np2 = n2[0];
 
@@ -60,6 +64,45 @@ void HyperresistiveDiffusionTerm::Rebuild(const real_t t, const real_t, FVM::Unk
         for (len_t j = 0; j < np2; j++) 
             for (len_t i = 0; i < np1; i++) 
                 Drr(ir, i, j) += drr;
+    }*/
+}
+
+/**
+ * Set diffusion coefficient, or derivative of, diffusion coefficient.
+ */
+void HyperresistiveDiffusionTerm::BuildCoefficient(
+	const real_t t, FVM::UnknownQuantityHandler*,
+	const real_t *coeff, const real_t **diffusion_coeff
+) {
+    FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
+
+    // XXX: here we assume that all radii have the same momentum grids
+    const len_t np1 = n1[0], np2 = n2[0];
+
+    // (skip ir=0 since psi_t=0 there, and to avoid 1/psitPrime = 1/0)
+    for (len_t ir = 1; ir < nr+1; ir++) {
+        real_t Bmin = rGrid->GetBmin_f(ir);
+        real_t BdotPhi = rGrid->GetBTorG_f(ir)*rGrid->GetFSA_1OverR2_f(ir);
+        real_t VpVol = rGrid->GetVpVol_f(ir); 
+
+        real_t psitPrime = VpVol*BdotPhi / (2*M_PI);
+
+        // The entire d psi/dt equation is multiplied by 2*pi*psi_t'/VpVol,
+        // so we get an extra factor of 2*pi here, and only one factor
+        // of psi_t' (the factor 1/VpVol from the normalisation is included 
+        // via the DiffusionTerm class). We also add a factor of 1/VpVol 
+        // to the diffusion coefficient to cancel the factor VpVol inside 
+        // the first radial derivative added by the DiffusionTerm. 
+        //
+        // Also, we divide by 'Bmin' since this operator is applied to
+        // 'j_tot / (B/Bmin)'.
+        real_t drr = 
+            2*M_PI*rGrid->GetToroidalFlux_f(ir)*coeff[ir] / (VpVol*psitPrime*Bmin);
+
+        for (len_t j = 0; j < np2; j++) 
+            for (len_t i = 0; i < np1; i++) 
+                //Drr(ir, i, j) += drr;
+				diffusion_coeff[ir][j*np1 + i] += drr;
     }
 }
 

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -71,7 +71,6 @@ void HyperresistiveDiffusionTerm::Rebuild(
  * Set diffusion coefficient, or derivative of, diffusion coefficient.
  */
 void HyperresistiveDiffusionTerm::BuildCoefficient(
-	const real_t t, FVM::UnknownQuantityHandler*,
 	const real_t *coeff, const real_t **diffusion_coeff
 ) {
     FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -31,47 +31,18 @@ HyperresistiveDiffusionTerm::~HyperresistiveDiffusionTerm() {
  * Build the coefficients of this diffusion term.
  */
 void HyperresistiveDiffusionTerm::Rebuild(
-	const real_t t, const real_t, FVM::UnknownQuantityHandler *unknowns
+	const real_t t, const real_t, FVM::UnknownQuantityHandler*
 ) {
     //FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
     const real_t *Lmbd  = this->EvaluateLambda(t);
-	this->BuildCoefficient(t, unknowns, Lmbd, this->drr);
-
-	/*
-    // XXX: here we assume that all radii have the same momentum grids
-    const len_t np1 = n1[0], np2 = n2[0];
-
-    // (skip ir=0 since psi_t=0 there, and to avoid 1/psitPrime = 1/0)
-    for (len_t ir = 1; ir < nr+1; ir++) {
-        real_t Bmin = rGrid->GetBmin_f(ir);
-        real_t BdotPhi = rGrid->GetBTorG_f(ir)*rGrid->GetFSA_1OverR2_f(ir);
-        real_t VpVol = rGrid->GetVpVol_f(ir); 
-
-        real_t psitPrime = VpVol*BdotPhi / (2*M_PI);
-
-        // The entire d psi/dt equation is multiplied by 2*pi*psi_t'/VpVol,
-        // so we get an extra factor of 2*pi here, and only one factor
-        // of psi_t' (the factor 1/VpVol from the normalisation is included 
-        // via the DiffusionTerm class). We also add a factor of 1/VpVol 
-        // to the diffusion coefficient to cancel the factor VpVol inside 
-        // the first radial derivative added by the DiffusionTerm. 
-        //
-        // Also, we divide by 'Bmin' since this operator is applied to
-        // 'j_tot / (B/Bmin)'.
-        real_t drr = 
-            2*M_PI*rGrid->GetToroidalFlux_f(ir)*Lmbd[ir] / (VpVol*psitPrime*Bmin);
-
-        for (len_t j = 0; j < np2; j++) 
-            for (len_t i = 0; i < np1; i++) 
-                Drr(ir, i, j) += drr;
-    }*/
+	this->BuildCoefficient(Lmbd, this->drr);
 }
 
 /**
  * Set diffusion coefficient, or derivative of, diffusion coefficient.
  */
 void HyperresistiveDiffusionTerm::BuildCoefficient(
-	const real_t *coeff, const real_t **diffusion_coeff
+	const real_t *coeff, real_t **diffusion_coeff
 ) {
     FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
 

--- a/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
@@ -12,8 +12,8 @@ using namespace DREAM;
 RunawayTransportRRAdaptiveMHDLike::RunawayTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t dBB0, bool localized
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, localized),
+	const real_t dBB0, const real_t suppression_level, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, suppression_level, localized),
 	RunawayTransportRechesterRosenbluth(grid, nullptr), dBOverB(dBB0) {
 		
 	this->dB = new real_t[grid->GetNr()];

--- a/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
@@ -12,8 +12,8 @@ using namespace DREAM;
 RunawayTransportRRAdaptiveMHDLike::RunawayTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t min_duration, const real_t dBB0
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration),
+	const real_t min_duration, const real_t dBB0, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration, localized),
 	RunawayTransportRechesterRosenbluth(grid, nullptr), dBOverB(dBB0) {
 		
 	this->dB = new real_t[grid->GetNr()];
@@ -39,7 +39,7 @@ const real_t *RunawayTransportRRAdaptiveMHDLike::EvaluateDeltaBOverB(const real_
 	
 	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
 	for (len_t ir = 0; ir < nr; ir++)
-		this->dB[ir] = v;
+		this->dB[ir] = v * this->mask[ir];
 	
 	return this->dB;
 }

--- a/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
@@ -1,0 +1,47 @@
+/**
+ */
+
+#include "DREAM/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.hpp"
+
+
+using namespace DREAM;
+
+/**
+ * Constructor.
+ */
+RunawayTransportRRAdaptiveMHDLike::RunawayTransportRRAdaptiveMHDLike(
+	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
+	const real_t grad_j_tot_max, const real_t min_duration,
+	const real_t dBB0
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, min_duration),
+	RunawayTransportRechesterRosenbluth(grid, nullptr), dBOverB(dBB0) {
+		
+	this->dB = new real_t[grid->GetNr()];
+}
+
+
+/**
+ * Destructor.
+ */
+RunawayTransportRRAdaptiveMHDLike::~RunawayTransportRRAdaptiveMHDLike() {
+	if (this->dB != nullptr)
+		delete [] this->dB;
+}
+
+
+/**
+ * Evaluate dB/B.
+ */
+const real_t *RunawayTransportRRAdaptiveMHDLike::EvaluateDeltaBOverB(const real_t t) {
+	real_t v = 0;
+	if (this->CheckTransportEnabled(t))
+		v = this->dBOverB;
+	
+	const len_t nr = this->AdaptiveMHDLikeTransportTerm::grid->GetNr();
+	for (len_t ir = 0; ir < nr; ir++)
+		this->dB[ir] = v;
+	
+	return this->dB;
+}
+
+

--- a/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
@@ -12,8 +12,8 @@ using namespace DREAM;
 RunawayTransportRRAdaptiveMHDLike::RunawayTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
 	const real_t grad_j_tot_max, bool gradient_normalized,
-	const real_t min_duration, const real_t dBB0, bool localized
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration, localized),
+	const real_t dBB0, bool localized
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, localized),
 	RunawayTransportRechesterRosenbluth(grid, nullptr), dBOverB(dBB0) {
 		
 	this->dB = new real_t[grid->GetNr()];

--- a/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
+++ b/src/Equations/Fluid/RunawayTransportRRAdaptiveMHDLike.cpp
@@ -11,9 +11,9 @@ using namespace DREAM;
  */
 RunawayTransportRRAdaptiveMHDLike::RunawayTransportRRAdaptiveMHDLike(
 	FVM::Grid *grid, FVM::UnknownQuantityHandler *uqh,
-	const real_t grad_j_tot_max, const real_t min_duration,
-	const real_t dBB0
-) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, min_duration),
+	const real_t grad_j_tot_max, bool gradient_normalized,
+	const real_t min_duration, const real_t dBB0
+) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, min_duration),
 	RunawayTransportRechesterRosenbluth(grid, nullptr), dBOverB(dBB0) {
 		
 	this->dB = new real_t[grid->GetNr()];

--- a/src/Equations/Fluid/RunawayTransportRechesterRosenbluth.cpp
+++ b/src/Equations/Fluid/RunawayTransportRechesterRosenbluth.cpp
@@ -1,0 +1,51 @@
+/**
+ * Implementation of a Rechester-Rosenbluth diffusion operator for the
+ * runaway electron density, n_re.
+ */
+
+#include "DREAM/Constants.hpp"
+#include "DREAM/Equations/Fluid/RunawayTransportRechesterRosenbluth.hpp"
+
+
+using namespace DREAM;
+
+
+/**
+ * Constructor.
+ */
+RunawayTransportRechesterRosenbluth::RunawayTransportRechesterRosenbluth(
+	FVM::Grid *grid, FVM::Interpolator1D *dBB
+) : FVM::DiffusionTerm(grid), dBB(dBB) { }
+
+
+/**
+ * Destructor.
+ */
+RunawayTransportRechesterRosenbluth::~RunawayTransportRechesterRosenbluth() {
+	if (this->dBB != nullptr)
+		delete this->dBB;
+}
+
+
+/**
+ * Rebuild the diffusion coefficient for this term.
+ */
+void RunawayTransportRechesterRosenbluth::Rebuild(
+	const real_t t, const real_t, FVM::UnknownQuantityHandler*
+) {
+	const real_t *dB_B = this->EvaluateDeltaBOverB(t);
+	FVM::RadialGrid *rg = this->grid->GetRadialGrid();
+	const len_t nr = this->grid->GetNr();
+
+	real_t qR0;
+	const real_t R0 = rg->GetR0();
+	if (isinf(R0))
+		qR0 = 1;
+	else
+		qR0 = R0;
+
+	for (len_t ir = 0; ir < nr; ir++)
+		Drr(ir, 0, 0) += M_PI * qR0 * Constants::c * dB_B[ir];
+}
+
+

--- a/src/IonHandler.cpp
+++ b/src/IonHandler.cpp
@@ -262,6 +262,17 @@ const real_t IonHandler::GetTotalIonDensity(len_t ir, len_t iZ) const{
     return niReturn;
 }
 
+/**
+ * Calculates the total mass density of the ions.
+ */
+const real_t IonHandler::GetTotalIonMassDensity(const len_t ir) const {
+	real_t rho = 0;
+	for (len_t iZ = 0; iZ < this->nZ; iZ++)
+		for (len_t Z0 = 0; Z0 <= this->Zs[iZ]; Z0++)
+			rho += this->GetIonSpeciesMass(iZ) * this->GetIonDensity(ir, iZ, Z0);
+	
+	return rho;
+}
 
 /**
  * Calculates the density of tritium in the plasma.

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -125,6 +125,7 @@ void SimulationGenerator::DefineOptions_ElectricField(Settings *s){
 	s->DefineSetting(MODULENAME_HYPRES "/grad_j_tot_max", "Maximum current density gradient prior to activation of hyperresistive term", (real_t)0.0);
 	s->DefineSetting(MODULENAME_HYPRES "/gradient_normalized", "Flag indicating whether or not 'grad_j_tot_max' is normalized to the average j_tot", (bool)false);
 	s->DefineSetting(MODULENAME_HYPRES "/dBB0", "Magnetic perturbation value for calculating adaptive diffusion coefficient, when enabled", (real_t)0.0);
+	s->DefineSetting(MODULENAME_HYPRES "/suppression_level", "Fraction of the maximum current density gradient below which the adaptive transport should be disabled", (real_t)0.9);
     DefineDataRT(MODULENAME_HYPRES, s, "Lambda");
 }
 
@@ -252,6 +253,7 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 		real_t grad_j_tot_max = s->GetReal(MODULENAME_HYPRES "/grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(MODULENAME_HYPRES "/gradient_normalized");
 		real_t dBB0 = s->GetReal(MODULENAME_HYPRES "/dBB0");
+		real_t suppression_level = s->GetReal(MODULENAME_HYPRES "/suppression_level");
 
 		bool localized = (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL);
 
@@ -259,7 +261,7 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 		AdaptiveHyperresistiveDiffusionTerm *ahrdt = new AdaptiveHyperresistiveDiffusionTerm(
 			fluidGrid, eqsys->GetUnknownHandler(), eqsys->GetIonHandler(),
 			grad_j_tot_max, gradient_normalized,
-			dBB0, localized
+			dBB0, suppression_level, localized
 		);
 
 		hypTerm->AddTerm(ahrdt);

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -123,6 +123,7 @@ void SimulationGenerator::DefineOptions_ElectricField(Settings *s){
     // Settings for hyperresistive term
     s->DefineSetting(MODULENAME_HYPRES "/mode", "Mode for the hyperresistive term", (int_t)OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_NEGLECT);
 	s->DefineSetting(MODULENAME_HYPRES "/grad_j_tot_max", "Maximum current density gradient prior to activation of hyperresistive term", (real_t)0.0);
+	s->DefineSetting(MODULENAME_HYPRES "/gradient_normalized", "Flag indicating whether or not 'grad_j_tot_max' is normalized to the average j_tot", (bool)false);
 	s->DefineSetting(MODULENAME_HYPRES "/Lambda0", "Value of adaptive diffusion coefficient when enabled", (real_t)0.0);
 	s->DefineSetting(MODULENAME_HYPRES "/min_duration", "Minimum duration of the adaptive hyperresistive term", (real_t)0.5e-3);
     DefineDataRT(MODULENAME_HYPRES, s, "Lambda");
@@ -247,13 +248,15 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
         eqn += " + hyperresistivity";
     } else if (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE) {
 		real_t grad_j_tot_max = s->GetReal(MODULENAME_HYPRES "/grad_j_tot_max");
+		bool gradient_normalized = s->GetBool(MODULENAME_HYPRES "/gradient_normalized");
 		real_t Lambda0 = s->GetReal(MODULENAME_HYPRES "/Lambda0");
 		real_t min_duration = s->GetReal(MODULENAME_HYPRES "/min_duration");
 
 		FVM::Operator *hypTerm = new FVM::Operator(fluidGrid);
 		AdaptiveHyperresistiveDiffusionTerm *ahrdt = new AdaptiveHyperresistiveDiffusionTerm(
 			fluidGrid, eqsys->GetUnknownHandler(),
-			grad_j_tot_max, Lambda0, min_duration
+			grad_j_tot_max, gradient_normalized,
+			Lambda0, min_duration
 		);
 
 		hypTerm->AddTerm(ahrdt);

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -124,7 +124,7 @@ void SimulationGenerator::DefineOptions_ElectricField(Settings *s){
     s->DefineSetting(MODULENAME_HYPRES "/mode", "Mode for the hyperresistive term", (int_t)OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_NEGLECT);
 	s->DefineSetting(MODULENAME_HYPRES "/grad_j_tot_max", "Maximum current density gradient prior to activation of hyperresistive term", (real_t)0.0);
 	s->DefineSetting(MODULENAME_HYPRES "/gradient_normalized", "Flag indicating whether or not 'grad_j_tot_max' is normalized to the average j_tot", (bool)false);
-	s->DefineSetting(MODULENAME_HYPRES "/Lambda0", "Value of adaptive diffusion coefficient when enabled", (real_t)0.0);
+	s->DefineSetting(MODULENAME_HYPRES "/dBB0", "Magnetic perturbation value for calculating adaptive diffusion coefficient, when enabled", (real_t)0.0);
 	s->DefineSetting(MODULENAME_HYPRES "/min_duration", "Minimum duration of the adaptive hyperresistive term", (real_t)0.5e-3);
     DefineDataRT(MODULENAME_HYPRES, s, "Lambda");
 }
@@ -252,16 +252,16 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 	) {
 		real_t grad_j_tot_max = s->GetReal(MODULENAME_HYPRES "/grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(MODULENAME_HYPRES "/gradient_normalized");
-		real_t Lambda0 = s->GetReal(MODULENAME_HYPRES "/Lambda0");
+		real_t dBB0 = s->GetReal(MODULENAME_HYPRES "/dBB0");
 		real_t min_duration = s->GetReal(MODULENAME_HYPRES "/min_duration");
 
 		bool localized = (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL);
 
 		FVM::Operator *hypTerm = new FVM::Operator(fluidGrid);
 		AdaptiveHyperresistiveDiffusionTerm *ahrdt = new AdaptiveHyperresistiveDiffusionTerm(
-			fluidGrid, eqsys->GetUnknownHandler(),
+			fluidGrid, eqsys->GetUnknownHandler(), eqsys->GetIonHandler(),
 			grad_j_tot_max, gradient_normalized,
-			Lambda0, min_duration, localized
+			dBB0, min_duration, localized
 		);
 
 		hypTerm->AddTerm(ahrdt);

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -125,7 +125,6 @@ void SimulationGenerator::DefineOptions_ElectricField(Settings *s){
 	s->DefineSetting(MODULENAME_HYPRES "/grad_j_tot_max", "Maximum current density gradient prior to activation of hyperresistive term", (real_t)0.0);
 	s->DefineSetting(MODULENAME_HYPRES "/gradient_normalized", "Flag indicating whether or not 'grad_j_tot_max' is normalized to the average j_tot", (bool)false);
 	s->DefineSetting(MODULENAME_HYPRES "/dBB0", "Magnetic perturbation value for calculating adaptive diffusion coefficient, when enabled", (real_t)0.0);
-	s->DefineSetting(MODULENAME_HYPRES "/min_duration", "Minimum duration of the adaptive hyperresistive term", (real_t)0.5e-3);
     DefineDataRT(MODULENAME_HYPRES, s, "Lambda");
 }
 
@@ -253,7 +252,6 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 		real_t grad_j_tot_max = s->GetReal(MODULENAME_HYPRES "/grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(MODULENAME_HYPRES "/gradient_normalized");
 		real_t dBB0 = s->GetReal(MODULENAME_HYPRES "/dBB0");
-		real_t min_duration = s->GetReal(MODULENAME_HYPRES "/min_duration");
 
 		bool localized = (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL);
 
@@ -261,7 +259,7 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 		AdaptiveHyperresistiveDiffusionTerm *ahrdt = new AdaptiveHyperresistiveDiffusionTerm(
 			fluidGrid, eqsys->GetUnknownHandler(), eqsys->GetIonHandler(),
 			grad_j_tot_max, gradient_normalized,
-			dBB0, min_duration, localized
+			dBB0, localized
 		);
 
 		hypTerm->AddTerm(ahrdt);

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -246,17 +246,22 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 
         eqsys->SetOperator(OptionConstants::UQTY_E_FIELD, OptionConstants::UQTY_J_TOT, hypTerm);
         eqn += " + hyperresistivity";
-    } else if (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE) {
+    } else if (
+		hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE ||
+		hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL
+	) {
 		real_t grad_j_tot_max = s->GetReal(MODULENAME_HYPRES "/grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(MODULENAME_HYPRES "/gradient_normalized");
 		real_t Lambda0 = s->GetReal(MODULENAME_HYPRES "/Lambda0");
 		real_t min_duration = s->GetReal(MODULENAME_HYPRES "/min_duration");
 
+		bool localized = (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL);
+
 		FVM::Operator *hypTerm = new FVM::Operator(fluidGrid);
 		AdaptiveHyperresistiveDiffusionTerm *ahrdt = new AdaptiveHyperresistiveDiffusionTerm(
 			fluidGrid, eqsys->GetUnknownHandler(),
 			grad_j_tot_max, gradient_normalized,
-			Lambda0, min_duration
+			Lambda0, min_duration, localized
 		);
 
 		hypTerm->AddTerm(ahrdt);

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -21,6 +21,7 @@
 #include "FVM/Equation/PrescribedParameter.hpp"
 #include "FVM/Equation/DiagonalLinearTerm.hpp"
 #include "FVM/Equation/LinearTransientTerm.hpp"
+#include "DREAM/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.hpp"
 #include "DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp"
 #include "DREAM/Equations/Fluid/EFieldFromConductivityTerm.hpp"
 
@@ -89,6 +90,7 @@ namespace DREAM {
 
 
 #define MODULENAME "eqsys/E_field"
+#define MODULENAME_HYPRES "eqsys/psi_p/hyperresistivity"
 
 
 /**
@@ -119,8 +121,11 @@ void SimulationGenerator::DefineOptions_ElectricField(Settings *s){
     DefineDataT(MODULENAME "/bc", s, "V_loop_wall");
 
     // Settings for hyperresistive term
-    s->DefineSetting("eqsys/psi_p/hyperresistivity/enabled", "Enable the hyperresistive diffusion term", (bool)false);
-    DefineDataRT("eqsys/psi_p/hyperresistivity", s, "Lambda");
+    s->DefineSetting(MODULENAME_HYPRES "/mode", "Mode for the hyperresistive term", (int_t)OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_NEGLECT);
+	s->DefineSetting(MODULENAME_HYPRES "/grad_j_tot_max", "Maximum current density gradient prior to activation of hyperresistive term", (real_t)0.0);
+	s->DefineSetting(MODULENAME_HYPRES "/Lambda0", "Value of adaptive diffusion coefficient when enabled", (real_t)0.0);
+	s->DefineSetting(MODULENAME_HYPRES "/min_duration", "Minimum duration of the adaptive hyperresistive term", (real_t)0.5e-3);
+    DefineDataRT(MODULENAME_HYPRES, s, "Lambda");
 }
 
 /**
@@ -222,23 +227,41 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
     Vloop->AddTerm(new VloopTerm(fluidGrid));
 
     // Add hyperresistive term
-    if (s->GetBool("eqsys/psi_p/hyperresistivity/enabled")) {
+	enum OptionConstants::eqterm_hyperresistivity_mode hypres_mode =
+		(enum OptionConstants::eqterm_hyperresistivity_mode)s->GetInteger(MODULENAME_HYPRES "/mode");
+    if (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_PRESCRIBED) {
         FVM::Interpolator1D *Lambda = LoadDataRT_intp(
-            "eqsys/psi_p/hyperresistivity",
+            MODULENAME_HYPRES,
             eqsys->GetFluidGrid()->GetRadialGrid(),
             s, "Lambda", true
         );
 
-        FVM::Operator *hyperTerm = new FVM::Operator(fluidGrid);
+        FVM::Operator *hypTerm = new FVM::Operator(fluidGrid);
         HyperresistiveDiffusionTerm *hrdt = new HyperresistiveDiffusionTerm(
             fluidGrid, Lambda
         );
-        hyperTerm->AddTerm(hrdt);
+        hypTerm->AddTerm(hrdt);
         oqty_terms->psi_p_hyperresistive = hrdt;
 
-        eqsys->SetOperator(OptionConstants::UQTY_E_FIELD, OptionConstants::UQTY_J_TOT, hyperTerm);
+        eqsys->SetOperator(OptionConstants::UQTY_E_FIELD, OptionConstants::UQTY_J_TOT, hypTerm);
         eqn += " + hyperresistivity";
-    }
+    } else if (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_ADAPTIVE) {
+		real_t grad_j_tot_max = s->GetReal(MODULENAME_HYPRES "/grad_j_tot_max");
+		real_t Lambda0 = s->GetReal(MODULENAME_HYPRES "/Lambda0");
+		real_t min_duration = s->GetReal(MODULENAME_HYPRES "/min_duration");
+
+		FVM::Operator *hypTerm = new FVM::Operator(fluidGrid);
+		AdaptiveHyperresistiveDiffusionTerm *ahrdt = new AdaptiveHyperresistiveDiffusionTerm(
+			fluidGrid, eqsys->GetUnknownHandler(),
+			grad_j_tot_max, Lambda0, min_duration
+		);
+
+		hypTerm->AddTerm(ahrdt);
+		oqty_terms->psi_p_hyperresistive = ahrdt;
+
+		eqsys->SetOperator(OptionConstants::UQTY_E_FIELD, OptionConstants::UQTY_J_TOT, hypTerm);
+		eqn += " + hyperresistivity";
+	}
 
     eqsys->SetOperator(OptionConstants::UQTY_E_FIELD, OptionConstants::UQTY_POL_FLUX, dtTerm, eqn);
     eqsys->SetOperator(OptionConstants::UQTY_E_FIELD, OptionConstants::UQTY_E_FIELD, Vloop);

--- a/src/Settings/Transport.cpp
+++ b/src/Settings/Transport.cpp
@@ -78,11 +78,6 @@ void SimulationGenerator::DefineOptions_Transport(
 		"Flag indicating whether or not 'mhdlike_grad_j_tot_max' is normalized to the average j_tot",
 		(bool)false
 	);
-	s->DefineSetting(
-		mod + "/" + subname + "/mhdlike_min_duration",
-		"Minimum duration of the adaptive hyperresistive term",
-		(real_t)0.5e-3
-	);
 
 	// Frozen current mode
 	s->DefineSetting(
@@ -435,7 +430,6 @@ bool SimulationGenerator::ConstructTransportTerm(
 		real_t dBB0 = s->GetReal(mod + "/" + subname + "/mhdlike_dBB0");
 		real_t grad_j_tot_max = s->GetReal(mod + "/" + subname + "/mhdlike_grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(mod + "/" + subname + "/mhdlike_gradient_normalized");
-		real_t min_duration = s->GetReal(mod + "/" + subname + "/mhdlike_min_duration");
 		bool localized = (type == OptionConstants::EQTERM_TRANSPORT_MHD_LIKE_LOCAL);
 
         if (heat) {
@@ -444,7 +438,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 			HeatTransportRRAdaptiveMHDLike *hrr = new HeatTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
 				grad_j_tot_max, gradient_normalized,
-				min_duration, dBB0, localized
+				dBB0, localized
 			);
 
 			oprtr->AddTerm(hrr);
@@ -464,7 +458,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 			RunawayTransportRRAdaptiveMHDLike *rrr = new RunawayTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
 				grad_j_tot_max, gradient_normalized,
-				min_duration, dBB0, localized
+				dBB0, localized
 			);
 			oprtr->AddTerm(rrr);
 

--- a/src/Settings/Transport.cpp
+++ b/src/Settings/Transport.cpp
@@ -74,6 +74,11 @@ void SimulationGenerator::DefineOptions_Transport(
 		(real_t)0.0
 	);
 	s->DefineSetting(
+		mod + "/" + subname + "/mhdlike_gradient_normalized",
+		"Flag indicating whether or not 'mhdlike_grad_j_tot_max' is normalized to the average j_tot",
+		(bool)false
+	);
+	s->DefineSetting(
 		mod + "/" + subname + "/mhdlike_min_duration",
 		"Minimum duration of the adaptive hyperresistive term",
 		(real_t)0.5e-3
@@ -426,6 +431,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 
 		real_t dBB0 = s->GetReal(mod + "/" + subname + "/mhdlike_dBB0");
 		real_t grad_j_tot_max = s->GetReal(mod + "/" + subname + "/mhdlike_grad_j_tot_max");
+		bool gradient_normalized = s->GetBool(mod + "/" + subname + "/mhdlike_gradient_normalized");
 		real_t min_duration = s->GetReal(mod + "/" + subname + "/mhdlike_min_duration");
 
         if (heat) {
@@ -433,7 +439,8 @@ bool SimulationGenerator::ConstructTransportTerm(
 
 			HeatTransportRRAdaptiveMHDLike *hrr = new HeatTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
-				grad_j_tot_max, min_duration, dBB0
+				grad_j_tot_max, gradient_normalized,
+				min_duration, dBB0
 			);
 
 			oprtr->AddTerm(hrr);
@@ -452,7 +459,8 @@ bool SimulationGenerator::ConstructTransportTerm(
 
 			RunawayTransportRRAdaptiveMHDLike *rrr = new RunawayTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
-				grad_j_tot_max, min_duration, dBB0
+				grad_j_tot_max, gradient_normalized,
+				min_duration, dBB0
 			);
 			oprtr->AddTerm(rrr);
 

--- a/src/Settings/Transport.cpp
+++ b/src/Settings/Transport.cpp
@@ -74,7 +74,7 @@ void SimulationGenerator::DefineOptions_Transport(
 		(real_t)0.0
 	);
 	s->DefineSetting(
-		mod + "/" + subname + "/min_duration",
+		mod + "/" + subname + "/mhdlike_min_duration",
 		"Minimum duration of the adaptive hyperresistive term",
 		(real_t)0.5e-3
 	);

--- a/src/Settings/Transport.cpp
+++ b/src/Settings/Transport.cpp
@@ -422,7 +422,10 @@ bool SimulationGenerator::ConstructTransportTerm(
     }
 
 	// MHD-like Rechester-Rosenbluth heat transport
-	if (type == OptionConstants::EQTERM_TRANSPORT_MHD_LIKE) {
+	if (
+		type == OptionConstants::EQTERM_TRANSPORT_MHD_LIKE ||
+		type == OptionConstants::EQTERM_TRANSPORT_MHD_LIKE_LOCAL
+	) {
         if (hasNonTrivialTransport)
             DREAM::IO::PrintWarning(
                 DREAM::IO::WARNING_INCOMPATIBLE_TRANSPORT,
@@ -433,6 +436,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 		real_t grad_j_tot_max = s->GetReal(mod + "/" + subname + "/mhdlike_grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(mod + "/" + subname + "/mhdlike_gradient_normalized");
 		real_t min_duration = s->GetReal(mod + "/" + subname + "/mhdlike_min_duration");
+		bool localized = (type == OptionConstants::EQTERM_TRANSPORT_MHD_LIKE_LOCAL);
 
         if (heat) {
 			hasNonTrivialTransport = true;
@@ -440,7 +444,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 			HeatTransportRRAdaptiveMHDLike *hrr = new HeatTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
 				grad_j_tot_max, gradient_normalized,
-				min_duration, dBB0
+				min_duration, dBB0, localized
 			);
 
 			oprtr->AddTerm(hrr);
@@ -460,7 +464,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 			RunawayTransportRRAdaptiveMHDLike *rrr = new RunawayTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
 				grad_j_tot_max, gradient_normalized,
-				min_duration, dBB0
+				min_duration, dBB0, localized
 			);
 			oprtr->AddTerm(rrr);
 

--- a/src/Settings/Transport.cpp
+++ b/src/Settings/Transport.cpp
@@ -78,6 +78,11 @@ void SimulationGenerator::DefineOptions_Transport(
 		"Flag indicating whether or not 'mhdlike_grad_j_tot_max' is normalized to the average j_tot",
 		(bool)false
 	);
+	s->DefineSetting(
+		mod + "/" + subname + "/mhdlike_suppression_level",
+		"Fraction of the maximum current density gradient below which the adaptive transport should be disabled",
+		(real_t)0.9
+	);
 
 	// Frozen current mode
 	s->DefineSetting(
@@ -430,6 +435,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 		real_t dBB0 = s->GetReal(mod + "/" + subname + "/mhdlike_dBB0");
 		real_t grad_j_tot_max = s->GetReal(mod + "/" + subname + "/mhdlike_grad_j_tot_max");
 		bool gradient_normalized = s->GetBool(mod + "/" + subname + "/mhdlike_gradient_normalized");
+		real_t suppression_level = s->GetReal(mod + "/" + subname + "/mhdlike_suppression_level");
 		bool localized = (type == OptionConstants::EQTERM_TRANSPORT_MHD_LIKE_LOCAL);
 
         if (heat) {
@@ -438,7 +444,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 			HeatTransportRRAdaptiveMHDLike *hrr = new HeatTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
 				grad_j_tot_max, gradient_normalized,
-				dBB0, localized
+				dBB0, suppression_level, localized
 			);
 
 			oprtr->AddTerm(hrr);
@@ -458,7 +464,7 @@ bool SimulationGenerator::ConstructTransportTerm(
 			RunawayTransportRRAdaptiveMHDLike *rrr = new RunawayTransportRRAdaptiveMHDLike(
 				grid, eqsys->GetUnknownHandler(),
 				grad_j_tot_max, gradient_normalized,
-				dBB0, localized
+				dBB0, suppression_level, localized
 			);
 			oprtr->AddTerm(rrr);
 


### PR DESCRIPTION
This branch implements a set of new operators for a type of transport which is driven by current density gradients. They are intended as a mitigation for current spikes which form during the CQ of a disruption, in a similar manner to how MHD instabilities are likely driven in experiments to prevent the formation of such spikes.

This branch introduces the following new C++ classes:
- ``RunawayTransportRechesterRosenbluth``: An implementation of the Rechester-Rosenbluth diffusion operator for the ``n_re`` fluid. Now, ``n_re`` transport can be enabled by just specifying $\delta B/B$.
- ``AdaptiveMHDLikeTransportTerm``: An abstract parent class which contains all the routines for determining if the current gradient-driven transport should be activated or not.
- ``AdaptiveHyperresistiveDiffusionTerm``: An implementation of the current gradient-driven transport for the hyperresistive diffusion term.
- ``HeatTransportRRAdaptiveMHDLike``: An implementation of the current gradient-driven transport for the Rechester-Rosenbluth heat diffusion term.
- ``RunawayTransportRRAdaptiveMHDLike``: An implementation of the current gradient-driven transport for the Rechester-Rosenbluth runaway diffusion term.

In addition, the derivation of Rechester-Rosenbluth transport for the runaway density has been documented.