### PR TITLE
Optimized PETSc matrix setters and AdvectionDiffusionTerm

### DIFF
--- a/fvm/Equation/AdvectionTerm.cpp
+++ b/fvm/Equation/AdvectionTerm.cpp
@@ -478,15 +478,21 @@ void AdvectionTerm::SetPartialJacobianContribution(int_t diagonalOffset, jacobia
         ResetJacobianColumn();
         SetVectorElements(JacobianColumn, x, dfr+n*(nr+1),
                             df1+n*nr, df2+n*nr, df1pSqAtZero+n*nr, set_mode);
-        len_t offset = 0;
-        for(len_t ir=0; ir<nr; ir++){
-            if((ir==0&&diagonalOffset==-1) || ir+diagonalOffset>=nr)
-                continue;
-            for (len_t j = 0; j < n2[ir]; j++)
-                for (len_t i = 0; i < n1[ir]; i++)
-                    jac->SetElement(offset + n1[ir]*j + i, n*nr+ir+diagonalOffset, JacobianColumn[offset + n1[ir]*j + i]);
-            offset += n1[ir]*n2[ir];
+
+    len_t offset = 0;
+    for (len_t ir = 0; ir < nr; ir++) {
+        const len_t m = n1[ir]*n2[ir];
+        if ((ir == 0 && diagonalOffset == -1) || ir + diagonalOffset >= nr) {
+            offset += m;
+            continue;
         }
+        const len_t col = n*nr + ir + diagonalOffset;
+        jac->SetColumn(
+            offset, col, m, JacobianColumn + offset
+        );
+
+        offset += m;
+    }
 }
 
 
@@ -512,9 +518,11 @@ void AdvectionTerm::ResetJacobianColumn(){
  */
 void AdvectionTerm::SetMatrixElements(Matrix *mat, real_t*) {
     jacobian_interp_mode set = NO_JACOBIAN;
+    mat->BeginBufferedSet(ADD_VALUES, (PetscInt)this->GetNumberOfNonZerosPerRow());
     #define f(K,I,J,V) mat->SetElement(offset+j*np1+i, offset + ((K)-ir)*np2*np1 + (J)*np1 + (I), (V))
     #   include "AdvectionTerm.set.cpp"
     #undef f
+    mat->EndBufferedSet();
 }
 
 

--- a/fvm/Equation/AdvectionTerm.cpp
+++ b/fvm/Equation/AdvectionTerm.cpp
@@ -361,29 +361,23 @@ void AdvectionTerm::ResetCoefficients() {
         const len_t np2 = this->grid->GetMomentumGrid(0)->GetNp2();
         const len_t np1 = this->grid->GetMomentumGrid(0)->GetNp1();
 
-        for (len_t j = 0; j < np2; j++)
-            for (len_t i = 0; i < np1; i++)
-                this->fr[ir][j*np1 + i]  = 0;
+        len_t N = np1*np2;
+        for (len_t idx = 0; idx < N; idx++)
+                this->fr[ir][idx]  = 0;
     }
 
     for (len_t ir = 0; ir < nr; ir++) {
         const len_t np2 = this->grid->GetMomentumGrid(ir)->GetNp2();
         const len_t np1 = this->grid->GetMomentumGrid(ir)->GetNp1();
 
-        for (len_t j = 0; j < np2; j++){
-            for (len_t i = 0; i < np1+1; i++)
-                this->f1[ir][j*(np1+1) + i]  = 0;
+        len_t N = (np1+1)*np2;
+        for (len_t idx = 0; idx < N; idx++)
+                this->f1[ir][idx]  = 0;
+        for (len_t j = 0; j < np2; j++)        
             this->f1pSqAtZero[ir][j] = 0;
-        }
-    }
-
-    for (len_t ir = 0; ir < nr; ir++) {
-        const len_t np2 = this->grid->GetMomentumGrid(ir)->GetNp2();
-        const len_t np1 = this->grid->GetMomentumGrid(ir)->GetNp1();
-
-        for (len_t j = 0; j < np2+1; j++)
-            for (len_t i = 0; i < np1; i++)
-                this->f2[ir][j*np1 + i]  = 0;
+        N = np1*(np2+1);
+        for (len_t idx = 0; idx < N; idx++)
+            this->f2[ir][idx]  = 0;
     }
 }
 
@@ -402,24 +396,28 @@ void AdvectionTerm::ResetDifferentiationCoefficients() {
             const len_t np2 = this->grid->GetMomentumGrid(0)->GetNp2();
             const len_t np1 = this->grid->GetMomentumGrid(0)->GetNp1();
 
-            for (len_t j = 0; j < np2; j++)
-                for (len_t i = 0; i < np1; i++)
-                    this->dfr[ir+n*(nr+1)][j*np1 + i] = 0;
+            len_t irn = ir+n*(nr+1);
+            len_t N = np2*np1;
+            for (len_t idx = 0; idx<N; idx++) 
+                this->dfr[irn][idx] = 0;
         }
 
         for (len_t ir = 0; ir < nr; ir++) {
             const len_t np2 = this->grid->GetMomentumGrid(ir)->GetNp2();
             const len_t np1 = this->grid->GetMomentumGrid(ir)->GetNp1();
 
-            for (len_t j = 0; j < np2; j++){
-                for (len_t i = 0; i < np1+1; i++)
-                    this->df1[ir+n*nr][j*(np1+1) + i] = 0;
-                this->df1pSqAtZero[ir+n*nr][j] = 0;
-            }
+            len_t irn = ir + n*nr;
 
-            for (len_t j = 0; j < np2+1; j++)
-                for (len_t i = 0; i < np1; i++)
-                    this->df2[ir+n*nr][j*np1 + i] = 0;
+            len_t N = np2*(np1+1);
+            for (len_t idx = 0; idx<N; idx++) 
+                this->df1[irn][idx] = 0;
+
+            N = (np2+1)*np1;
+            for (len_t idx = 0; idx<N; idx++) 
+                this->df2[irn][idx] = 0;
+
+            for (len_t j = 0; j < np2; j++)
+                this->df1pSqAtZero[irn][j] = 0;
         }
     }
 }
