### PR TITLE
Throw on an unknown wall loop-voltage equation type

### DIFF
--- a/src/Settings/Equations/psi_p.cpp
+++ b/src/Settings/Equations/psi_p.cpp
@@ -372,7 +372,7 @@ void SimulationGenerator::ConstructEquation_psi_wall_selfconsistent(
             eqsys->SetInitialValue(id_I_w, &I_wall_0);
         }
     } else
-        FVM::FVMException("Unrecognized equation type for '%s': %d.",
+        throw FVM::FVMException("Unrecognized equation type for '%s': %d.",
                 OptionConstants::UQTY_V_LOOP_WALL, type);
     // Set equation dpsi_w/dt = V_loop_wall
     FVM::Operator *Op_psi_wall_1 = new FVM::Operator(scalarGrid);


### PR DESCRIPTION
## Summary

Throw the existing `FVMException` when an unknown wall loop-voltage equation type is supplied.

## Behavior being checked

While testing an invalid equation type in `ConstructEquation_psi_wall_selfconsistent()`, I noticed that the exception was constructed but not thrown. Setup then continued and terminated later with `std::out_of_range`, which hid the intended diagnostic.

With this change, the same input stops at:

```text
Unrecognized equation type for 'V_loop_w': 999.
```

## Validation

- `git diff --check` — exit 0
- `cmake --build build -j 10` — exit 0
- `./build/iface/dreami invalid-wall-bc.h5` — exit 1 at the expected `FVMException`
- `./build/tests/cxx/dreamtests all` — exit 0, 13 of 13 tests completed successfully
- `tests/physics/runtests.py all` — exit 255 with the same 16 low-field avalanche reference mismatches as `upstream/master`
- `./testDREAM.sh` — exit 1 before building on macOS because the script reads `/proc/cpuinfo`; the same baseline failure occurs on `upstream/master`

## Scope/non-goals

This only adds the missing `throw`. It does not change the wall model, boundary conditions, or equation construction.

## Issue reference

No issue. Searches for `unknown wall loop voltage` and `psi_p FVMException` found no duplicate issue or pull request. Issues #307 and #487 concern separate Ampère/Faraday model changes.
