### PR TITLE
Fix typos in tritium sections in n_re and ions in docs

### DIFF
--- a/doc/sphinx/source/frontend/api/Settings/eqsys/ions.rst
+++ b/doc/sphinx/source/frontend/api/Settings/eqsys/ions.rst
@@ -667,7 +667,7 @@ The corresponding runaway rate is given by
    \left( \frac{\mathrm{d} n_{\rm RE}}{\mathrm{d} t} \right)_{\rm T} \approx
    \ln 2 \frac{n_{\rm T}}{\tau_{\rm T}} F_\beta\left( \gamma_{\rm c} \right),
 
-where :math:`n_{\rm T}` is the tritium density, :math:`\tau_{\rm T} = 4800\pm 8`
+where :math:`n_{\rm T}` is the tritium density, :math:`\tau_{\rm T} = 4500\pm 8`
 days is the tritium half-life, and :math:`F_\beta(\gamma_{\rm c})` denotes the
 fraction of beta electrons generated with an energy above the critical energy
 :math:`\gamma_{\rm c}` for runaway to occur.

--- a/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
+++ b/doc/sphinx/source/frontend/api/Settings/eqsys/n_re.rst
@@ -293,11 +293,12 @@ mechanism in a DREAM simulation:
 .. code-block:: python
 
    import DREAM.Settings.Equations.IonSpecies as Ions
+   import DREAM.Settings.Equations.RunawayElectons as Runaways
 
    ds = DREAMSettings()
    ...
    # Include source term in equation for n_re
-   ds.eqsys.n_re.setTritium(tritium=TRITIUM_MODE_FLUID)
+   ds.eqsys.n_re.setTritium(tritium=Runaways.TRITIUM_MODE_FLUID)
 
    # Add tritium ion species to list of ions
    ds.eqsys.ions.addIon('T', Z=1, iontype=Ions.IONS_DYNAMIC, n=2e19, tritium=True)
@@ -334,12 +335,12 @@ and the kinetic source rate by
 Following Martin-Solis Eq (24), we model the photon energy spectrum with 
 
 .. math::
-   \Phi = \Phi_0 \frac{\exp[ - \exp(-z) - z + 1 ]}{5.8844 m_e c^2} 
+   \Phi = \Phi_0 \frac{\exp[ - \exp(-z) - z + 1 ]}{5.8844 m_{\rm e} c^2} 
 
 where :math:`\Phi_0 = \int \Phi \,\mathrm{d}E_\gamma` is the total photon gamma flux.
 For ITER, according to Martin-Solis, this value is :math:`\Phi_0 \approx 10^{18}\,\mathrm{m}^{-2}\mathrm{s}^{-1}`
 during the nuclear phase.
-We use :math:`z = [C_1 + \ln(E_\gamma[MeV])]/C_2 + C_3(E_\gamma[MeV])^2`, where :math:`C_1,\ C_2` and :math:`C_3`
+We use :math:`z = [C_1 + \ln(E_\gamma\,[\rm{MeV}])]/C_2 + C_3(E_\gamma\,[\rm{MeV}])^2`, where :math:`C_1,\ C_2` and :math:`C_3`
 are free positive parameters used to determine the shape of the photon flux spectrum. The Compton fitting tool can
 be used to fit these parameters to data of this spectrum, otherwise the default values are the ones used by 
 Martin-Solis, i.e. :math:`C_1 = 1.2`, :math:`C_2 = 0.8` and :math:`C_3 = 0`.


### PR DESCRIPTION
Found a few typos regarding the tritium seed in the docs. The half-life was incorrect in "ions", and the code example in "n_re" would not run. In addition, I added a few ```\rm``` in the equations in the Compton section where it was missing