@@ -500,14 +498,9 @@ void AdvectionTerm::SetPartialJacobianContribution(int_t diagonalOffset, jacobia
  * Sets the jacobian helper vector to zero
  */
 void AdvectionTerm::ResetJacobianColumn(){
-    len_t offset = 0; 
-    for(len_t ir=0; ir<nr; ir++){
-        for (len_t j = 0; j < n2[ir]; j++) 
-            for (len_t i = 0; i < n1[ir]; i++) 
-                JacobianColumn[offset + n1[ir]*j + i] = 0;
-
-        offset += n1[ir]*n2[ir];
-    }
+    const len_t N = grid->GetNCells();
+    for(len_t i=0; i<N; i++)
+        JacobianColumn[i] = 0;
 }
 
 /**

--- a/fvm/Equation/AdvectionTerm.set.cpp
+++ b/fvm/Equation/AdvectionTerm.set.cpp
@@ -40,6 +40,8 @@
                     S_i, // advection coefficient on left-hand face of the cell
                     S_o; // advection coefficient on right-hand face of the cell
                 real_t *delta;
+                const len_t ij = j*np1 + i;
+                const real_t vp_ij = Vp[ij];
                 /////////////////////////
                 // RADIUS
                 /////////////////////////
@@ -59,9 +61,11 @@
 
                 // Trapping BC: even if the cell is not ignorable, it may still 
                 // be such that the radial flux should be mirrored 
-                if( !isNegativeTrappedRadial && ( Fr(ir,   i, j, fr) || Fr(ir+1, i, j, fr) ) ) {
-                    S_i = Fr(ir,   i, j, fr) *  Vp_fr[j*np1+i] / (Vp[j*np1+i] * dr[ir]);
-                    S_o = Fr(ir+1, i, j, fr) * Vp_fr1[j*np1+i] / (Vp[j*np1+i] * dr[ir]);
+                const real_t fr_i = Fr(ir, i, j, fr);
+                const real_t fr_o = Fr(ir+1, i, j, fr);
+                if( !isNegativeTrappedRadial && ( fr_i || fr_o ) ) {
+                    S_i = fr_i *  Vp_fr[ij] / (vp_ij * dr[ir]);
+                    S_o = fr_o * Vp_fr1[ij] / (vp_ij * dr[ir]);
 
                     if(set==JACOBIAN_SET_LOWER){
                         S_i *= 1 - deltaRadialFlux[ir];
@@ -75,13 +79,18 @@
                     }
 
                     delta = deltar->GetCoefficient(ir,i,j,interp_mode);
+                    len_t n;
+                    len_t kmin = deltar->GetKmin(ir, &n);
+                    len_t kmax = deltar->GetKmax(ir,nr);
                     // Phi^(r)_{ir-1/2,i,j}: Flow into the cell from the "left" r face
-                    for(len_t n, k = deltar->GetKmin(ir, &n); k <= deltar->GetKmax(ir,nr); k++, n++)
+                    for(len_t k = kmin; k <= kmax; k++, n++)
                         X(k, -S_i * delta[n]);
 
                     delta = deltar->GetCoefficient(ir+1,i,j,interp_mode);
+                    kmin = deltar->GetKmin(ir+1, &n);   
+                    kmax = deltar->GetKmax(ir+1, nr);
                     // Phi^(r)_{ir+1/2,i,j}: Flow out from the cell to the "right" r face
-                    for(len_t n, k = deltar->GetKmin(ir+1, &n); k <= deltar->GetKmax(ir+1,nr); k++, n++)
+                    for(len_t k = kmin; k <= kmax; k++, n++)
                         X(k,  S_o * delta[n]);
                 }
                 #undef X
@@ -94,45 +103,60 @@
                 /////////////////////////
                 #define X(I,J,V) f(ir,(I),(J),(V))
 
+                const real_t f1_i = F1(ir, i, j, f1);
+                const real_t f1_o = F1(ir, i + 1, j, f1);
+                const real_t f1_zero = F1PSqAtZero(ir,j,f1pSqAtZero);
                 if(
-                    (mg->GetP1_f(i)==0 && F1PSqAtZero(ir,j,f1pSqAtZero)) ||
-                    F1(ir, i, j, f1) || F1(ir, i+1, j, f1)
+                    (mg->GetP1_f(i)==0 && f1_zero) || f1_i || f1_o
                 ) {
-                    real_t VpDp1 = Vp[j*np1+i]*dp1[i];
+                    real_t VpDp1 = vp_ij*dp1[i];
                     if(mg->GetP1_f(i)==0){
                         // treats singular p=0 point separately
                         const real_t *VpOverP2AtZero = grid->GetVpOverP2AtZero(ir);
-                        S_i = F1PSqAtZero(ir,j,f1pSqAtZero) * VpOverP2AtZero[j] / VpDp1;
+                        S_i = f1_zero * VpOverP2AtZero[j] / VpDp1;
                     } else 
-                        S_i = F1(ir, i, j, f1) * Vp_f1[j*(np1+1) + i] / VpDp1;
-                    S_o = F1(ir, i+1, j, f1) * Vp_f1[j*(np1+1) + i+1] / VpDp1;
+                        S_i = f1_i * Vp_f1[ij + j] / VpDp1;
+                    S_o = f1_o * Vp_f1[ij + j + 1] / VpDp1;
 
                     delta = delta1->GetCoefficient(ir,i,j,interp_mode);
+                    len_t n;
+                    len_t kmin = delta1->GetKmin(i, &n);
+                    len_t kmax = delta1->GetKmax(i, np1);
                     // Phi^(1)_{ir,i-1/2,j}: Flow into the cell from the "left" p1 face
-                    for(len_t n, k = delta1->GetKmin(i,&n); k <= delta1->GetKmax(i,np1); k++, n++)
+                    for(len_t k = kmin; k <= kmax; k++, n++)
                         X(k, j, -S_i * delta[n]);
-                    // Phi^(1)_{ir,i+1/2,j}: Flow out from the cell to the "right" p1 face
+
                     delta = delta1->GetCoefficient(ir,i+1,j,interp_mode);
-                    for(len_t n, k = delta1->GetKmin(i+1,&n); k <= delta1->GetKmax(i+1,np1); k++, n++)
+                    kmin = delta1->GetKmin(i+1, &n);
+                    kmax = delta1->GetKmax(i+1, np1);
+                    // Phi^(1)_{ir,i+1/2,j}: Flow out from the cell to the "right" p1 face
+                    for(len_t k = kmin; k <= kmax; k++, n++)
                         X(k, j,  S_o * delta[n]);
                 }
                 /////////////////////////
                 // MOMENTUM 2
                 /////////////////////////
 
-                if(F2(ir, i, j,   f2) || F2(ir, i, j+1,   f2)){
-                    real_t VpDp2 = Vp[j*np1+i]*dp2[j];
-                    S_i = F2(ir, i, j,   f2) * Vp_f2[j*np1+i]     / VpDp2;
-                    S_o = F2(ir, i, j+1, f2) * Vp_f2[(j+1)*np1+i] / VpDp2;
+                const real_t f2_i = F2(ir, i, j, f2);
+                const real_t f2_o = F2(ir, i, j + 1, f2);
+                if(f2_i || f2_o){
+                    real_t VpDp2 = vp_ij*dp2[j];
+                    S_i = f2_i * Vp_f2[ij] / VpDp2;
+                    S_o = f2_o * Vp_f2[ij + np1] / VpDp2;
 
                     delta = delta2->GetCoefficient(ir,i,j,interp_mode);
+                    len_t n;
+                    len_t kmin = delta2->GetKmin(j, &n);
+                    len_t kmax = delta2->GetKmax(j, np2);
                     // Phi^(2)_{ir,i,j-1/2}: Flow into the cell from the "left" p2 face
-                    for(len_t n, k = delta2->GetKmin(j,&n); k <= delta2->GetKmax(j,np2); k++, n++)
+                    for(len_t k = kmin; k <= kmax; k++, n++)
                         X(i, k, -S_i * delta[n]);
 
                     delta = delta2->GetCoefficient(ir,i,j+1,interp_mode);
+                    kmin = delta2->GetKmin(j+1, &n);
+                    kmax = delta2->GetKmax(j+1, np2);
                     // Phi^(2)_{ir,i,j+1/2}: Flow out from the cell to the "right" p2 face
-                    for(len_t n, k = delta2->GetKmin(j+1,&n); k <= delta2->GetKmax(j+1,np2); k++, n++)
+                    for(len_t k = kmin; k <= kmax; k++, n++)
                         X(i, k,  S_o * delta[n]);
                 }
                 #undef X

--- a/fvm/Equation/DiffusionTerm.cpp
+++ b/fvm/Equation/DiffusionTerm.cpp
@@ -395,15 +395,20 @@ void DiffusionTerm::SetPartialJacobianContribution(int_t diagonalOffset, jacobia
         SetVectorElements(JacobianColumn, x, ddrr+n*(nr+1),
                             dd11+n*nr, dd12+n*nr,
                             dd21+n*nr, dd22+n*nr, set_mode);
-        len_t offset = 0;
-        for(len_t ir=0; ir<nr; ir++){
-            if((ir==0&&diagonalOffset==-1) || ir+diagonalOffset>=nr)
-                continue;
-            for (len_t j = 0; j < n2[ir]; j++)
-                for (len_t i = 0; i < n1[ir]; i++)
-                    jac->SetElement(offset + n1[ir]*j + i, n*nr+ir+diagonalOffset, JacobianColumn[offset + n1[ir]*j + i]);
-            offset += n1[ir]*n2[ir];
+    len_t offset = 0;
+    for (len_t ir = 0; ir < nr; ir++) {
+        const len_t m = n1[ir]*n2[ir];
+        if ((ir == 0 && diagonalOffset == -1) || ir + diagonalOffset >= nr) {
+            offset += m;
+            continue;
         }
+        const len_t col = n*nr + ir + diagonalOffset;
+        jac->SetColumn(
+            offset, col, m, JacobianColumn + offset
+        );
+
+        offset += m;
+    }
 }
 
 /**
@@ -429,9 +434,11 @@ void DiffusionTerm::ResetJacobianColumn(){
  */
 void DiffusionTerm::SetMatrixElements(Matrix *mat, real_t*) {
     jacobian_interp_mode set = NO_JACOBIAN;
+    mat->BeginBufferedSet(ADD_VALUES, (PetscInt)this->GetNumberOfNonZerosPerRow());
     #define f(K,I,J,V) mat->SetElement(offset+j*np1+i, offset + ((K)-ir)*np2*np1 + (J)*np1 + (I), (V))
     #   include "DiffusionTerm.set.cpp"
     #undef f
+    mat->EndBufferedSet();
 }
 
 

--- a/fvm/Equation/DiffusionTerm.cpp
+++ b/fvm/Equation/DiffusionTerm.cpp
@@ -271,31 +271,22 @@ void DiffusionTerm::ResetCoefficients() {
         const len_t np2 = this->grid->GetMomentumGrid(0)->GetNp2();
         const len_t np1 = this->grid->GetMomentumGrid(0)->GetNp1();
 
-        for (len_t j = 0; j < np2; j++)
-            for (len_t i = 0; i < np1; i++)
-                this->drr[ir][j*np1 + i]  = 0;
+        for (len_t idx = 0; idx < np1*np2; idx++)
+            this->drr[ir][idx]  = 0;
     }
 
     for (len_t ir = 0; ir < nr; ir++) {
         const len_t np2 = this->grid->GetMomentumGrid(ir)->GetNp2();
         const len_t np1 = this->grid->GetMomentumGrid(ir)->GetNp1();
 
-        for (len_t j = 0; j < np2; j++)
-            for (len_t i = 0; i < np1+1; i++) {
-                this->d11[ir][j*(np1+1) + i]  = 0;
-                this->d12[ir][j*(np1+1) + i]  = 0;
-            }
-    }
-
-    for (len_t ir = 0; ir < nr; ir++) {
-        const len_t np2 = this->grid->GetMomentumGrid(ir)->GetNp2();
-        const len_t np1 = this->grid->GetMomentumGrid(ir)->GetNp1();
-
-        for (len_t j = 0; j < np2+1; j++)
-            for (len_t i = 0; i < np1; i++) {
-                this->d22[ir][j*np1 + i]  = 0;
-                this->d21[ir][j*np1 + i]  = 0;
-            }
+        for (len_t idx = 0; idx < (np1+1)*np2; idx++){
+            this->d11[ir][idx]  = 0;
+            this->d12[ir][idx]  = 0;
+        }
+        for (len_t idx = 0; idx < np1*(np2+1); idx++){
+            this->d22[ir][idx]  = 0;
+            this->d21[ir][idx]  = 0;
+        }
     }
 }
 
