### PR TITLE
Small change in string interpreting for FluidQuantity plotting

### DIFF
--- a/py/DREAM/Output/FluidQuantity.py
+++ b/py/DREAM/Output/FluidQuantity.py
@@ -276,7 +276,7 @@ class FluidQuantity(UnknownQuantity):
         if colorbar:
             cb = plt.colorbar(mappable=cp, ax=ax)
             if logscale:
-                cb.ax.set_ylabel('$\log _{10}($'+'{}'.format(self.getTeXName()+')'))
+                cb.ax.set_ylabel(r'$\log _{10}($'+'{}'.format(self.getTeXName()+')'))
             else:
                 cb.ax.set_ylabel('{}'.format(self.getTeXName()))
             


### PR DESCRIPTION
A syntax warning was being thrown with invalid escape sequence `\l`, thererefore cast the string as a Raw string. Typically done for latex in matplotlib (e.g., `'\alpha'` requires `r'\alpha'`). 

The warning was thrown everytime `DREAMpy` was imported. I disabled it locally, but thought to fix it for other new users. 