### PR TITLE
Add routines for downloading TCV magnetic eq

### DIFF
--- a/tools/eqget/MainWindow.py
+++ b/tools/eqget/MainWindow.py
@@ -14,6 +14,7 @@ from DREAM import DREAMIO
 from pathlib import Path
 
 import AUG
+import TCV
 import EqFile
 
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -45,6 +46,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if AUG.isAvailable():
             self.ui.cbTokamak.addItem('ASDEX Upgrade', AUG)
+        if TCV.isAvailable():
+            self.ui.cbTokamak.addItem('TCV', TCV)
 
         self.ui.cbTokamak.addItem('File', EqFile)
         self.tokamakChanged()
@@ -163,7 +166,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.plotFluxSurfaces()
             self.toggleEnabled(True)
         except Exception as ex:
-            QMessageBox.critical(self, 'Error loading data', f"The specified data file could not be loaded:\n\n{ex}")
+            QMessageBox.critical(self, 'Error loading data', f"The specified data file could not be loaded:\n\n{traceback.format_exc()}")
 
 
     def calculateShaping(self):

--- a/tools/eqget/TCV.py
+++ b/tools/eqget/TCV.py
@@ -1,0 +1,60 @@
+
+import h5py
+import numpy as np
+import sys
+import eqhelpers
+
+try:
+    from tcvpyget import TCV as TCVMDS
+    tcv = TCVMDS()
+
+    AVAILABLE = True
+except:
+    AVAILABLE = False
+
+
+def isAvailable():
+    """
+    Returns ``True`` if this module can be used to fetch equilibrium data
+    on this system.
+    """
+    return AVAILABLE
+
+
+def getLUKE(shot, time, filename=None):
+    """
+    Returns magnetic equilibrium data for the given time of the specified
+    TCV shot. If ``filename`` is provided, the data is also saved to the
+    named LUKE equilibrium data file.
+
+    :param shot: TCV shot to fetch equilibrium data for.
+    :param time: Time to fetch equilibrium for.
+    :param filename: Name of file to store data in.
+    """
+    global tcv
+
+    tcv.openShot(shot)
+    eq = tcv.equilibrium(time=time)
+    tcv.closeall()
+
+    if filename:
+        with h5py.File(filename, 'w') as f:
+            f.create_group('equil')
+
+            for key in equil.keys():
+                f[f'equil/{key}'] = eq[key]
+
+    return eq
+
+
+def getShaping(shot, time, filename=None, equil=None):
+    """
+    Fit shaping parameters to the numerical equilibrium in TCV shot 'shot'
+    at time 'time'.
+    """
+    if equil is None:
+        equil = getLUKE(shot=shot, time=time)
+
+    return eqhelpers.parametrize_equilibrium(**equil)
+
+


### PR DESCRIPTION
This pull request adds new routines for downloading a magnetic equilibrium for a specified shot and time point from the TCV shot database. The routines use the Python library ``tcvpyget``, developed by me and which is available either on LAC8 or in a private GitHub repository, to get the equilibrium.