### PR TITLE
MGI patch

### DIFF
--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -609,6 +609,9 @@ class Ions(UnknownQuantity):
         neutral_prescribed_diffusion = None
         charged_prescribed_advection = None
         neutral_prescribed_advection = None
+        ion_source_t = None
+        ion_source_x = None
+        ion_source_r = None
         self.typeTi = IONS_T_I_NEGLECT
         if 'typeTi' in data:
             self.typeTi = int(scal(data['typeTi']))
@@ -645,6 +648,12 @@ class Ions(UnknownQuantity):
         if 'ion_source' in data:
             ion_source_t = data['ion_source']['t']
             ion_source_x = data['ion_source']['x']
+
+        if 'ion_source_volumetric' in data:
+            ion_source_t = data['ion_source_volumetric']['t']
+            ion_source_x = data['ion_source_volumetric']['x']
+            ion_source_r = data['ion_source_volumetric'].get('r', None)
+
 
         iidx, pidx, spiidx, cpdidx, npdidx, cpaidx, npaidx, srcidx = 0, 0, 0, 0, 0, 0, 0, 0
         for i in range(len(Z)):
@@ -736,7 +745,7 @@ class Ions(UnknownQuantity):
                 self.addIonSource(names[i], dNdt=ion_source_x[srcidx,:], t=ion_source_t, source_type=ION_SOURCE_PRESCRIBED)
                 srcidx += Z[i] + 1  # Move to next ion's position
             elif ion_source_types is not None and ion_source_types[i] == ION_SOURCE_PRESCRIBED_VOLUMETRIC:
-                ion_source_r = data['ion_source'].get('r', None)
+                #ion_source_r = data['ion_source'].get('r', None)
                 
                 # Extract the full 3D source data for this ion species
                 if len(ion_source_x.shape) == 3:
@@ -952,12 +961,21 @@ class Ions(UnknownQuantity):
 
         if self.tSourceTerm is not None:
             data['ion_source_types'] = sourceterm_types
-            data['ion_source'] = {
-                't': self.tSourceTerm,
-                'x': sourceterm
-            }
-            if self.rSourceTerm is not None and len(sourceterm.shape) == 3:
-                    data['ion_source']['r'] = self.rSourceTerm
+
+            if len(sourceterm.shape) == 2:
+                data['ion_source'] = {
+                    't': self.tSourceTerm,
+                    'x': sourceterm
+                }
+            elif len(sourceterm.shape) == 3:
+                data['ion_source_volumetric'] = {
+                    't': self.tSourceTerm,
+                    'r': self.rSourceTerm,
+                    'x': sourceterm
+                }
+            else:
+                raise EquationException(f"Unexpected ion source shape: {sourceterm.shape}.")
+
 
         # Flux limiter settings
         data['adv_interp_charged'] = self.advectionInterpolationCharged.todict()

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -648,6 +648,9 @@ class Ions(UnknownQuantity):
         if 'ion_source' in data:
             ion_source_t = data['ion_source']['t']
             ion_source_x = data['ion_source']['x']
+            
+            if len(ion_source_x.shape) == 3:
+                ion_source_r = data['ion_source'].get('r', None)
 
         if 'ion_source_volumetric' in data:
             ion_source_t = data['ion_source_volumetric']['t']
@@ -747,8 +750,6 @@ class Ions(UnknownQuantity):
             elif ion_source_types is not None and ion_source_types[i] == ION_SOURCE_PRESCRIBED_VOLUMETRIC:
                 
                 # Extract the full 3D source data for this ion species
-                if ion_source_r is None:
-                    raise EquationException("Volumetric ion source requires a radial grid 'r'.")
                 if len(ion_source_x.shape) == 3:
                     dNdt_data = ion_source_x[srcidx:srcidx+(Z[i]+1), :, :]
                     srcidx += Z[i] + 1  # Move to next ion's position

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -745,7 +745,6 @@ class Ions(UnknownQuantity):
                 self.addIonSource(names[i], dNdt=ion_source_x[srcidx,:], t=ion_source_t, source_type=ION_SOURCE_PRESCRIBED)
                 srcidx += Z[i] + 1  # Move to next ion's position
             elif ion_source_types is not None and ion_source_types[i] == ION_SOURCE_PRESCRIBED_VOLUMETRIC:
-                #ion_source_r = data['ion_source'].get('r', None)
                 
                 # Extract the full 3D source data for this ion species
                 if len(ion_source_x.shape) == 3:

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -747,6 +747,8 @@ class Ions(UnknownQuantity):
             elif ion_source_types is not None and ion_source_types[i] == ION_SOURCE_PRESCRIBED_VOLUMETRIC:
                 
                 # Extract the full 3D source data for this ion species
+                if ion_source_r is None:
+                    raise EquationException("Volumetric ion source requires a radial grid 'r'.")
                 if len(ion_source_x.shape) == 3:
                     dNdt_data = ion_source_x[srcidx:srcidx+(Z[i]+1), :, :]
                     srcidx += Z[i] + 1  # Move to next ion's position

