### PR TITLE
Fix animation bug with matplotlib 3.11

### DIFF
--- a/py/DREAM/Output/FluidQuantity.py
+++ b/py/DREAM/Output/FluidQuantity.py
@@ -123,7 +123,8 @@ class FluidQuantity(UnknownQuantity):
         ax.set_xlabel(r'$r/a$ (m)')
 
         # Create the animation
-        ani = animation.FuncAnimation(fig, update_ani, frames=self.time.size,
+        nframes = int(self.time.size)
+        ani = animation.FuncAnimation(fig, update_ani, frames=nframes,
             interval=speed, repeat_delay=repeat_delay, repeat=repeat, blit=blit,
             fargs=(self, ax, line, txt, keeplines, tfac, tunits[idx], keep))
 

--- a/py/DREAM/Output/KineticQuantity.py
+++ b/py/DREAM/Output/KineticQuantity.py
@@ -257,7 +257,8 @@ class KineticQuantity(UnknownQuantity):
         ax.set_xlabel(r'$r/a$ (m)')
 
         # Create the animation
-        ani = animation.FuncAnimation(fig, update_ani, frames=self.time.size,
+        nframes = int(self.time.size)
+        ani = animation.FuncAnimation(fig, update_ani, frames=nframes,
             interval=speed, repeat_delay=repeat_delay, repeat=repeat, blit=blit,
             fargs=(self, ax, lines, txt, favg, keeplines, tfac, tunits[idx], keep))
 


### PR DESCRIPTION
Fixes the bug reported in #531 which appears in matplotlib 3.11 and which causes ``FluidQuantity.animate()`` and ``KineticQuantity.animate()`` to no longer work.