### PR TITLE
Add support for initializing j_hot

### DIFF
--- a/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
+++ b/include/DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp
@@ -6,23 +6,28 @@
 #include "FVM/Interpolator1D.hpp"
 #include "FVM/Grid/Grid.hpp"
 #include "FVM/UnknownQuantityHandler.hpp"
+#include "DREAM/IonHandler.hpp"
 
 namespace DREAM {
     class HyperresistiveDiffusionTerm
         : public FVM::DiffusionTerm {
     private:
+		IonHandler *ions;
         FVM::Interpolator1D *Lambda=nullptr; 
+		FVM::Interpolator1D *dBB=nullptr;
+		
+		real_t *lambda_buf = nullptr;
 	
 	protected:
-		virtual const real_t *EvaluateLambda(const real_t t) { return this->Lambda->Eval(t); }
+		virtual const real_t *EvaluateLambda(const real_t t);
 
 		void BuildCoefficient(const real_t*, real_t**);
 
     public:
-        HyperresistiveDiffusionTerm(FVM::Grid*, FVM::Interpolator1D*);
+        HyperresistiveDiffusionTerm(FVM::Grid*, IonHandler*, FVM::Interpolator1D*, FVM::Interpolator1D*);
 		virtual ~HyperresistiveDiffusionTerm();
         
-        virtual const real_t *GetLambda() const { return Lambda->GetBuffer(); }
+        virtual const real_t *GetLambda() const;
         virtual void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
     };
 }

--- a/py/DREAM/Settings/Equations/HotElectronDistribution.py
+++ b/py/DREAM/Settings/Equations/HotElectronDistribution.py
@@ -1,6 +1,7 @@
 
 from . import DistributionFunction as DistFunc
 from . DistributionFunction import DistributionFunction
+from . PrescribedInitialParameter import PrescribedInitialParameter
 
 # BOUNDARY CONDITIONS (WHEN f_re IS DISABLED)
 # (NOTE: These are kept for backwards compatibility. You
@@ -37,8 +38,9 @@ PARTICLE_SOURCE_SHAPE_DELTA = 2
 
 F_HOT_DIST_MODE_NONREL = 1
 
-class HotElectronDistribution(DistributionFunction):
+class HotElectronDistribution(DistributionFunction, PrescribedInitialParameter):
     