--- a/py/DREAM/Settings/Equations/Ions.py
+++ b/py/DREAM/Settings/Equations/Ions.py
@@ -651,11 +651,15 @@ class Ions(UnknownQuantity):
             
             if len(ion_source_x.shape) == 3:
                 ion_source_r = data['ion_source'].get('r', None)
+                if ion_source_r is None:
+                    raise EquationException("The legacy 3D ion source ('ion_source') requires an explicit radial grid 'r'.")
 
         if 'ion_source_volumetric' in data:
             ion_source_t = data['ion_source_volumetric']['t']
             ion_source_x = data['ion_source_volumetric']['x']
             ion_source_r = data['ion_source_volumetric'].get('r', None)
+            if ion_source_r is None:
+                raise EquationException("The volumetric ion source ('ion_source_volumetric') requires an explicit radial grid 'r'.")
 
 
         iidx, pidx, spiidx, cpdidx, npdidx, cpaidx, npaidx, srcidx = 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/Settings/Equations/ions.cpp
+++ b/src/Settings/Equations/ions.cpp
@@ -68,7 +68,8 @@ void SimulationGenerator::DefineOptions_Ions(Settings *s) {
     DefineDataIonRT(MODULENAME, s, "neutral_prescribed_diffusion");
     DefineDataIonRT(MODULENAME, s, "charged_prescribed_advection");
     DefineDataIonRT(MODULENAME, s, "neutral_prescribed_advection");
-	DefineDataIonRT(MODULENAME, s, "ion_source");
+	DefineDataIonT(MODULENAME, s, "ion_source");
+    DefineDataIonRT(MODULENAME, s, "ion_source_volumetric");
 }
 
 /**
@@ -509,7 +510,7 @@ void SimulationGenerator::ConstructEquation_Ions(
 
             // Load prescribed source term data
 			MultiInterpolator1D *source_data = LoadDataIonRT(
-				MODULENAME,fluidGrid->GetRadialGrid(), s, nZ0_dynamic+nZ0_prescribed, "ion_source"
+				MODULENAME,fluidGrid->GetRadialGrid(), s, nZ0_dynamic+nZ0_prescribed, "ion_source_volumetric"
 			);
             
             len_t *all_ion_indices = new len_t[nZ];

--- a/src/Settings/Equations/ions.cpp
+++ b/src/Settings/Equations/ions.cpp
@@ -505,21 +505,25 @@ void SimulationGenerator::ConstructEquation_Ions(
 	}
 
     //Adds ion source (for 1 ion species) term to all grid, 
+    bool hasVolumetricIonSource = false;
     for (len_t iZ = 0; iZ < nZ; iZ++) {
         if (source_types[iZ] == OptionConstants::ION_SOURCE_PRESCRIBED_VOLUMETRIC) {
-
-            // Load prescribed source term data
-			MultiInterpolator1D *source_data = LoadDataIonRT(
-				MODULENAME,fluidGrid->GetRadialGrid(), s, nZ0_dynamic+nZ0_prescribed, "ion_source_volumetric"
-			);
-            
-            len_t *all_ion_indices = new len_t[nZ];
-            for (len_t i = 0; i < nZ; i++)
-                all_ion_indices[i] = i;
-
-            //One species source iZ added to all grid
-            eqn->AddTerm(new IonSourceTerm(fluidGrid, ih, nZ, all_ion_indices, source_data));
+            hasVolumetricIonSource = true;
+            break;
         }
+    }
+
+    if (hasVolumetricIonSource) {
+        MultiInterpolator1D *source_data = LoadDataIonRT(
+            MODULENAME, fluidGrid->GetRadialGrid(), s,
+            nZ0_dynamic+nZ0_prescribed, "ion_source_volumetric"
+        );
+
+        len_t *all_ion_indices = new len_t[nZ];
+        for (len_t i = 0; i < nZ; i++)
+            all_ion_indices[i] = i;
+
+        eqn->AddTerm(new IonSourceTerm(fluidGrid, ih, nZ, all_ion_indices, source_data));
     }
 
     // Initialize dynamic ions

--- a/src/Settings/Equations/ions.cpp
+++ b/src/Settings/Equations/ions.cpp
@@ -504,7 +504,7 @@ void SimulationGenerator::ConstructEquation_Ions(
 		}
 	}
 
-    //Adds ion source (for 1 ion species) term to all grid, 
+    // One species source iZ added to all grid
     bool hasVolumetricIonSource = false;
     for (len_t iZ = 0; iZ < nZ; iZ++) {
         if (source_types[iZ] == OptionConstants::ION_SOURCE_PRESCRIBED_VOLUMETRIC) {


### PR DESCRIPTION

When `ion_source_volumetric` was implemented, the old MGI `ion_source` method stopped working properly. That method injects particles from the outer radial grid and is defined in 2D, but the C++ code was accidentally changed to interpolate it in only 3D.

This PR fixes the issue by separating the logic into two different interpolation paths:

- a 2D interpolation for the old MGI `ion_source`
- a 3D interpolation for `ionsource_volumetric`