### PR TITLE
Fix issue #401

### DIFF
--- a/src/Equations/AnalyticDistributionRE.cpp
+++ b/src/Equations/AnalyticDistributionRE.cpp
@@ -301,7 +301,7 @@ real_t AnalyticDistributionRE::evaluateFullDistributionWithE(
 	len_t ir, real_t xi0, real_t p, real_t E,
 	real_t *dfdxi0, real_t *dfdp, real_t *dfdr
 ) {
-	return evaluateEnergyDistributionWithE(ir, p, E, dfdp, dfdr) *
+	return evaluateEnergyDistribution(ir, p, dfdp, dfdr) *
 		evaluatePitchDistributionWithE(ir, xi0, p, E, dfdxi0, dfdp, dfdr);
 }
 


### PR DESCRIPTION
This pull request implements a fix for #401. Since ``E-Eceff`` in the exponent of the energy distribution is supposed to cancel the same factor in the avalanche growth rate (which is evaluated in ``RunawayFluid``, and therefore always uses the latest value for ``E_field``), the energy distribution should always be evaluated with the latest value for ``E_field``, regardless of what value is used for the pitch distribution.