### PR TITLE
Use expint from GSL

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ alphabetical order):
 Adam Kit
 Alexandre Fil
 Andréas Sundström
+Björn Zaar
 Boel Brandström
 Esmée Berger
 Ferenc Lengyel

--- a/src/Equations/SPIHandler.cpp
+++ b/src/Equations/SPIHandler.cpp
@@ -372,7 +372,7 @@ void SPIHandler::AssignDriftComputationParameters(len_t ip){
        
     // Calculate the fraction of the heat flux being absorbed in the cloud, using eq. 4.77 in Nicos MSc thesis
     real_t x = rf->GetElectronCollisionTimeThermal(irp[ip])*neBgDrift/n0Drift*(1+Zavg0Drift)*sqrt(2*TeBgDrift*qe/me)/LcInitDrift;// Ratio of mean free path and cloud length
-    plasmoidAbsorbtionFactor[ip] = 1-1/(x*x)*(exp(-1/sqrt(x))*(-0.5*sqrt(x)+0.5*x+x*sqrt(x)+x*x)-0.5*expint(-1/sqrt(x)));
+    plasmoidAbsorbtionFactor[ip] = 1-1/(x*x)*(exp(-1/sqrt(x))*(-0.5*sqrt(x)+0.5*x+x*sqrt(x)+x*x)-0.5*gsl_sf_expint_Ei(-1/sqrt(x)));
 
 }
 


### PR DESCRIPTION
DREAM failed to build with Clang, as "expint" in SPIHandler.cpp was not recognized.

Changed "expint" to "gsl_sf_expint_Ei" instead .