@@ -314,26 +305,26 @@ void DiffusionTerm::ResetDifferentiationCoefficients() {
             const len_t np2 = this->grid->GetMomentumGrid(0)->GetNp2();
             const len_t np1 = this->grid->GetMomentumGrid(0)->GetNp1();
 
-            for (len_t j = 0; j < np2; j++)
-                for (len_t i = 0; i < np1; i++)
-                    this->ddrr[ir+n*(nr+1)][j*np1 + i] = 0;
+            len_t irn = ir+n*(nr+1);
+            len_t N = np1*np2;
+            for (len_t idx = 0; idx < N; idx++)
+                this->ddrr[irn][idx] = 0;
         }
         
         for (len_t ir = 0; ir < nr; ir++) {
             const len_t np2 = this->grid->GetMomentumGrid(ir)->GetNp2();
             const len_t np1 = this->grid->GetMomentumGrid(ir)->GetNp1();
-
-            for (len_t j = 0; j < np2; j++)
-                for (len_t i = 0; i < np1+1; i++) {
-                    this->dd11[ir+n*nr][j*(np1+1) + i] = 0;
-                    this->dd12[ir+n*nr][j*(np1+1) + i] = 0;
-                }
-        
-            for (len_t j = 0; j < np2+1; j++)
-                for (len_t i = 0; i < np1; i++) {
-                    this->dd22[ir+n*nr][j*np1 + i] = 0;
-                    this->dd21[ir+n*nr][j*np1 + i] = 0;
-                }
+            len_t irn = ir+n*nr;
+            len_t N = (np1+1)*np2;
+            for (len_t idx = 0; idx < N; idx++){
+                this->dd11[irn][idx] = 0;
+                this->dd12[irn][idx] = 0;
+            }
+            N = np1*(np2+1);
+            for (len_t idx = 0; idx < N; idx++){
+                this->dd22[irn][idx] = 0;
+                this->dd21[irn][idx] = 0;
+            }
         }
     }
 }
