### PR TITLE
Add "PrintBOfTheta()" to FluxSurfaceAverager

### DIFF
--- a/fvm/Grid/FluxSurfaceAverager.cpp
+++ b/fvm/Grid/FluxSurfaceAverager.cpp
@@ -808,3 +808,17 @@ real_t FluxSurfaceAverager::EvaluateCellAveragedBounceIntegralOverP2(len_t ir, r
 
     return (partResult1+partResult2+partResult3)/dxi;
 }
+
+/**
+ * Print the variation of B(theta) to stdout.
+ */
+void FluxSurfaceAverager::PrintBOfTheta(const len_t ir, const len_t N, enum fluxGridType fgt) {
+	printf("B(theta) at ir = " LEN_T_PRINTF_FMT "\n", ir);
+	for (len_t i = 0; i < N; i++)
+		printf("%.12e,", 2*M_PI * (i/((real_t)N)) - M_PI);
+	printf("\n");
+		
+	for (len_t i = 0; i < N; i++)
+		printf("%.12e,", BAtTheta(ir, 2*M_PI * (i/((real_t)N)) - M_PI, fgt));
+	printf("\n");
+}

--- a/fvm/Grid/FluxSurfaceAverager.cpp
+++ b/fvm/Grid/FluxSurfaceAverager.cpp
@@ -819,7 +819,7 @@ void FluxSurfaceAverager::PrintBOfTheta(const len_t ir, const len_t N, enum flux
 		printf(",%.12e", 2*M_PI * (i/((real_t)N)) - M_PI);
 	printf("]\n");
 		
-	printf("B = [%.12e", BAtTheta(ir, -M_PI, fgt));
+	printf("B     = [%.12e", BAtTheta(ir, -M_PI, fgt));
 	for (len_t i = 0; i < N; i++)
 		printf(",%.12e", BAtTheta(ir, 2*M_PI * (i/((real_t)N)) - M_PI, fgt));
 	printf("]\n");

--- a/fvm/Grid/FluxSurfaceAverager.cpp
+++ b/fvm/Grid/FluxSurfaceAverager.cpp
@@ -814,11 +814,14 @@ real_t FluxSurfaceAverager::EvaluateCellAveragedBounceIntegralOverP2(len_t ir, r
  */
 void FluxSurfaceAverager::PrintBOfTheta(const len_t ir, const len_t N, enum fluxGridType fgt) {
 	printf("B(theta) at ir = " LEN_T_PRINTF_FMT "\n", ir);
-	for (len_t i = 0; i < N; i++)
-		printf("%.12e,", 2*M_PI * (i/((real_t)N)) - M_PI);
-	printf("\n");
+	printf("theta = [%.12e", -M_PI);
+	for (len_t i = 1; i < N; i++)
+		printf(",%.12e", 2*M_PI * (i/((real_t)N)) - M_PI);
+	printf("]\n");
 		
+	printf("B = [%.12e", BAtTheta(ir, -M_PI, fgt));
 	for (len_t i = 0; i < N; i++)
-		printf("%.12e,", BAtTheta(ir, 2*M_PI * (i/((real_t)N)) - M_PI, fgt));
-	printf("\n");
+		printf(",%.12e", BAtTheta(ir, 2*M_PI * (i/((real_t)N)) - M_PI, fgt));
+	printf("]\n");
 }
+

--- a/include/FVM/Grid/FluxSurfaceAverager.hpp
+++ b/include/FVM/Grid/FluxSurfaceAverager.hpp
@@ -199,6 +199,8 @@ namespace DREAM::FVM {
             real_t BOverBmin, real_t ROverR0, real_t NablaR2, const int_t *Flist
         );
         real_t EvaluateAvalancheDeltaHat(len_t ir, real_t p, real_t xi_l, real_t xi_u, real_t Vp, real_t VpVol, int_t RESign = 1);
+
+		void PrintBOfTheta(const len_t ir, const len_t N=1000, enum fluxGridType fgt=FLUXGRIDTYPE_DISTRIBUTION);
     };
 }
 


### PR DESCRIPTION
This routine prints the magnetic field strength as a function of poloidal angle. It is often useful when debugging numerical equilibria.