+
     def __init__(self, settings,
         fhot=None, initr=None, initp=None, initxi=None,
         initppar=None, initpperp=None,
@@ -71,6 +73,9 @@ class HotElectronDistribution(DistributionFunction):
         self.particleSource = particleSource
         self.particleSourceShape = particleSourceShape
 
+        self.Ip0 = None
+        self.jhot0 = None
+
 
     def setHotRegionThreshold(self, pThreshold=7, pMode=HOT_REGION_P_MODE_THERMAL):
         """
@@ -93,6 +98,21 @@ class HotElectronDistribution(DistributionFunction):
         self.particleSourceShape = shape
 
 
+    def setInitialJHot(self, j, r=0, Ip0=None):
+        """
+        Set the initial current density carried by the hot electrons.
+        This is only relevant if using COLLFREQ_MODE_SUPERTHERMAL with nXi = 1.
+        Ip0 is used to re-scale the current density profile.
+        """
+        _data, _rad = self._setInitialData(data=j, radius=r)
+
+        self.jhot0 = _data
+        self.jhot0_r = _rad
+        self.Ip0 = Ip0
+
+        self._verifySettingsPrescribedInitialData('j_hot', self.jhot0, self.jhot0_r)
+
+
     def fromdict(self, data):
         """
         Load data for this object from the given dictionary.
@@ -108,6 +128,13 @@ class HotElectronDistribution(DistributionFunction):
         if 'particleSourceShape' in data:
             self.particleSourceShape = data['particleSourceShape']
 
+        if 'j_hot0' in data:
+            self.jhot0 = data['j_hot0']['x']
+            self.jhot0_r = data['j_hot0']['r']
+
+            if 'Ip0' in data:
+                self.Ip0 = data['Ip0']
+
 
     def todict(self):
         """
@@ -121,6 +148,15 @@ class HotElectronDistribution(DistributionFunction):
             data['pThresholdMode'] = self.pThresholdMode
             data['particleSource'] = self.particleSource
             data['particleSourceShape'] = self.particleSourceShape
+
+        if self.jhot0 is not None:
+            data['j_hot0'] = {
+                'x': self.jhot0,
+                'r': self.jhot0_r
+            }
+
+            if self.Ip0 is not None:
+                data['Ip0'] = self.Ip0
 
         return data
 

--- a/py/DREAM/Settings/Equations/PoloidalFlux.py
+++ b/py/DREAM/Settings/Equations/PoloidalFlux.py
@@ -26,13 +26,17 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         self.hyperresistivity_Lambda_r = None
         self.hyperresistivity_Lambda_t = None
 
+        self.hyperresistivity_dBB_x = None
+        self.hyperresistivity_dBB_r = None
+        self.hyperresistivity_dBB_t = None
+
         self.hyperresistivity_grad_j_tot_max = None
         self.hyperresistivity_gradient_normalized = False
         self.hyperresistivity_dBB0 = None
         self.hyperresistivity_suppression_level = 0.9
 
 
-    def setHyperresistivity(self, Lambda, radius=None, times=None):
+    def setHyperresistivity(self, Lambda=None, dBB=None, radius=None, times=None):
         """
         Enable the hyperresistive diffusion term and specify the
         transport coefficient ``Lambda``.
@@ -41,12 +45,20 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         :param radius: Radial grid on which  ``Lambda`` is specified (if any).
         :param times:  Time grid on which ``Lambda`` is specified (if any).
         """
-        d, r, t = self._setPrescribedData(data=Lambda, radius=radius, times=times)
+        if Lambda is not None:
+            d, r, t = self._setPrescribedData(data=Lambda, radius=radius, times=times)
 
-        self.hyperresistivity_mode = HYPERRESISTIVITY_MODE_PRESCRIBED
-        self.hyperresistivity_Lambda_x = d
-        self.hyperresistivity_Lambda_r = r
-        self.hyperresistivity_Lambda_t = t
+            self.hyperresistivity_mode = HYPERRESISTIVITY_MODE_PRESCRIBED
+            self.hyperresistivity_Lambda_x = d
+            self.hyperresistivity_Lambda_r = r
+            self.hyperresistivity_Lambda_t = t
+        elif dBB is not None:
+            d, r, t = self._setPrescribedData(data=dBB, radius=radius, times=times)
+
+            self.hyperresistivity_mode = HYPERRESISTIVITY_MODE_PRESCRIBED
+            self.hyperresistivity_dBB_x = d
+            self.hyperresistivity_dBB_r = r
+            self.hyperresistivity_dBB_t = t
 
 
     def setHyperresistivityAdaptive(
@@ -96,6 +108,10 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
                 self.hyperresistivity_Lambda_x = hyp['Lambda']['x']
                 self.hyperresistivity_Lambda_r = hyp['Lambda']['r']
                 self.hyperresistivity_Lambda_t = hyp['Lambda']['t']
+            elif 'dBB' in hyp:
+                self.hyperresistivity_dBB_x = hyp['dBB']['x']
+                self.hyperresistivity_dBB_r = hyp['dBB']['r']
+                self.hyperresistivity_dBB_t = hyp['dBB']['t']
             elif 'dBB0' in hyp:
                 self.hyperresistivity_dBB0 = float(scal(hyp['dBB0']))
                 self.hyperresistivity_grad_j_tot_max = float(scal(hyp['grad_j_tot_max']))
@@ -111,11 +127,18 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         hypres = { 'mode': self.hyperresistivity_mode }
 
         if self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_PRESCRIBED:
-            hypres['Lambda'] = {
-                'x': self.hyperresistivity_Lambda_x,
-                'r': self.hyperresistivity_Lambda_r,
-                't': self.hyperresistivity_Lambda_t
-            }
+            if self.hyperresistivity_Lambda_x is not None:
+                hypres['Lambda'] = {
+                    'x': self.hyperresistivity_Lambda_x,
+                    'r': self.hyperresistivity_Lambda_r,
+                    't': self.hyperresistivity_Lambda_t
+                }
+            elif self.hyperresistivity_dBB_x is not None:
+                hypres['dBB'] = {
+                    'x': self.hyperresistivity_dBB_x,
+                    'r': self.hyperresistivity_dBB_r,
+                    't': self.hyperresistivity_dBB_t
+                }
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE or self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL:
             hypres['dBB0'] = self.hyperresistivity_dBB0
             hypres['grad_j_tot_max'] = self.hyperresistivity_grad_j_tot_max
@@ -132,7 +155,12 @@ class PoloidalFlux(UnknownQuantity,PrescribedParameter):
         if self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_NEGLECT:
             pass
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_PRESCRIBED:
-            self._verifySettingsPrescribedData('psi_p hyperresistivity', data=self.hyperresistivity_Lambda_x, radius=self.hyperresistivity_Lambda_r, times=self.hyperresistivity_Lambda_t)
+            if self.hyperresistivity_Lambda_x is not None:
+                self._verifySettingsPrescribedData('psi_p hyperresistivity', data=self.hyperresistivity_Lambda_x, radius=self.hyperresistivity_Lambda_r, times=self.hyperresistivity_Lambda_t)
+            elif self.hyperresistivity_dBB_x is not None:
+                self._verifySettingsPrescribedData('psi_p hyperresistivity', data=self.hyperresistivity_dBB_x, radius=self.hyperresistivity_dBB_r, times=self.hyperresistivity_dBB_t)
+            else:
+                raise EquationException(f"Hyperresistivity mode is set to 'prescribed', but no data has been provided for either 'Lambda' or 'dBB'.")
         elif self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE or self.hyperresistivity_mode == HYPERRESISTIVITY_MODE_ADAPTIVE_LOCAL:
             if not np.isscalar(self.hyperresistivity_dBB0):
                 raise EquationException(f"The hyperresistivity parameter 'dBB0' must be a scalar. Current value: {self.hyperresistivity_dBB0}.")

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -96,10 +96,14 @@ const real_t *AdaptiveHyperresistiveDiffusionTerm::EvaluateLambda(const real_t t
 	const real_t *n_i = uqh->GetUnknownData(this->id_n_i);
 	for (len_t iZs = 0; iZs < nZs; iZs++) {
 		for (len_t ir = 0; ir < nr+1; ir++) {
+			real_t ni;
 			if (ir < nr)
-				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*n_i[iZs*nr + ir]);
+				ni = n_i[iZs*nr + ir];
 			else
-				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*n_i[iZs*nr + nr-1]);
+				ni = n_i[iZs*nr + nr-1];
+
+			if (ni > 0)
+				this->dLambda[iZs*(nr+1) + ir] = -this->Lambda[ir] / (2*ni);
 		}
 	}
 	

--- a/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/AdaptiveHyperresistiveDiffusionTerm.cpp
@@ -18,7 +18,7 @@ AdaptiveHyperresistiveDiffusionTerm::AdaptiveHyperresistiveDiffusionTerm(
 	const real_t grad_j_tot_max, bool gradient_normalized,
 	const real_t dBB0, const real_t suppression_level, bool localized
 ) : AdaptiveMHDLikeTransportTerm(grid, uqh, grad_j_tot_max, gradient_normalized, suppression_level, localized),
-	HyperresistiveDiffusionTerm(grid, nullptr), ions(ions), dBB0(dBB0) {
+	HyperresistiveDiffusionTerm(grid, ions, nullptr, nullptr), ions(ions), dBB0(dBB0) {
 	
 	this->Lambda0 = new real_t[grid->GetNr()+1];
 	this->Lambda = new real_t[grid->GetNr()+1];

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -19,9 +19,6 @@ HyperresistiveDiffusionTerm::HyperresistiveDiffusionTerm(
     
     SetName("HyperresistiveDiffusionTerm");
 
-	if (this->Lambda == nullptr && this->dBB == nullptr)
-		throw DREAMException("HyperresistiveDiffusionTerm: either Lambda or dBB must be provided.");
-	
 	if (this->dBB != nullptr)
 		this->lambda_buf = new real_t[g->GetNr()+1];
 }

--- a/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
+++ b/src/Equations/Fluid/HyperresistiveDiffusionTerm.cpp
@@ -3,6 +3,8 @@
  * Based on the section on hyperresistivity in DREAM/doc/notes/theory
  */
 
+#include "DREAM/Constants.hpp"
+#include "DREAM/DREAMException.hpp"
 #include "DREAM/Equations/Fluid/HyperresistiveDiffusionTerm.hpp"
 
 
@@ -12,10 +14,16 @@ using namespace DREAM;
  * Constructor.
  */
 HyperresistiveDiffusionTerm::HyperresistiveDiffusionTerm(
-    FVM::Grid *g, FVM::Interpolator1D *Lambda
-) : FVM::DiffusionTerm(g), Lambda(Lambda) {
+    FVM::Grid *g, IonHandler *ions, FVM::Interpolator1D *Lambda, FVM::Interpolator1D *dBB
+) : FVM::DiffusionTerm(g), ions(ions), Lambda(Lambda), dBB(dBB) {
     
     SetName("HyperresistiveDiffusionTerm");
+
+	if (this->Lambda == nullptr && this->dBB == nullptr)
+		throw DREAMException("HyperresistiveDiffusionTerm: either Lambda or dBB must be provided.");
+	
+	if (this->dBB != nullptr)
+		this->lambda_buf = new real_t[g->GetNr()+1];
 }
 
 
@@ -25,7 +33,66 @@ HyperresistiveDiffusionTerm::HyperresistiveDiffusionTerm(
 HyperresistiveDiffusionTerm::~HyperresistiveDiffusionTerm() {
 	if (this->Lambda != nullptr)
 		delete this->Lambda;
+	if (this->dBB != nullptr)
+		delete this->dBB;
+	if (this->lambda_buf != nullptr)
+		delete [] this->lambda_buf;
 }
+
+
+/**
+ * Get the current value for the hyperresistive diffusion coefficient.
+ */
+const real_t *HyperresistiveDiffusionTerm::GetLambda() const {
+	if (this->Lambda != nullptr)
+		return this->Lambda->GetBuffer();
+	else if (this->dBB != nullptr)
+		return this->lambda_buf;
+	else
+		throw DREAMException("HyperresistiveDiffusionTerm: either Lambda or dBB must be provided.");
+}
+
+
+/**
+ * Evaluate the hyperresistive diffusion coefficient.
+ */
+const real_t *HyperresistiveDiffusionTerm::EvaluateLambda(const real_t t) {
+	if (this->Lambda != nullptr)
+		return this->Lambda->Eval(t);
+	else if (this->dBB != nullptr) {
+		// Evaluate Lambda from dB/B
+		FVM::RadialGrid *rGrid = grid->GetRadialGrid(); 
+		const len_t nr = rGrid->GetNr();
+		const real_t R0 = rGrid->GetR0();
+
+		const real_t *dBB0 = this->dBB->Eval(t);
+		const real_t qR0 = R0;
+
+		// (skip ir=0 since psi_t=0 there, and to avoid 1/psitPrime = 1/0)
+		for (len_t ir = 0; ir < nr+1; ir++) {
+			real_t Bavg = rGrid->GetFSA_B_f(ir) * rGrid->GetBmin_f(ir);
+
+			real_t rho;
+			if (ir < nr)
+				rho = this->ions->GetTotalIonMassDensity(ir);
+			else
+				rho = this->ions->GetTotalIonMassDensity(nr-1);
+
+			real_t V_A = Bavg / std::sqrt(Constants::mu0 * rho);
+			real_t a = rGrid->GetMinorRadius();
+			real_t psit = rGrid->GetToroidalFlux_f(nr);
+
+			real_t pf = M_PI*Constants::mu0 * qR0 * R0;
+
+			this->lambda_buf[ir] =
+				pf * V_A * (psit*psit) / (288*a*a) * dBB0[ir]*dBB0[ir];
+		}
+
+		return this->lambda_buf;
+	} else
+		throw DREAMException("HyperresistiveDiffusionTerm: either Lambda or dBB must be provided.");
+}
+
 
 /**
  * Build the coefficients of this diffusion term.

--- a/src/Settings/Equations/E_field.cpp
+++ b/src/Settings/Equations/E_field.cpp
@@ -130,6 +130,7 @@ void SimulationGenerator::DefineOptions_ElectricField(Settings *s){
 	s->DefineSetting(MODULENAME_HYPRES "/dBB0", "Magnetic perturbation value for calculating adaptive diffusion coefficient, when enabled", (real_t)0.0);
 	s->DefineSetting(MODULENAME_HYPRES "/suppression_level", "Fraction of the maximum current density gradient below which the adaptive transport should be disabled", (real_t)0.9);
     DefineDataRT(MODULENAME_HYPRES, s, "Lambda");
+	DefineDataRT(MODULENAME_HYPRES, s, "dBB");
 }
 
 /**
@@ -234,15 +235,29 @@ void SimulationGenerator::ConstructEquation_E_field_selfconsistent(
 	enum OptionConstants::eqterm_hyperresistivity_mode hypres_mode =
 		(enum OptionConstants::eqterm_hyperresistivity_mode)s->GetInteger(MODULENAME_HYPRES "/mode");
     if (hypres_mode == OptionConstants::EQTERM_HYPERRESISTIVITY_MODE_PRESCRIBED) {
-        FVM::Interpolator1D *Lambda = LoadDataRT_intp(
-            MODULENAME_HYPRES,
-            eqsys->GetFluidGrid()->GetRadialGrid(),
-            s, "Lambda", true
-        );
+		FVM::Interpolator1D *Lambda = nullptr, *dBB = nullptr;
+		len_t nr_inp;
+
+		if (s->GetRealArray(MODULENAME_HYPRES "/Lambda/r", 1, &nr_inp, false) != nullptr) {
+			Lambda = LoadDataRT_intp(
+				MODULENAME_HYPRES,
+				eqsys->GetFluidGrid()->GetRadialGrid(),
+				s, "Lambda", true
+			);
+		} else if (s->GetRealArray(MODULENAME_HYPRES "/dBB/r", 1, &nr_inp, false) != nullptr) {
+			dBB = LoadDataRT_intp(
+				MODULENAME_HYPRES,
+				eqsys->GetFluidGrid()->GetRadialGrid(),
+				s, "dBB", true
+			);
+		} else
+			throw SettingsException(
+				"For hyperresistive diffusion, one of 'Lambda' and 'dBB' must be provided."
+			);
 
         FVM::Operator *hypTerm = new FVM::Operator(fluidGrid);
         HyperresistiveDiffusionTerm *hrdt = new HyperresistiveDiffusionTerm(
-            fluidGrid, Lambda
+            fluidGrid, eqsys->GetIonHandler(), Lambda, dBB
         );
         hypTerm->AddTerm(hrdt);
         oqty_terms->psi_p_hyperresistive = hrdt;

--- a/src/Settings/Equations/f_hot.cpp
+++ b/src/Settings/Equations/f_hot.cpp
@@ -56,6 +56,11 @@ void SimulationGenerator::DefineOptions_f_hot(Settings *s) {
     s->DefineSetting(MODULENAME "/particleSourceShape", "Determines the shape of the particle source term.", (int_t)OptionConstants::EQTERM_PARTICLE_SOURCE_SHAPE_MAXWELLIAN);
 	
     s->DefineSetting(MODULENAME "/dist_mode", "Which analytic model to use for the hottail distribution", (int_t)OptionConstants::UQTY_F_HOT_DIST_MODE_NONREL);
+
+	// Initial j_hot in isotropic mode
+	s->DefineSetting(MODULENAME "/Ip0", "Plasma current at t=0, used to calculate initial j_hot in isotropic mode.", (real_t)0);
+	//s->DefineSetting(MODULENAME "/j_hot0", "Initial j_hot profile.", (real_t*)nullptr);
+	DefineDataR(MODULENAME, s, "j_hot0");
 }
 
 /**

--- a/src/Settings/Equations/j_hot.cpp
+++ b/src/Settings/Equations/j_hot.cpp
@@ -159,15 +159,32 @@ void SimulationGenerator::ConstructEquation_j_hot_hottailMode(
 
     eqsys->SetOperator(id_jhot, id_jhot, Op1, "j_hot = int(-E/nu_D * df_hot/dp) + int(v*f_hot) [hot-tail mode]");
     eqsys->SetOperator(id_jhot, id_fhot, Op2);
-    // Set initialization method
-    eqsys->initializer->AddRule(
-        id_jhot,
-        EqsysInitializer::INITRULE_EVAL_EQUATION,
-        nullptr,
-        // Dependencies
-        id_fhot,
-        id_Eterm,
-        id_Tcold,
-        EqsysInitializer::COLLQTYHDL_HOTTAIL
-    );
+
+	if (s->GetReal("eqsys/f_hot/Ip0") != 0) {
+		real_t *j_hot0 = LoadDataR("eqsys/f_hot", eqsys->GetFluidGrid()->GetRadialGrid(), s, "j_hot0");
+		const real_t Ip0 = (real_t) s->GetReal("eqsys/f_hot/Ip0");
+		const real_t Ipj = TotalPlasmaCurrentFromJTot::EvaluateIp(
+			eqsys->GetFluidGrid()->GetRadialGrid(), j_hot0
+		);
+		const real_t f = Ip0 / Ipj;
+		const len_t nr = fluidGrid->GetNr();
+
+		for (len_t ir = 0; ir < nr; ir++)
+			j_hot0[ir] *= f;
+
+		eqsys->SetInitialValue(OptionConstants::UQTY_J_HOT, j_hot0);
+		delete [] j_hot0;
+	} else {
+		// Set initialization method
+		eqsys->initializer->AddRule(
+			id_jhot,
+			EqsysInitializer::INITRULE_EVAL_EQUATION,
+			nullptr,
+			// Dependencies
+			id_fhot,
+			id_Eterm,
+			id_Tcold,
+			EqsysInitializer::COLLQTYHDL_HOTTAIL
+		);
+	}
 }


### PR DESCRIPTION
In isotropic simulations, we currently have to run an initialization simulation with only one purpose: setting a desired initial value of ``j_hot``. It should be possible to accomplish this much more easily, and so in this pull request I propose a more user-friendly approach for initializing the isotropic model.