### PR TITLE
Compton tritium bug

### DIFF
--- a/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticAvalancheRP.hpp
+++ b/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticAvalancheRP.hpp
@@ -1,0 +1,24 @@
+#ifndef _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_AVALANCHE_SOURCE_RP_HPP
+#define _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_AVALANCHE_SOURCE_RP_HPP
+
+#include "FVM/Equation/DiagonalQuadraticTerm.hpp"
+
+/**
+ * Implementation of an equation term which represents the total
+ * number of electrons created by the kinetic Rosenbluth-Putvinski source
+ */ 
+namespace DREAM {
+    class TotalElectronDensityFromKineticAvalancheRP : public FVM::DiagonalQuadraticTerm {
+    public:
+        real_t pLower, pUpper, scaleFactor;
+        TotalElectronDensityFromKineticAvalancheRP(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, real_t scaleFactor = 1.0) 
+            : FVM::DiagonalQuadraticTerm(g,u->GetUnknownID(OptionConstants::UQTY_N_TOT),u), pLower(pLower), pUpper(pUpper), scaleFactor(scaleFactor) {}
+
+        virtual void SetWeights() override {
+            for(len_t i = 0; i<grid->GetNCells(); i++)
+                weights[i] = scaleFactor * AvalancheSourceRP::EvaluateNormalizedTotalKnockOnNumber(pLower, pUpper);
+        }
+    };
+} 
+
+#endif/*_DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_AVALANCHE_SOURCE_RP_HPP*/

--- a/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticAvalancheRP.hpp
+++ b/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticAvalancheRP.hpp
@@ -2,6 +2,8 @@
 #define _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_AVALANCHE_SOURCE_RP_HPP
 
 #include "FVM/Equation/DiagonalQuadraticTerm.hpp"
+#include "DREAM/Equations/Kinetic/AvalancheSourceRP.hpp"
+#include "DREAM/Settings/OptionConstants.hpp"
 
 /**
  * Implementation of an equation term which represents the total

--- a/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.hpp
+++ b/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.hpp
@@ -11,8 +11,8 @@ namespace DREAM {
         : public FVM::DiagonalLinearTerm {
     private: 
         len_t limit;
-        gsl_integration_workspace * wp;
-        gsl_integration_workspace * wpOut;
+        gsl_integration_workspace * wp = nullptr;
+        gsl_integration_workspace * wpOut = nullptr;
     public:
         real_t pLower, pUpper;
         real_t integratedComptonSpectrum, C1, C2, C3;
@@ -21,6 +21,8 @@ namespace DREAM {
         real_t photonFlux;
         TotalElectronDensityFromKineticCompton(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::Interpolator1D *comptonPhotonFlux, 
                 real_t integratedComptonSpectrum, real_t C1, real_t C2, real_t C3, real_t scaleFactor = 1.0);
+        
+        ~TotalElectronDensityFromKineticCompton();
         
         virtual void Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler*) override;
 

--- a/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.hpp
+++ b/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.hpp
@@ -1,0 +1,31 @@
+#ifndef _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_COMPTON_HPP
+#define _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_COMPTON_HPP
+
+#include "FVM/Equation/DiagonalLinearTerm.hpp"
+#include "FVM/Interpolator1D.hpp"
+#include "DREAM/Settings/OptionConstants.hpp"
+#include "DREAM/Equations/Kinetic/ComptonSource.hpp"
+
+namespace DREAM {
+    class TotalElectronDensityFromKineticCompton 
+        : public FVM::DiagonalLinearTerm {
+    private: 
+        len_t limit;
+        gsl_integration_workspace * wp;
+        gsl_integration_workspace * wpOut;
+    public:
+        real_t pLower, pUpper;
+        real_t integratedComptonSpectrum, C1, C2, C3;
+        FVM::Interpolator1D *comptonPhotonFlux;
+        real_t scaleFactor;
+        real_t photonFlux;
+        TotalElectronDensityFromKineticCompton(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::Interpolator1D *comptonPhotonFlux, 
+                real_t integratedComptonSpectrum, real_t C1, real_t C2, real_t C3, real_t scaleFactor = 1.0);
+        
+        virtual void Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler*) override;
+
+        virtual void SetWeights() override;
+    };
+}
+
+#endif/*_DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_COMPTON_HPP*/

