### PR TITLE
Fix bug in IonSourceTerm

### DIFF
--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.interpolate
 from numpy.matlib import repmat
 from DREAM.Settings.Equations.EquationException import EquationException
-from DREAM.Settings.Equations.IonSpecies import IonSpecies, IONS_PRESCRIBED, IONIZATION_MODE_FLUID, IONIZATION_MODE_KINETIC, IONIZATION_MODE_KINETIC_APPROX_JAC, IONIZATION_MODE_FLUID_RE, ION_OPACITY_MODE_TRANSPARENT, ION_CHARGED_DIFFUSION_MODE_NONE, ION_CHARGED_DIFFUSION_MODE_PRESCRIBED, ION_NEUTRAL_DIFFUSION_MODE_NONE, ION_NEUTRAL_DIFFUSION_MODE_PRESCRIBED, ION_CHARGED_ADVECTION_MODE_NONE, ION_CHARGED_ADVECTION_MODE_PRESCRIBED, ION_NEUTRAL_ADVECTION_MODE_NONE, ION_NEUTRAL_ADVECTION_MODE_PRESCRIBED
+from DREAM.Settings.Equations.IonSpecies import IonSpecies, IONS_PRESCRIBED, IONIZATION_MODE_FLUID, IONIZATION_MODE_KINETIC, IONIZATION_MODE_KINETIC_APPROX_JAC, IONIZATION_MODE_FLUID_RE, ION_OPACITY_MODE_TRANSPARENT, ION_CHARGED_DIFFUSION_MODE_NONE, ION_CHARGED_DIFFUSION_MODE_PRESCRIBED, ION_NEUTRAL_DIFFUSION_MODE_NONE, ION_NEUTRAL_DIFFUSION_MODE_PRESCRIBED, ION_CHARGED_ADVECTION_MODE_NONE, ION_CHARGED_ADVECTION_MODE_PRESCRIBED, ION_NEUTRAL_ADVECTION_MODE_NONE, ION_NEUTRAL_ADVECTION_MODE_PRESCRIBED, ION_SOURCE_NONE, ION_SOURCE_PRESCRIBED
 from . UnknownQuantity import UnknownQuantity
 from .. import AdvectionInterpolation
 
@@ -616,6 +616,13 @@ class Ions(UnknownQuantity):
         if 'initialNi' in data:
             initialNi = data['initialNi']
 
+        if 'ion_source_types' in data:
+            ion_source_types = data['ion_source_types']
+            ion_source_t = data['ion_source']['t']
+            ion_source_x = data['ion_source']['x']
+        else:
+            ion_source_types = None
+
         iidx, pidx, spiidx, cpdidx, npdidx, cpaidx, npaidx = 0, 0, 0, 0, 0, 0, 0
         for i in range(len(Z)):
             if types[i] == IONS_PRESCRIBED:
@@ -700,6 +707,10 @@ class Ions(UnknownQuantity):
                 neutral_advection_mode=neutral_advection_modes[i], neutral_prescribed_advection = npa,
                 rNeutralPrescribedAdvection=rnpa, tNeutralPrescribedAdvection = tnpa,
                 T=T, n=dens, r=r, t=t, tritium=tritium, hydrogen=hydrogen, init_equil=init_equil)
+
+            # Load ion source
+            if ion_source_types and ion_source_types[i] == ION_SOURCE_PRESCRIBED:
+                self.addIonSource(names[i], dNdt=ion_source_x[i], t=ion_source_t[i])
 
         if 'ionization' in data:
             self.ionization = int(data['ionization'])

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -709,8 +709,8 @@ class Ions(UnknownQuantity):
                 T=T, n=dens, r=r, t=t, tritium=tritium, hydrogen=hydrogen, init_equil=init_equil)
 
             # Load ion source
-            if ion_source_types and ion_source_types[i] == ION_SOURCE_PRESCRIBED:
-                self.addIonSource(names[i], dNdt=ion_source_x[i], t=ion_source_t[i])
+            if ion_source_types is not None and ion_source_types[i] == ION_SOURCE_PRESCRIBED:
+                self.addIonSource(names[i], dNdt=ion_source_x[i,:], t=ion_source_t)
 
         if 'ionization' in data:
             self.ionization = int(data['ionization'])

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -618,10 +618,14 @@ class Ions(UnknownQuantity):
 
         if 'ion_source_types' in data:
             ion_source_types = data['ion_source_types']
-            ion_source_t = data['ion_source']['t']
-            ion_source_x = data['ion_source']['x']
+            if len(ion_source_types) == 0:
+                ion_source_types = None
         else:
             ion_source_types = None
+
+        if 'ion_source' in data:
+            ion_source_t = data['ion_source']['t']
+            ion_source_x = data['ion_source']['x']
 
         iidx, pidx, spiidx, cpdidx, npdidx, cpaidx, npaidx = 0, 0, 0, 0, 0, 0, 0
         for i in range(len(Z)):

--- a/src/Settings/Equations/ions.cpp
+++ b/src/Settings/Equations/ions.cpp
@@ -446,11 +446,6 @@ void SimulationGenerator::ConstructEquation_Ions(
         MODULENAME, fluidGrid->GetRadialGrid(), s, nZ0_neutral_prescribed_advection, "neutral_prescribed_advection", true
     );
 
-	// Load prescribed source term data
-	MultiInterpolator1D *source_data = LoadDataIonT(
-		MODULENAME, s, nZ0_dynamic+nZ0_prescribed, "ion_source"
-	);
-
     // Add diffusion terms
     len_t offsetChargedDiffusion = 0;
     len_t offsetNeutralDiffusion = 0;
@@ -493,6 +488,11 @@ void SimulationGenerator::ConstructEquation_Ions(
                     "ions: Ion species with prescribed time evolutions cannot contain source terms. Ion '%s' has non-zero source term.",
 					ionNames[iZ].c_str()
 				);
+
+			// Load prescribed source term data
+			MultiInterpolator1D *source_data = LoadDataIonT(
+				MODULENAME, s, nZ0_dynamic+nZ0_prescribed, "ion_source"
+			);
 
 			eqn->AddBoundaryCondition(new IonSourceBoundaryCondition(
 				fluidGrid, ih, source_data, iZ


### PR DESCRIPTION
As reported in #411, the ion source term halts with a segmentation fault. The issue was due to that for each species, one ``IonBoundaryCondition`` is created and given a reference to a single ``MultiInterpolator1D`` object representing the ion source term prescription. When the code finishes, it deletes each of the ``IonBoundaryCondition``s, which in turn calls the destructor for ``MultiInterpolator1D``. When this is done for the second time, the ``MultiInterpolator1D`` was already deleted when the destructor is called, which results in a segmentation fault.

The solution to this problem was to load one ``MultiInterpolator1D`` for each ``IonBoundaryCondition``. This may consume unnecessary memory, but simplifies the code (and does not consume excessive amounts of memory since the ``MultiInterpolator1D`` occupies memory of order O(nr*nIons)).