### PR TITLE
Fixed tau_coll bug

### DIFF
--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -266,15 +266,12 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         """
         Specify which model to use for hottail runaway generation
         """
-        if hottail is False:
+        if hottail is False or hottail == HOTTAIL_MODE_DISABLED:
             self.hottail = HOTTAIL_MODE_DISABLED
             self.settings.eqsys.f_hot.enableAnalyticalDistribution(False)
         else:
-            self.hottail = hottail
-            if hottail != HOTTAIL_MODE_DISABLED:
-                self.settings.eqsys.f_hot.enableAnalyticalDistribution()
-            else:
-                self.settings.eqsys.f_hot.enableAnalyticalDistribution(False)
+            self.hottail = int(hottail)
+            self.settings.eqsys.f_hot.enableAnalyticalDistribution()
 
 
     def setNegativeRunaways(self, negative_re=True):

--- a/py/DREAM/Settings/Equations/RunawayElectrons.py
+++ b/py/DREAM/Settings/Equations/RunawayElectrons.py
@@ -268,10 +268,13 @@ class RunawayElectrons(UnknownQuantity,PrescribedInitialParameter):
         """
         if hottail is False:
             self.hottail = HOTTAIL_MODE_DISABLED
+            self.settings.eqsys.f_hot.enableAnalyticalDistribution(False)
         else:
             self.hottail = hottail
             if hottail != HOTTAIL_MODE_DISABLED:
                 self.settings.eqsys.f_hot.enableAnalyticalDistribution()
+            else:
+                self.settings.eqsys.f_hot.enableAnalyticalDistribution(False)
 
 
     def setNegativeRunaways(self, negative_re=True):


### PR DESCRIPTION
If you have start a simulation from another output and in the first output have hot-tail enabled but in the second output turn it off, you get the error that `tau_coll` does not exist in the equation system (which should not be a problem if the fluid hottail model is not utilized). I have solved this in this pull request. 