--- a/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.hpp
+++ b/include/DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.hpp
@@ -1,0 +1,41 @@
+#ifndef _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_TRITIUM_HPP
+#define _DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_TRITIUM_HPP
+
+#include "FVM/Equation/EquationTerm.hpp"
+#include "DREAM/IonHandler.hpp"
+#include "DREAM/Equations/Kinetic/TritiumSource.hpp"
+
+namespace DREAM {
+    class TotalElectronDensityFromKineticTritium 
+        : public FVM::EquationTerm {
+    public:
+        len_t id_nT;
+        len_t indT;
+        real_t pLower, pUpper, scaleFactor;
+        real_t *weights = nullptr;
+        bool hasBeenInitialized = false;
+        
+        
+        TotalElectronDensityFromKineticTritium(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, 
+            IonHandler *ions, len_t iIon, real_t scaleFactor = 1.0);
+        
+        ~TotalElectronDensityFromKineticTritium();
+
+        void AllocateWeights();
+        void DeallocateWeights();
+        void InitializeWeights();
+
+        void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override;
+
+        bool SetJacobianBlock(const len_t , const len_t derivId, FVM::Matrix *jac, const real_t*);
+        void SetMatrixElements(FVM::Matrix *mat, real_t* /*rhs*/) override;
+        void SetVectorElements(real_t *vec, const real_t *x) override;
+        void SetWeights();
+
+        virtual len_t GetNumberOfNonZerosPerRow() const override { return 1; }
+        virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return GetNumberOfNonZerosPerRow(); }
+        
+    };
+}
+
+#endif/*_DREAM_EQUATIONS_TOTAL_ELECTRON_DENSITY_FROM_KINETIC_TRITIUM_HPP*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,8 @@ set(dream_equations
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/SvenssonTransport.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/TotalElectronDensityTerm.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/TritiumRateTerm.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp"
+    "${PROJECT_SOURCE_DIR}/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/FrozenCurrentTransport.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Kinetic/AvalancheSourceRP.cpp"
     "${PROJECT_SOURCE_DIR}/src/Equations/Kinetic/BCIsotropicSourcePXi.cpp"

