### PR TITLE
Small update and bug fix

### DIFF
--- a/py/DREAM/Output/DistributionFunction.py
+++ b/py/DREAM/Output/DistributionFunction.py
@@ -75,7 +75,8 @@ class DistributionFunction(KineticQuantity):
         this distribution function.
         """
         j = self.currentDensity(t=t)
-        return self.grid.integrate(j)
+        geom = self.grid.GR0/self.grid.Bmin * self.grid.FSA_R02OverR2
+        return self.grid.integrate(j, geom)/ (2*np.pi)
 
 
     def pressure(self, t=None, r=None):

--- a/py/DREAM/Output/KineticQuantity.py
+++ b/py/DREAM/Output/KineticQuantity.py
@@ -342,7 +342,6 @@ class KineticQuantity(UnknownQuantity):
             raise OutputException("Data dimensionality is too high. Unable to visualize kinetic quantity.")
 
         if coordinates is None:
-            print(self.p1.shape)
             cp = ax.contourf(self.p1, self.p2, data, cmap='GeriMap', **kwargs)
             ax.set_xlabel(self.momentumgrid.getP1TeXName())
             ax.set_ylabel(self.momentumgrid.getP2TeXName())

--- a/py/DREAM/Output/KineticQuantity.py
+++ b/py/DREAM/Output/KineticQuantity.py
@@ -331,7 +331,7 @@ class KineticQuantity(UnknownQuantity):
         data = None
         sign = ''
         if logarithmic:
-            if np.all(self.data[t,r,:] <=0 ):
+            if np.all(self.data[t,r,:] <=0):
                 sign = '$-$'
                 data = np.log10(-self.data[t,r,:])
             else:

--- a/py/DREAM/Output/KineticQuantity.py
+++ b/py/DREAM/Output/KineticQuantity.py
@@ -329,10 +329,11 @@ class KineticQuantity(UnknownQuantity):
                 show = True
 
         data = None
+        sign = ''
         if logarithmic:
             if np.max(self.data[t,r,:]) <=0:
+                sign = '$-$'
                 data = np.log10(-self.data[t,r,:])
-                print('Warning: This quantity is negative, but for the purpose of logarithmic plotting it has been turned positive.')
             else:
                 data = np.log10(self.data[t,r,:])
         else:
@@ -371,6 +372,8 @@ class KineticQuantity(UnknownQuantity):
             ax.set_ylabel(r'$p_\perp/mc$')
         else:
             raise OutputException("Unrecognized coordinate type: '{}'.".format(coordinates))
+
+        ax.set_title(f'{sign}{self.getTeXName()}')
 
         cb = None
         if genax:

--- a/py/DREAM/Output/KineticQuantity.py
+++ b/py/DREAM/Output/KineticQuantity.py
@@ -331,7 +331,7 @@ class KineticQuantity(UnknownQuantity):
         data = None
         sign = ''
         if logarithmic:
-            if np.max(self.data[t,r,:]) <=0:
+            if np.all(self.data[t,r,:] <=0 ):
                 sign = '$-$'
                 data = np.log10(-self.data[t,r,:])
             else:

--- a/py/DREAM/Output/KineticQuantity.py
+++ b/py/DREAM/Output/KineticQuantity.py
@@ -299,7 +299,7 @@ class KineticQuantity(UnknownQuantity):
         q = np.zeros((len(t), len(r)))
         for iT in range(len(t)):
             for iR in range(len(r)):
-                q[iT,iR] = self.momentumgrid.integrate2D(self.data[t[iT],r[iR],:] * weight[t[iT],r[iR],:])[0]
+                q[iT,iR] = self.momentumgrid.integrate2D(self.data[t[iT],r[iR],:] * weight[t[iT],r[iR],:])[iR]
         
         return q
 
@@ -330,7 +330,11 @@ class KineticQuantity(UnknownQuantity):
 
         data = None
         if logarithmic:
-            data = np.log10(self.data[t,r,:])
+            if np.max(self.data[t,r,:]) <=0:
+                data = np.log10(-self.data[t,r,:])
+                print('Warning: This quantity is negative, but for the purpose of logarithmic plotting it has been turned positive.')
+            else:
+                data = np.log10(self.data[t,r,:])
         else:
             data = self.data[t,r,:]
 
@@ -338,6 +342,7 @@ class KineticQuantity(UnknownQuantity):
             raise OutputException("Data dimensionality is too high. Unable to visualize kinetic quantity.")
 
         if coordinates is None:
+            print(self.p1.shape)
             cp = ax.contourf(self.p1, self.p2, data, cmap='GeriMap', **kwargs)
             ax.set_xlabel(self.momentumgrid.getP1TeXName())
             ax.set_ylabel(self.momentumgrid.getP2TeXName())


### PR DESCRIPTION
The Moment-function of the KineticQuantity-class always used Vprime/VpVol w.r.t. r=0, instead of r=iR, which we have fixed. We also added toe functionality to plot negative quantities with logarithmic scales. 