### PR TITLE
Fixed bug for restarting simulation with scrape off

### DIFF
--- a/py/DREAM/Output/LCFSLoss.py
+++ b/py/DREAM/Output/LCFSLoss.py
@@ -6,7 +6,7 @@ from .ScalarQuantity import ScalarQuantity
 
 class LCFSLoss(OtherFluidQuantity):
 
-    def __init__(self, name, data, description, grid, output):
+    def __init__(self, name, data, description, grid, output, momentumgrid):
         """
         Constructor.
         """

--- a/py/DREAM/Output/OtherQuantities.py
+++ b/py/DREAM/Output/OtherQuantities.py
@@ -110,7 +110,7 @@ class OtherQuantities:
             else:
                 o = datatype(name=name, data=data, description=desc, grid=self.grid, output=self.output, momentumgrid=self.momentumgrid)
         elif name in self.SPECIAL_TREATMENT:
-            if self.SPECIAL_TREATMENT[name] == OtherIonSpeciesFluidQuantity or self.SPECIAL_TREATMENT[name] == LCFSLoss:
+            if self.SPECIAL_TREATMENT[name] == OtherIonSpeciesFluidQuantity:
                 o = self.SPECIAL_TREATMENT[name](name=name, data=data, description=desc, grid=self.grid, output=self.output)
             elif data.ndim == 5 and self.momentumgrid is not None:
                 o = self.SPECIAL_TREATMENT[name](name=name, data=data, description=desc, grid=self.grid, output=self.output, momentumgrid=self.momentumgrid)

--- a/py/DREAM/Output/OtherQuantities.py
+++ b/py/DREAM/Output/OtherQuantities.py
@@ -110,7 +110,7 @@ class OtherQuantities:
             else:
                 o = datatype(name=name, data=data, description=desc, grid=self.grid, output=self.output, momentumgrid=self.momentumgrid)
         elif name in self.SPECIAL_TREATMENT:
-            if self.SPECIAL_TREATMENT[name] == OtherIonSpeciesFluidQuantity:
+            if self.SPECIAL_TREATMENT[name] == OtherIonSpeciesFluidQuantity or self.SPECIAL_TREATMENT[name] == LCFSLoss:
                 o = self.SPECIAL_TREATMENT[name](name=name, data=data, description=desc, grid=self.grid, output=self.output)
             elif data.ndim == 5 and self.momentumgrid is not None:
                 o = self.SPECIAL_TREATMENT[name](name=name, data=data, description=desc, grid=self.grid, output=self.output, momentumgrid=self.momentumgrid)


### PR DESCRIPTION
If you initialize a simulation from another with scrape off, it crashed because the scrape off class does not take a momentumgrid as an input, similar to OtherIonSpeciesFluidQuantity. I therefore did the same solution for LCFSLoss as for OtherIonSpeciesFluidQuantity