--- a/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp
+++ b/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp
@@ -1,0 +1,31 @@
+#include "DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.hpp"
+
+/**
+ * Implementation of an equation term which represents the total
+ * number of electrons created by the kinetic Compton scattering 
+ * source
+ */ 
+using namespace DREAM;
+
+TotalElectronDensityFromKineticCompton::TotalElectronDensityFromKineticCompton(
+    FVM::Grid* g, real_t pLower, real_t pUpper,
+    FVM::Interpolator1D *comptonPhotonFlux, real_t integratedComptonSpectrum, 
+    real_t C1, real_t C2, real_t C3, real_t scaleFactor
+) : FVM::DiagonalLinearTerm(g), pLower(pLower), pUpper(pUpper), 
+        integratedComptonSpectrum(integratedComptonSpectrum), C1(C1), C2(C2), C3(C3), comptonPhotonFlux(comptonPhotonFlux), scaleFactor(scaleFactor) 
+{
+    this->limit = 1000;
+    this->wp = gsl_integration_workspace_alloc(limit);
+    this->wpOut = gsl_integration_workspace_alloc(limit);
+}
+
+void TotalElectronDensityFromKineticCompton::Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler*) {
+    this->photonFlux = this->comptonPhotonFlux->Eval(t)[0];
+    this->DiagonalLinearTerm::Rebuild(0,0,nullptr);
+}
+void TotalElectronDensityFromKineticCompton::SetWeights() {
+    struct DREAM::ComptonSource::intparams params = {this->limit, this->wp, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
+    struct DREAM::ComptonSource::intparams paramsOut = {this->limit, this->wpOut, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
+    for(len_t i = 0; i<grid->GetNCells(); i++)
+        weights[i] = scaleFactor * this->photonFlux * ComptonSource::EvaluateTotalComptonNumber(pLower, &params, &paramsOut, pUpper);
+}

--- a/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp
+++ b/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp
@@ -20,9 +20,9 @@ TotalElectronDensityFromKineticCompton::TotalElectronDensityFromKineticCompton(
 }
 
 TotalElectronDensityFromKineticCompton::~TotalElectronDensityFromKineticCompton() {
-    if (wp)
+    if (wp != nullptr)
         gsl_integration_workspace_free(wp);
-    if (wpOut) 
+    if (wpOut != nullptr) 
         gsl_integration_workspace_free(wpOut);
 }
 

--- a/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp
+++ b/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.cpp
@@ -19,13 +19,24 @@ TotalElectronDensityFromKineticCompton::TotalElectronDensityFromKineticCompton(
     this->wpOut = gsl_integration_workspace_alloc(limit);
 }
 
+TotalElectronDensityFromKineticCompton::~TotalElectronDensityFromKineticCompton() {
+    if (wp)
+        gsl_integration_workspace_free(wp);
+    if (wpOut) 
+        gsl_integration_workspace_free(wpOut);
+}
+
 void TotalElectronDensityFromKineticCompton::Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler*) {
     this->photonFlux = this->comptonPhotonFlux->Eval(t)[0];
-    this->DiagonalLinearTerm::Rebuild(0,0,nullptr);
+    this->DiagonalLinearTerm::Rebuild(t,0,nullptr);
+    this->SetWeights();
 }
 void TotalElectronDensityFromKineticCompton::SetWeights() {
     struct DREAM::ComptonSource::intparams params = {this->limit, this->wp, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
     struct DREAM::ComptonSource::intparams paramsOut = {this->limit, this->wpOut, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
+
+    const real_t nCompton = ComptonSource::EvaluateTotalComptonNumber(pLower, &params, &paramsOut, pUpper);
+    const real_t w = scaleFactor * this->photonFlux * nCompton;
     for(len_t i = 0; i<grid->GetNCells(); i++)
-        weights[i] = scaleFactor * this->photonFlux * ComptonSource::EvaluateTotalComptonNumber(pLower, &params, &paramsOut, pUpper);
+        weights[i] = w;
 }

--- a/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.cpp
+++ b/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.cpp
@@ -1,0 +1,90 @@
+#include "DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.hpp"
+
+/**
+ * Implementation of an equation term which represents the total
+ * number of electrons created by the kinetic Tritium beta decay
+ * source
+ */ 
+using namespace DREAM;
+
+TotalElectronDensityFromKineticTritium::TotalElectronDensityFromKineticTritium(
+    FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, IonHandler *ions, len_t iIon, real_t scaleFactor
+) : FVM::EquationTerm(g), pLower(pLower), pUpper(pUpper), scaleFactor(scaleFactor) {
+
+    this->id_nT = u->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
+    
+    this->indT = ions->GetIndex(iIon, 0);
+}
+
+TotalElectronDensityFromKineticTritium::~TotalElectronDensityFromKineticTritium() {
+    this->DeallocateWeights();
+}
+
+void TotalElectronDensityFromKineticTritium::AllocateWeights() {
+    DeallocateWeights(); 
+
+    const len_t N = grid->GetNCells();
+    weights = new real_t[N];
+    for (len_t i = 0; i < N; i++)
+        weights[i] = 0;
+}
+
+void TotalElectronDensityFromKineticTritium::DeallocateWeights(){
+    if(weights!=nullptr) 
+    delete[] weights;
+}
+
+void TotalElectronDensityFromKineticTritium::InitializeWeights(){
+    AllocateWeights(); 
+    SetWeights();
+    hasBeenInitialized = false;
+}
+
+void TotalElectronDensityFromKineticTritium::Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) { 
+    if(!hasBeenInitialized){
+        InitializeWeights();
+        hasBeenInitialized = true;
+    } 
+}
+
+bool TotalElectronDensityFromKineticTritium::SetJacobianBlock(const len_t , const len_t derivId, FVM::Matrix *jac, const real_t*){
+    if(derivId != id_nT)
+        return false;
+    SetMatrixElements(jac, nullptr);
+    return true;
+}
+
+void TotalElectronDensityFromKineticTritium::SetMatrixElements(FVM::Matrix *mat, real_t* /*rhs*/) {
+    for(len_t iZ0=0; iZ0<2; iZ0++){
+        len_t offset = 0;
+        for(len_t ir=0; ir<nr; ir++){
+            for(len_t i=0; i<n1[ir]; i++){
+                for(len_t j=0; j<n2[ir]; j++){
+                    len_t ind = offset + n1[ir]*j + i;
+                    mat->SetElement(ind, (iZ0 + indT)*nr + ir, weights[ind]);
+                }
+            }
+            offset += n1[ir]*n2[ir];
+        }        
+    }
+}
+
+void TotalElectronDensityFromKineticTritium::SetVectorElements(real_t *vec, const real_t *x) {
+    for(len_t iZ0=0; iZ0<2; iZ0++){
+        len_t offset = 0; 
+        for(len_t ir=0; ir<nr; ir++){
+            for(len_t i=0; i<n1[ir]; i++){
+                for(len_t j=0; j<n2[ir]; j++){
+                    len_t ind = offset + n1[ir]*j + i;
+                    vec[ind] += weights[ind]*x[(iZ0 + indT)*nr + ir];
+                }
+            }
+            offset += n1[ir]*n2[ir];
+        }
+    }
+}
+
+void TotalElectronDensityFromKineticTritium::SetWeights() {
+    for(len_t i = 0; i<grid->GetNCells(); i++)
+        weights[i] = scaleFactor * TritiumSource::EvaluateTotalTritiumNumber(pLower, pUpper);
+}

--- a/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.cpp
+++ b/src/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.cpp
@@ -85,6 +85,7 @@ void TotalElectronDensityFromKineticTritium::SetVectorElements(real_t *vec, cons
 }
 
 void TotalElectronDensityFromKineticTritium::SetWeights() {
+    const real_t w = scaleFactor * TritiumSource::EvaluateTotalTritiumNumber(pLower, pUpper);
     for(len_t i = 0; i<grid->GetNCells(); i++)
-        weights[i] = scaleFactor * TritiumSource::EvaluateTotalTritiumNumber(pLower, pUpper);
+        weights[i] = w;
 }

--- a/src/Settings/Equations/f_hot.cpp
+++ b/src/Settings/Equations/f_hot.cpp
@@ -10,6 +10,7 @@
 #include "DREAM/EquationSystem.hpp"
 #include "FVM/Equation/ConstantParameter.hpp"
 #include "FVM/Equation/DiagonalQuadraticTerm.hpp"
+#include "FVM/Equation/DiagonalLinearTerm.hpp"
 #include "FVM/Equation/Operator.hpp"
 #include "FVM/Equation/IdentityTerm.hpp"
 #include "FVM/Equation/TransientTerm.hpp"
@@ -255,7 +256,7 @@ namespace DREAM {
 }
 
 namespace DREAM {
-    class TotalElectronDensityFromKineticCompton : public FVM::DiagonalQuadraticTerm {
+    class TotalElectronDensityFromKineticCompton : public FVM::DiagonalLinearTerm {
     private: 
         len_t limit;
         gsl_integration_workspace * wp;
@@ -266,9 +267,9 @@ namespace DREAM {
         FVM::Interpolator1D *comptonPhotonFlux;
         real_t scaleFactor;
         real_t photonFlux;
-        TotalElectronDensityFromKineticCompton(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, FVM::Interpolator1D *comptonPhotonFlux, 
+        TotalElectronDensityFromKineticCompton(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::Interpolator1D *comptonPhotonFlux, 
                 real_t integratedComptonSpectrum, real_t C1, real_t C2, real_t C3, real_t scaleFactor = 1.0) 
-            : FVM::DiagonalQuadraticTerm(g,u->GetUnknownID(OptionConstants::UQTY_N_TOT),u), pLower(pLower), pUpper(pUpper), 
+            : FVM::DiagonalLinearTerm(g), pLower(pLower), pUpper(pUpper), 
                 integratedComptonSpectrum(integratedComptonSpectrum), C1(C1), C2(C2), C3(C3), comptonPhotonFlux(comptonPhotonFlux), scaleFactor(scaleFactor) {
                 this->limit = 1000;
                 this->wp = gsl_integration_workspace_alloc(limit);
@@ -277,7 +278,7 @@ namespace DREAM {
         
         virtual void Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler*) override {
             this->photonFlux = this->comptonPhotonFlux->Eval(t)[0];
-            this->DiagonalQuadraticTerm::Rebuild(0,0,nullptr);
+            this->DiagonalLinearTerm::Rebuild(0,0,nullptr);
         }
         virtual void SetWeights() override {
             struct DREAM::ComptonSource::intparams params = {this->limit, this->wp, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
@@ -289,13 +290,93 @@ namespace DREAM {
 }
 
 namespace DREAM {
-    class TotalElectronDensityFromKineticTritium : public FVM::DiagonalQuadraticTerm {
+    class TotalElectronDensityFromKineticTritium : public FVM::EquationTerm { // TODO: Uppdatera med setMatrix och setVectorElements
     public:
+        len_t id_nT;
+        len_t indT;
         real_t pLower, pUpper, scaleFactor;
-        TotalElectronDensityFromKineticTritium(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, real_t scaleFactor = 1.0) 
-            : FVM::DiagonalQuadraticTerm(g,u->GetUnknownID(OptionConstants::UQTY_N_TOT),u), pLower(pLower), pUpper(pUpper), scaleFactor(scaleFactor) {}
+        real_t *weights = nullptr;
+        bool hasBeenInitialized = false;
+        
+        TotalElectronDensityFromKineticTritium(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, IonHandler *ions, len_t iIon, real_t scaleFactor = 1.0) 
+            : FVM::EquationTerm(g), pLower(pLower), pUpper(pUpper), scaleFactor(scaleFactor) {
 
-        virtual void SetWeights() override {
+            this->id_nT = u->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
+            
+            this->indT = ions->GetIndex(iIon, 0);
+        }
+        
+        ~TotalElectronDensityFromKineticTritium() {
+            this->DeallocateWeights();
+        }
+        void AllocateWeights() {
+            DeallocateWeights(); 
+
+            const len_t N = grid->GetNCells();
+            weights = new real_t[N];
+            for (len_t i = 0; i < N; i++)
+                weights[i] = 0;
+        }
+
+        void DeallocateWeights(){
+            if(weights!=nullptr) 
+            delete[] weights;
+        }
+        void InitializeWeights(){
+            AllocateWeights(); 
+            SetWeights();
+            hasBeenInitialized = false;
+        }
+        void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override { 
+            if(!hasBeenInitialized){
+                InitializeWeights();
+                hasBeenInitialized = true;
+            } 
+        }
+
+        bool SetJacobianBlock(const len_t , const len_t derivId, FVM::Matrix *jac, const real_t*){
+            if(derivId != id_nT)
+                return false;
+            SetMatrixElements(jac, nullptr);
+            return true;
+        }
+
+        void SetMatrixElements(FVM::Matrix *mat, real_t* /*rhs*/) override {
+            for(len_t iZ0=0; iZ0<2; iZ0++){
+                len_t offset = 0;
+                for(len_t ir=0; ir<nr; ir++){
+                    for(len_t i=0; i<n1[ir]; i++){
+                        for(len_t j=0; j<n2[ir]; j++){
+                            len_t ind = offset + n1[ir]*j + i;
+                            mat->SetElement(ind, (iZ0 + indT)*nr + ir, weights[ind]);
+                        }
+                    }
+                    offset += n1[ir]*n2[ir];
+                }        
+            }
+        }
+
+        /**
+        * Set vector elements.
+        */
+        void SetVectorElements(real_t *vec, const real_t *x) override {
+            for(len_t iZ0=0; iZ0<2; iZ0++){
+                len_t offset = 0; 
+                for(len_t ir=0; ir<nr; ir++){
+                    for(len_t i=0; i<n1[ir]; i++){
+                        for(len_t j=0; j<n2[ir]; j++){
+                            len_t ind = offset + n1[ir]*j + i;
+                            vec[ind] += weights[ind]*x[(iZ0 + indT)*nr + ir];
+                        }
+                    }
+                    offset += n1[ir]*n2[ir];
+                }
+            }
+        }
+
+        virtual len_t GetNumberOfNonZerosPerRow() const override { return 1; }
+        virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return GetNumberOfNonZerosPerRow(); }
+        virtual void SetWeights() {
             for(len_t i = 0; i<grid->GetNCells(); i++)
                 weights[i] = scaleFactor * TritiumSource::EvaluateTotalTritiumNumber(pLower, pUpper);
         }
@@ -382,7 +463,7 @@ void SimulationGenerator::ConstructEquation_S_particle_explicit(EquationSystem *
             throw NotImplementedException("f_hot: Kinetic compton source only implemented for p-xi grid.");
 
         Op_Ntot->AddTerm(
-            new TotalElectronDensityFromKineticCompton(fluidGrid, 0, pMax, unknowns, LoadDataT("eqsys/n_re/compton", s, "flux"), 
+            new TotalElectronDensityFromKineticCompton(fluidGrid, 0, pMax, LoadDataT("eqsys/n_re/compton", s, "flux"), 
                 s->GetReal("eqsys/n_re/compton/gammaInt"), s->GetReal("eqsys/n_re/compton/C1"), s->GetReal("eqsys/n_re/compton/C2"), 
                 s->GetReal("eqsys/n_re/compton/C3"), -1.0)
         );
@@ -404,11 +485,16 @@ void SimulationGenerator::ConstructEquation_S_particle_explicit(EquationSystem *
             );
         if(eqsys->GetHotTailGridType() != OptionConstants::MOMENTUMGRID_TYPE_PXI)
             throw NotImplementedException("f_hot: Kinetic tritium source only implemented for p-xi grid.");
+        
+        const len_t *ti = eqsys->GetIonHandler()->GetTritiumIndices();
+        for(len_t iT=0; iT<eqsys->GetIonHandler()->GetNTritiumIndices(); iT++){
+            Op_Ni->AddTerm(
+                new TotalElectronDensityFromKineticTritium(fluidGrid, 0, pLimTritium, unknowns, eqsys->GetIonHandler(), ti[iT], -1.0)
+            );
+        }
 
-        Op_Ni->AddTerm(
-            new TotalElectronDensityFromKineticTritium(fluidGrid, 0, pLimTritium, unknowns, -1.0)
-        );
-        desc += " - internal Tritium";
+        
+        desc += " - internal tritium";
     }
     // Add source terms
     bool signPositive = false;

--- a/src/Settings/Equations/f_hot.cpp
+++ b/src/Settings/Equations/f_hot.cpp
@@ -19,6 +19,9 @@
 #include "DREAM/Equations/Fluid/DensityFromDistributionFunction.hpp"
 #include "DREAM/Equations/Fluid/FreeElectronDensityTransientTerm.hpp"
 #include "DREAM/Equations/Fluid/KineticEquationTermIntegratedOverMomentum.hpp"
+#include "DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticAvalancheRP.hpp"
+#include "DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticCompton.hpp"
+#include "DREAM/Equations/Fluid/TotalElectronDensityFromKinetic/TotalElectronDensityFromKineticTritium.hpp"
 #include "DREAM/Equations/Kinetic/BCIsotropicSourcePXi.hpp"
 #include "DREAM/Equations/Kinetic/ComptonSource.hpp"
 #include "DREAM/Equations/Kinetic/ElectricFieldTerm.hpp"
@@ -238,152 +241,6 @@ void SimulationGenerator::ConstructEquation_f_hot_prescribed(
 }
 
 /**
- * Implementation of an equation term which represents the total
- * number of electrons created by the kinetic Rosenbluth-Putvinski source
- */
-namespace DREAM {
-    class TotalElectronDensityFromKineticAvalanche : public FVM::DiagonalQuadraticTerm {
-    public:
-        real_t pLower, pUpper, scaleFactor;
-        TotalElectronDensityFromKineticAvalanche(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, real_t scaleFactor = 1.0) 
-            : FVM::DiagonalQuadraticTerm(g,u->GetUnknownID(OptionConstants::UQTY_N_TOT),u), pLower(pLower), pUpper(pUpper), scaleFactor(scaleFactor) {}
-
-        virtual void SetWeights() override {
-            for(len_t i = 0; i<grid->GetNCells(); i++)
-                weights[i] = scaleFactor * AvalancheSourceRP::EvaluateNormalizedTotalKnockOnNumber(pLower, pUpper);
-        }
-    };
-}
-
-namespace DREAM {
-    class TotalElectronDensityFromKineticCompton : public FVM::DiagonalLinearTerm {
-    private: 
-        len_t limit;
-        gsl_integration_workspace * wp;
-        gsl_integration_workspace * wpOut;
-    public:
-        real_t pLower, pUpper;
-        real_t integratedComptonSpectrum, C1, C2, C3;
-        FVM::Interpolator1D *comptonPhotonFlux;
-        real_t scaleFactor;
-        real_t photonFlux;
-        TotalElectronDensityFromKineticCompton(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::Interpolator1D *comptonPhotonFlux, 
-                real_t integratedComptonSpectrum, real_t C1, real_t C2, real_t C3, real_t scaleFactor = 1.0) 
-            : FVM::DiagonalLinearTerm(g), pLower(pLower), pUpper(pUpper), 
-                integratedComptonSpectrum(integratedComptonSpectrum), C1(C1), C2(C2), C3(C3), comptonPhotonFlux(comptonPhotonFlux), scaleFactor(scaleFactor) {
-                this->limit = 1000;
-                this->wp = gsl_integration_workspace_alloc(limit);
-                this->wpOut = gsl_integration_workspace_alloc(limit);
-            }
-        
-        virtual void Rebuild(const real_t t, const real_t, FVM::UnknownQuantityHandler*) override {
-            this->photonFlux = this->comptonPhotonFlux->Eval(t)[0];
-            this->DiagonalLinearTerm::Rebuild(0,0,nullptr);
-        }
-        virtual void SetWeights() override {
-            struct DREAM::ComptonSource::intparams params = {this->limit, this->wp, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
-            struct DREAM::ComptonSource::intparams paramsOut = {this->limit, this->wpOut, this->integratedComptonSpectrum, this->C1, this->C2, this->C3};
-            for(len_t i = 0; i<grid->GetNCells(); i++)
-                weights[i] = scaleFactor * this->photonFlux * ComptonSource::EvaluateTotalComptonNumber(pLower, &params, &paramsOut, pUpper);
-        }
-    };
-}
-
-namespace DREAM {
-    class TotalElectronDensityFromKineticTritium : public FVM::EquationTerm { // TODO: Uppdatera med setMatrix och setVectorElements
-    public:
-        len_t id_nT;
-        len_t indT;
-        real_t pLower, pUpper, scaleFactor;
-        real_t *weights = nullptr;
-        bool hasBeenInitialized = false;
-        
-        TotalElectronDensityFromKineticTritium(FVM::Grid* g, real_t pLower, real_t pUpper, FVM::UnknownQuantityHandler *u, IonHandler *ions, len_t iIon, real_t scaleFactor = 1.0) 
-            : FVM::EquationTerm(g), pLower(pLower), pUpper(pUpper), scaleFactor(scaleFactor) {
-
-            this->id_nT = u->GetUnknownID(OptionConstants::UQTY_ION_SPECIES);
-            
-            this->indT = ions->GetIndex(iIon, 0);
-        }
-        
-        ~TotalElectronDensityFromKineticTritium() {
-            this->DeallocateWeights();
-        }
-        void AllocateWeights() {
-            DeallocateWeights(); 
-
-            const len_t N = grid->GetNCells();
-            weights = new real_t[N];
-            for (len_t i = 0; i < N; i++)
-                weights[i] = 0;
-        }
-
-        void DeallocateWeights(){
-            if(weights!=nullptr) 
-            delete[] weights;
-        }
-        void InitializeWeights(){
-            AllocateWeights(); 
-            SetWeights();
-            hasBeenInitialized = false;
-        }
-        void Rebuild(const real_t, const real_t, FVM::UnknownQuantityHandler*) override { 
-            if(!hasBeenInitialized){
-                InitializeWeights();
-                hasBeenInitialized = true;
-            } 
-        }
-
-        bool SetJacobianBlock(const len_t , const len_t derivId, FVM::Matrix *jac, const real_t*){
-            if(derivId != id_nT)
-                return false;
-            SetMatrixElements(jac, nullptr);
-            return true;
-        }
-
-        void SetMatrixElements(FVM::Matrix *mat, real_t* /*rhs*/) override {
-            for(len_t iZ0=0; iZ0<2; iZ0++){
-                len_t offset = 0;
-                for(len_t ir=0; ir<nr; ir++){
-                    for(len_t i=0; i<n1[ir]; i++){
-                        for(len_t j=0; j<n2[ir]; j++){
-                            len_t ind = offset + n1[ir]*j + i;
-                            mat->SetElement(ind, (iZ0 + indT)*nr + ir, weights[ind]);
-                        }
-                    }
-                    offset += n1[ir]*n2[ir];
-                }        
-            }
-        }
-
-        /**
-        * Set vector elements.
-        */
-        void SetVectorElements(real_t *vec, const real_t *x) override {
-            for(len_t iZ0=0; iZ0<2; iZ0++){
-                len_t offset = 0; 
-                for(len_t ir=0; ir<nr; ir++){
-                    for(len_t i=0; i<n1[ir]; i++){
-                        for(len_t j=0; j<n2[ir]; j++){
-                            len_t ind = offset + n1[ir]*j + i;
-                            vec[ind] += weights[ind]*x[(iZ0 + indT)*nr + ir];
-                        }
-                    }
-                    offset += n1[ir]*n2[ir];
-                }
-            }
-        }
-
-        virtual len_t GetNumberOfNonZerosPerRow() const override { return 1; }
-        virtual len_t GetNumberOfNonZerosPerRow_jac() const override { return GetNumberOfNonZerosPerRow(); }
-        virtual void SetWeights() {
-            for(len_t i = 0; i<grid->GetNCells(); i++)
-                weights[i] = scaleFactor * TritiumSource::EvaluateTotalTritiumNumber(pLower, pUpper);
-        }
-    };
-}
-
-/**
  * Build the equation for S_particle, which contains the rate at which the total local free electron density changes
  * (i.e. by ionization, transport of hot electrons, runaway sources).
  * Uses the implicit method, where the source amplitude is indirectly set by requiring
@@ -449,7 +306,7 @@ void SimulationGenerator::ConstructEquation_S_particle_explicit(EquationSystem *
         real_t pCutoff = s->GetReal("eqsys/n_re/pCutAvalanche");
         real_t pMax = hottailGrid->GetMomentumGrid(0)->GetP1_f(hottailGrid->GetNp1(0));
         Op_Nre->AddTerm(
-            new TotalElectronDensityFromKineticAvalanche(fluidGrid, pCutoff, pMax, unknowns, -1.0)
+            new TotalElectronDensityFromKineticAvalancheRP(fluidGrid, pCutoff, pMax, unknowns, -1.0)
         );
         desc += " - internal avalanche";
     }


### PR DESCRIPTION
The classes to evaluate densities of electrons to remove to compensate for kinetic Compton and Tritium where derived from the wrong class, meaning they gave the wrong numbers. I have fixed this, and also moved out the classes from the f_hot-file for a cleaner code