@@ -415,14 +406,9 @@ void DiffusionTerm::SetPartialJacobianContribution(int_t diagonalOffset, jacobia
  * Sets the jacobian helper vector to zero
  */
 void DiffusionTerm::ResetJacobianColumn(){
-    len_t offset = 0; 
-    for(len_t ir=0; ir<nr; ir++){
-        for (len_t j = 0; j < n2[ir]; j++) 
-            for (len_t i = 0; i < n1[ir]; i++) 
-                JacobianColumn[offset + n1[ir]*j + i] = 0;
-
-        offset += n1[ir]*n2[ir];
-    }
+    len_t N = grid->GetNCells();
+    for(len_t idx=0; idx<N; idx++)
+        JacobianColumn[idx] = 0;
 }
 
 

--- a/fvm/Equation/DiffusionTerm.set.cpp
+++ b/fvm/Equation/DiffusionTerm.set.cpp
@@ -40,7 +40,8 @@
 
             for (len_t i = 0; i < np1; i++) {
                 real_t S;
-
+                const len_t ij = j*np1 + i;
+                const real_t vp_ij = Vp[ij];
                 /////////////////////////
                 // RADIUS
                 /////////////////////////
@@ -51,13 +52,16 @@
                 // diffusion coefficients should must be negative to get the correct
                 // sign on the diffusion term, which is why we use abs(Drr) here. 
                 // This should however probably be reworked in a better way...
-                if(!isNegativeTrappedRadial && ( abs(Drr(ir, i, j, drr)) || abs(Drr(ir+1, i, j, drr)) ) ){
+
+                if(!isNegativeTrappedRadial) {
+                    const real_t drr_i = Drr(ir, i, j, drr);
+                    const real_t drr_o = Drr(ir+1, i, j, drr);
                     #define X(K,V) f((K),i,j,(V))
                     // Phi^(r)_{k-1/2}
-                    if (ir > 0) {
+                    if (drr_i && ir > 0) {
                         // XXX: Here, we explicitly assume that the momentum grids are
                         // the same at all radii, so that p at (ir, i, j) = p at (ir+1, i, j)
-                        S = Drr(ir, i, j, drr)*Vp_fr[j*np1+i] / (dr[ir]*dr_f[ir-1]*Vp[j*np1+i]);
+                        S = drr_i*Vp_fr[ij] / (dr[ir]*dr_f[ir-1]*vp_ij);
                         if(set==JACOBIAN_SET_LOWER)
                             S *= 1 - deltaRadialFlux[ir];
                         else if(set==JACOBIAN_SET_CENTER)
@@ -71,10 +75,10 @@
                     }
 
                     // Phi^(r)_{k+1/2}
-                    if (ir < nr-1) {
+                    if (drr_o && ir < nr-1) {
                         // XXX: Here, we explicitly assume that the momentum grids are
                         // the same at all radii, so that p at (ir, i, j) = p at (ir+1, i, j)
-                        S = Drr(ir+1, i, j, drr)*Vp_fr1[j*np1+i] / (dr[ir]*dr_f[ir]*Vp[j*np1+i]);
+                        S = drr_o * Vp_fr1[ij] / (dr[ir]*dr_f[ir]*vp_ij);
 
                         if(set==JACOBIAN_SET_LOWER)
                             S = 0;
@@ -97,14 +101,14 @@
                 /////////////////////////
                 // Phi^(1)_{i-1/2,j}
                 if (i > 0) {
-                    S = D11(ir, i, j, d11)*Vp_f1[j*(np1+1)+i] / (dp1[i]*dp1_f[i-1]*Vp[j*np1+i]);
+                    S = D11(ir, i, j, d11)*Vp_f1[ij + j] / (dp1[i]*dp1_f[i-1]*vp_ij);
                     X(i-1, j, -S);
                     X(i, j,   +S);
                 }
 
                 // Phi^(1)_{i+1/2,j}
                 if (i < np1-1) {
-                    S = D11(ir, i+1, j, d11)*Vp_f1[j*(np1+1)+i+1] / (dp1[i]*dp1_f[i]*Vp[j*np1+i]);
+                    S = D11(ir, i+1, j, d11)*Vp_f1[ij + j + 1] / (dp1[i]*dp1_f[i]*vp_ij);
                     X(i+1, j, -S);
                     X(i,   j, +S);
                 }
@@ -114,14 +118,14 @@
                 /////////////////////////
                 // Phi^(2)_{i-1/2,j}
                 if (j > 0) {
-                    S = D22(ir, i, j, d22)*Vp_f2[j*np1+i] / (dp2[j]*dp2_f[j-1]*Vp[j*np1+i]);
+                    S = D22(ir, i, j, d22)*Vp_f2[ij] / (dp2[j]*dp2_f[j-1]*vp_ij);
                     X(i, j,   +S);
                     X(i, j-1, -S);
                 }
 
                 // Phi^(2)_{i+1/2,j}
                 if (j < np2-1) {
-                    S = D22(ir, i, j+1, d22)*Vp_f2[(j+1)*np1+i] / (dp2[j]*dp2_f[j]*Vp[j*np1+i]);
+                    S = D22(ir, i, j+1, d22)*Vp_f2[ij + np1 ] / (dp2[j]*dp2_f[j]*vp_ij);
                     X(i, j+1, -S);
                     X(i, j,   +S);
                 }
@@ -129,18 +133,20 @@
                 /////////////////////////
                 // MOMENTUM 1/2
                 /////////////////////////
+                const real_t d12_i = D12(ir, i, j, d12);
                 // Phi^(1)_{i-1/2,j}
-                if (D12(ir, i, j, d12) && i > 0 && (j > 0 && j < np2-1)) {
-                    S = D12(ir, i, j, d12)*Vp_f1[j*(np1+1)+i] / (dp1[i]*(dp2_f[j]+dp2_f[j-1])*Vp[j*np1+i]);
+                if (d12_i && i > 0 && (j > 0 && j < np2-1)) {
+                    S = d12_i * Vp_f1[ij + j] / (dp1[i]*(dp2_f[j]+dp2_f[j-1])*vp_ij);
                     X(i,   j+1, +S);
                     X(i-1, j+1, +S);
                     X(i,   j-1, -S);
                     X(i-1, j-1, -S);
                 }
 
+                const real_t d12_o = D12(ir, i+1, j, d12);
                 // Phi^(1)_{i+1/2,j}
-                if (D12(ir,i+1,j, d12) && i < np1-1 && (j > 0 && j < np2-1)) {
-                    S = D12(ir,i+1,j, d12)*Vp_f1[j*(np1+1)+i+1]/(dp1[i]*(dp2_f[j]+dp2_f[j-1])*Vp[j*np1+i]);
+                if (d12_o && i < np1-1 && (j > 0 && j < np2-1)) {
+                    S = d12_o * Vp_f1[ij + j + 1]/(dp1[i]*(dp2_f[j]+dp2_f[j-1])*vp_ij);
                     X(i+1, j+1, -S);
                     X(i,   j+1, -S);
                     X(i+1, j-1, +S);
@@ -150,18 +156,20 @@
                 /////////////////////////
                 // MOMENTUM 2/1
                 /////////////////////////
+                const real_t d21_i = D21(ir, i, j, d21);
                 // Phi^(2)_{i,j-1/2}
-                if (D21(ir,i,j,d21) && j > 0 && (i > 0 && i < np1-1)) {
-                    S = D21(ir,i,j,d21)*Vp_f2[j*np1+i] / (dp2[j]*(dp1_f[i]+dp1_f[i-1])*Vp[j*np1+i]);
+                if (d21_i && j > 0 && (i > 0 && i < np1-1)) {
+                    S = d21_i * Vp_f2[ij] / (dp2[j]*(dp1_f[i]+dp1_f[i-1])*vp_ij);
                     X(i+1, j-1, +S);
                     X(i+1, j,   +S);
                     X(i-1, j-1, -S);
                     X(i-1, j,   -S);
                 }
 
+                const real_t d21_o = D21(ir, i, j+1, d21);
                 // Phi^(2)_{i,j+1/2}
-                if (D21(ir,i,j+1,d21) && j < np2-1 && (i > 0 && i < np1-1)) {
-                    S = D21(ir,i,j+1,d21)*Vp_f2[(j+1)*np1+i] / (dp2[j]*(dp1_f[i]+dp1_f[i-1])*Vp[j*np1+i]);
+                if (d21_o && j < np2-1 && (i > 0 && i < np1-1)) {
+                    S = d21_o * Vp_f2[ij + np1] / (dp2[j]*(dp1_f[i]+dp1_f[i-1])*vp_ij);
                     X(i+1, j+1, -S);
                     X(i+1, j,   -S);
                     X(i-1, j+1, +S);

--- a/fvm/Matrix.cpp
+++ b/fvm/Matrix.cpp
@@ -5,6 +5,7 @@
  * 'EquationSystem' class.
  */
 
+#include <algorithm>
 #include <iostream>
 #include <petscmat.h>
 #include "FVM/Matrix.hpp"
@@ -64,7 +65,7 @@ void Matrix::Construct(
     // kept when 'ZeroRows()' is called.
     MatSetOption(this->petsc_mat, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE);
 
-    // Don't complain about new allocations
+    // Fail if the code attempts to insert a structural nonzero not covered by preallocation.
     MatSetOption(this->petsc_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
     //MatSetOption(this->petsc_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
     
@@ -77,6 +78,7 @@ void Matrix::Construct(
     // diagonals to be explicitly set, even if not used)
     for (PetscInt i = 0; i < m; i++)
         MatSetValue(this->petsc_mat, i, i, 0, ADD_VALUES);
+
 
     this->PartialAssemble();
 }
@@ -366,8 +368,96 @@ void Matrix::SetElement(
     const PetscInt irow, const PetscInt icol,
     const PetscScalar v, InsertMode insert_mode
 ) {
-    if (v != 0)
-        MatSetValue(this->petsc_mat, this->rowOffset+irow, this->colOffset+icol, v, insert_mode);
+    if (v == 0) return;
+
+    const PetscInt row = rowOffset + irow;
+    const PetscInt col = colOffset + icol;
+
+    if (!buffering) {
+        MatSetValue(petsc_mat, row, col, v, insert_mode);
+        return;
+    }
+
+    // buffering mode: flush when row changes
+    if (bufRow != row) {
+        FlushBufferedRow();
+        bufRow = row;
+    }
+
+
+    // rare slow path if row exceeds reserve
+    if (bufLen >= (PetscInt)bufCols.size()) {
+        const PetscInt newCap = std::max((PetscInt)16, 2*(PetscInt)bufCols.size());
+        bufCols.resize(newCap);
+        bufVals.resize(newCap);
+    }
+
+    bufCols[bufLen] = col;
+    bufVals[bufLen] = v;
+    ++bufLen;
+}
+
+void Matrix::SetColumn(
+    PetscInt firstLocalRow, PetscInt localCol,
+    PetscInt m, const PetscScalar *vals,
+    InsertMode mode
+) {
+    if (m <= 0) return;
+
+    const PetscInt col = this->colOffset + localCol;
+    const PetscInt r0  = this->rowOffset + firstLocalRow;
+
+    if ((PetscInt)tmpRows.size() < m) tmpRows.resize(m);
+    if ((PetscInt)tmpVals.size() < m) tmpVals.resize(m);
+
+    PetscInt nnz = 0;
+    for (PetscInt r = 0; r < m; ++r) {
+        const PetscScalar v = vals[r];
+        if (v == 0)
+            continue;
+        tmpRows[nnz] = r0 + r;
+        tmpVals[nnz] = v;
+        ++nnz;
+    }
+
+    if (nnz > 0) {
+        MatSetValues(this->petsc_mat, nnz, tmpRows.data(), 1, &col, tmpVals.data(), mode);
+    }
+}
+
+/**
+ * Buffered insertion implementation:
+ * Accumulate entries for one row and submit them in a single MatSetValues()
+ * call. This is primarily meant to speed up row-oriented assembly loops.
+ */
+void Matrix::BeginBufferedSet(InsertMode mode, PetscInt reserve) {
+    buffering = true;
+    bufMode = mode;
+    bufRow = -1;
+    bufLen = 0;
+
+    if (reserve > 0 && (PetscInt)bufCols.size() < reserve) {
+        bufCols.resize(reserve);
+        bufVals.resize(reserve);
+    }
+}
+
+void Matrix::FlushBufferedRow() {
+    if (bufRow < 0 || bufLen == 0) 
+        return;
+
+    MatSetValues(petsc_mat, 1, &bufRow,
+                 bufLen, bufCols.data(),
+                 bufVals.data(), bufMode);
+
+    bufLen = 0;
+}
+
+void Matrix::EndBufferedSet() {
+    FlushBufferedRow();
+    buffering = false;
+    bufRow = -1;
+    bufLen = 0;
 }
 
 /**

--- a/include/DREAM/Equations/FluidSourceTerm.hpp
+++ b/include/DREAM/Equations/FluidSourceTerm.hpp
@@ -9,6 +9,8 @@ namespace DREAM {
 
     private:
         real_t *sourceVec = nullptr;
+        real_t *tmpVec = nullptr;  // scratch for setting jacobian columns
+        void Deallocate();
     protected:
         FVM::UnknownQuantityHandler *unknowns;
         virtual real_t GetSourceFunction(len_t ir, len_t i, len_t j) = 0;

--- a/include/FVM/Matrix.hpp
+++ b/include/FVM/Matrix.hpp
@@ -8,6 +8,18 @@
 #include "FVM/FVMException.hpp"
 
 namespace DREAM::FVM {
+    /**
+     * Matrix wrapper around a PETSc Mat.
+     *
+     * The Matrix object may represent a view into a sub-block of a larger
+     * matrix. In that case, rowOffset/colOffset are added to all indices
+     * passed to setters/getters.
+     *
+     * Performance:
+     *  - Repeated calls to MatSetValue() can be expensive. For assembly code
+     *    that inserts many entries per row, the buffered insertion API can
+     *    reduce PETSc call overhead by batching row insertions via MatSetValues().
+     */
     class Matrix {
         protected:
             Mat petsc_mat;
@@ -16,7 +28,18 @@ namespace DREAM::FVM {
 
             PetscInt rowOffset=0, colOffset=0;
 
+            std::vector<PetscInt> tmpRows;
+            std::vector<PetscScalar> tmpVals;
+
             bool allocated=false;
+
+            bool buffering = false;
+            PetscInt bufRow = -1;
+            PetscInt bufLen = 0;
+            InsertMode bufMode = ADD_VALUES;
+            std::vector<PetscInt> bufCols;
+            std::vector<PetscScalar> bufVals;
+            void FlushBufferedRow();
 
             void Construct(
                 const PetscInt, const PetscInt,
@@ -65,11 +88,62 @@ namespace DREAM::FVM {
             PetscInt GetRowOffset() const { return this->rowOffset; }
             PetscInt GetColOffset() const { return this->colOffset; }
 
+            /**
+             * Set one matrix element.
+             *
+             * If buffered insertion is enabled (BeginBufferedSet), values are queued
+             * and flushed per row using MatSetValues(). Otherwise, this calls MatSetValue().
+             */
             void SetElement(
                 const PetscInt, const PetscInt,
                 const PetscScalar, InsertMode im=ADD_VALUES
             );
-			void SetRow(
+
+            /**
+             * Insert values in a single column for a contiguous block of rows.
+             *
+             * This is a fast path for column-oriented assembly where the caller has a
+             * contiguous block of values corresponding to rows:
+             *
+             *   row = firstLocalRow + r,   r = 0..m-1
+             *   col = localCol
+             *   value(row, col) = vals[r]
+             *
+             * Applies rowOffset/colOffset internally. Exact zeros are skipped to avoid
+             * creating structural nonzeros for inactive rows (matching SetElement()).
+             */
+            void SetColumn(
+                PetscInt firstLocalRow, PetscInt localCol,
+                PetscInt m, const PetscScalar *vals,
+                InsertMode im=ADD_VALUES
+            );
+
+            /**
+             * Enable buffered insertion mode.
+             *
+             * While buffering is enabled, SetElement() accumulates (col,value) pairs
+             * for the current row and flushes them with MatSetValues() when the row
+             * changes or EndBufferedSet() is called.
+             *
+             * mode:    Insert mode for the whole buffered region (typically ADD_VALUES).
+             * reserve: Optional hint for expected nnz per row.
+             */
+            void BeginBufferedSet(InsertMode mode = ADD_VALUES, PetscInt reserve = 0);
+
+            /**
+             * Disable buffered insertion mode and flush any pending row.
+             */
+            void EndBufferedSet();
+
+            /**
+             * Insert values in a single row for multiple columns (row-oriented bulk insert).
+             *
+             * Notes:
+             *  - Applies rowOffset/colOffset.
+             *  - Does not filter zeros (callers may intentionally insert zeros to
+             *    establish a stable sparsity pattern).
+             */
+            void SetRow(
 				PetscInt, const PetscInt,
 				PetscInt*, const PetscScalar*,
 				InsertMode im=ADD_VALUES

--- a/src/Equations/FluidSourceTerm.cpp
+++ b/src/Equations/FluidSourceTerm.cpp
@@ -20,22 +20,41 @@ using namespace DREAM;
 FluidSourceTerm::FluidSourceTerm(
     FVM::Grid *kineticGrid, FVM::UnknownQuantityHandler *u
 ) : EquationTerm(kineticGrid), unknowns(u) {
-    sourceVec = new real_t[kineticGrid->GetNCells()];
+    GridRebuilt();
 }
 
 /**
  * Destructor
  */
 FluidSourceTerm::~FluidSourceTerm(){
-    delete [] sourceVec;
+    Deallocate();
+}
+
+void FluidSourceTerm::Deallocate(){
+    if (sourceVec != nullptr){
+        delete [] sourceVec;
+        sourceVec = nullptr;
+    }
+    if (tmpVec != nullptr){
+        delete [] tmpVec;
+        tmpVec = nullptr;
+    }
+
 }
 
 /**
  *  Reallocate when grid is rebuilt
  */
 bool FluidSourceTerm::GridRebuilt(){
-    delete [] sourceVec;
+    Deallocate();
     sourceVec = new real_t[this->grid->GetNCells()];
+    len_t n_max = 0;
+    for(len_t ir=0; ir<nr; ir++){
+        len_t N = n1[ir]*n2[ir];
+        if (N>n_max)
+            n_max = N;
+    }    
+    tmpVec = new real_t[n_max];
     return true;    
 }
 
@@ -74,14 +93,11 @@ void FluidSourceTerm::NormalizeSourceToConstant(const real_t c, real_t *normFact
  */
 void FluidSourceTerm::SetMatrixElements(FVM::Matrix *mat, real_t* /*rhs*/){
     len_t offset = 0;
-    for(len_t ir=0; ir<nr; ir++){
-        for(len_t i=0; i<n1[ir]; i++)
-            for(len_t j=0; j<n2[ir]; j++){
-                len_t ind = offset + n1[ir]*j + i;
-                mat->SetElement(ind, ir, sourceVec[ind]);
-            }
-        offset += n1[ir]*n2[ir];
-    }        
+    for (len_t ir = 0; ir < nr; ir++) {
+        const len_t m = n1[ir]*n2[ir];
+        mat->SetColumn(offset, ir, m, sourceVec + offset);
+        offset += m;
+    }
 }
 
 /**
@@ -115,12 +131,14 @@ bool FluidSourceTerm::SetJacobianBlock(const len_t uqtyId, const len_t derivId, 
 
     len_t offset = 0;
     for(len_t ir=0; ir<nr; ir++){
-        for(len_t i=0; i<n1[ir]; i++)
-            for(len_t j=0; j<n2[ir]; j++){
-                real_t dS = GetSourceFunctionJacobian(ir,i,j,derivId);
-                jac->SetElement(offset + n1[ir]*j + i, ir, dS*x[ir]);
+        for(len_t j=0; j<n2[ir]; j++){
+            for(len_t i=0; i<n1[ir]; i++){
+                tmpVec[n1[ir]*j + i] = x[ir] * GetSourceFunctionJacobian(ir,i,j,derivId);
             }
-        offset += n1[ir]*n2[ir];
+        }
+        const len_t m = n1[ir] * n2[ir]; 
+        jac->SetColumn(offset, ir, m, tmpVec);
+        offset += m;
     }
 
     return contributes;

--- a/src/Equations/FluidSourceTerm.cpp
+++ b/src/Equations/FluidSourceTerm.cpp
@@ -106,12 +106,12 @@ void FluidSourceTerm::SetMatrixElements(FVM::Matrix *mat, real_t* /*rhs*/){
 void FluidSourceTerm::SetVectorElements(real_t *vec, const real_t *x){
     len_t offset = 0;
     for(len_t ir=0; ir<nr; ir++){
-        for(len_t i=0; i<n1[ir]; i++)
-            for(len_t j=0; j<n2[ir]; j++){
-                len_t ind = offset + n1[ir]*j + i;
-                vec[ind] += sourceVec[ind]*x[ir];
-            }
-        offset += n1[ir]*n2[ir];
+        const len_t N = n1[ir] * n2[ir];
+        const len_t nmin = offset;
+        const len_t nmax = offset + N;
+        for(len_t ind=nmin; ind<nmax; ind++)
+            vec[ind] += sourceVec[ind]*x[ir];
+        offset += N;
     }
 }
 


### PR DESCRIPTION
Introduces a buffered-mode `Matrix::SetElement`, and a new batch column setter `Matrix::SetColumn`. Also introduces many small optimizations to `AdvectionTerm` and `DiffusionTerm`.

I noticed in a test simulation with kinetic electrons and dynamic ions (20 charge states, and using full ion jacobian in the kinetic equation) that ~50% of the total simulation time would sit in `AdvectionDiffusionTerm::SetJacobianBlock`.  With the optimizations in this PR:

- total time inside `AdvectionDiffusionTerm::SetJacobianBlock` reduced by 52%
- total time inside `Matrix::SetElement` reduced by 75%

The net effect is a total simulation time slashed by 31% in this (nearly "worst-case") example. 

This new functionality can likely be incorporated in a few more equation terms, but AdvectionDiffusion (fixed here) is generally the biggest one.


