### PR TITLE
Add helper functions for radial grids in EQDSK

### DIFF
--- a/tools/eqget/EqBase.py
+++ b/tools/eqget/EqBase.py
@@ -437,6 +437,41 @@ class EqBase:
         return self.rho(psi_n)*self.a_minor
 
 
+    def get_r_distance(self, psi_n):
+        """
+        Get the distance from the magnetic axis to the given flux surface along
+        the Z=Z0 line.
+        """
+        psi_n = np.asarray(psi_n)
+        scalar_input = psi_n.ndim == 0
+        psi_n = np.atleast_1d(psi_n)
+
+        r_dist = np.zeros(psi_n.shape)
+        for i in range(psi_n.size):
+            R, _ = self.get_flux_surface(psi_n[i], theta=0)
+            r_dist[i] = R - self.R0
+
+        return r_dist[0] if scalar_input else r_dist
+
+
+    def get_rho_tor(self, psi_n):
+        """
+        Get the normalized toroidal flux coordinate corresponding to the
+        given normalized poloidal flux points.
+        """
+        psi_n = np.asarray(psi_n)
+        scalar_input = psi_n.ndim == 0
+        psi_n = np.atleast_1d(psi_n)
+
+        PHI = self.q.integral(0, 1)
+        rho_tor = np.zeros(psi_n.shape)
+        for i in range(psi_n.size):
+            rho_tor[i] = self.q.integral(0, psi_n[i]) / PHI
+
+        rho_tor = np.sqrt(rho_tor)
+        return rho_tor[0] if scalar_input else rho_tor
+
+
     def process_data(self, data, override_psilim=False, plot_on_error=True):
         """
         Load data from the given EQDSK dictionary.

--- a/tools/eqget/EqBase.py
+++ b/tools/eqget/EqBase.py
@@ -444,14 +444,16 @@ class EqBase:
         """
         psi_n = np.asarray(psi_n)
         scalar_input = psi_n.ndim == 0
-        psi_n = np.atleast_1d(psi_n)
+        orig_shape = psi_n.shape
+        psi_n = np.atleast_1d(psi_n).ravel()
 
-        r_dist = np.zeros(psi_n.shape)
-        for i in range(psi_n.size):
-            R, _ = self.get_flux_surface(psi_n[i], theta=0)
+        r_dist = np.empty(psi_n.size)
+        for i, p in enumerate(psi_n):
+            R, _ = self.get_flux_surface(p, theta=0)
             r_dist[i] = R - self.R0
 
-        return r_dist[0] if scalar_input else r_dist
+        r_dist = r_dist.reshape(orig_shape)
+        return r_dist.item() if scalar_input else r_dist
 
 
     def get_rho_tor(self, psi_n):
@@ -461,15 +463,15 @@ class EqBase:
         """
         psi_n = np.asarray(psi_n)
         scalar_input = psi_n.ndim == 0
-        psi_n = np.atleast_1d(psi_n)
+        orig_shape = psi_n.shape
+        psi_n = np.atleast_1d(psi_n).ravel()
 
-        PHI = self.q.integral(0, 1)
-        rho_tor = np.zeros(psi_n.shape)
-        for i in range(psi_n.size):
-            rho_tor[i] = self.q.integral(0, psi_n[i]) / PHI
+        Qint = self.q.antiderivative()
+        PHI = Qint(1.0) - Qint(0.0)
+        Phi = Qint(psi_n) - Qint(0.0)
+        rho_tor = np.sqrt(Phi/PHI).reshape(orig_shape)
 
-        rho_tor = np.sqrt(rho_tor)
-        return rho_tor[0] if scalar_input else rho_tor
+        return rho_tor.item() if scalar_input else rho_tor
 
 
     def process_data(self, data, override_psilim=False, plot_on_error=True):


### PR DESCRIPTION
This pull request adds two helper functions to the ``EqBase`` class (used for e.g. the EQDSK equilibrium class). The helper functions are:

``get_r_distance(psi_n)`` -- evaluates the DREAM radius (distance from magnetic axis to flux surface along Z = Z0) for a given flux surface, or set of flux surfaces.

``get_rho_tor(psi_n)`` -- evaluates the normalized toroidal flux radius $\rho = \sqrt{\Phi/\Phi_{\rm lcfs}}$.