### PR TITLE
Align J_DOT_GRADPHI with the stored R0 normalization

### DIFF
--- a/src/Settings/Equations/j_tot.cpp
+++ b/src/Settings/Equations/j_tot.cpp
@@ -73,7 +73,7 @@ void SimulationGenerator::ConstructEquation_j_tot_prescribed(
 
 	// Re-scale if not j_parallel
 	if (prof_type == OptionConstants::CURRENT_PROFILE_TYPE_J_DOT_GRADPHI) {
-		// Conversion from <j . grad phi>  -->  j_||
+		// Convert <j_parallel . grad phi> to DREAM's j_parallel at B=Bmin.
 		const len_t nr_f = rGrid->GetNr()+1;
 		const real_t *r_f = rGrid->GetR_f();
 		const real_t *GR0_f = rGrid->GetBTorG_f();
@@ -99,7 +99,7 @@ void SimulationGenerator::ConstructEquation_j_tot_prescribed(
 
 		for (len_t ir = 0; ir < dd->nr; ir++) {
 			const real_t r = dd->r[ir];
-			real_t geom = iBmin->Eval(r)[0] * R0*R0*R0 / (iGR0->Eval(r)[0] * iR02OverR2->Eval(r)[0]);
+			real_t geom = iBmin->Eval(r)[0] * R0 / (iGR0->Eval(r)[0] * iR02OverR2->Eval(r)[0]);
 
 			for (len_t i = 0; i < dd->nt; i++)
 				dd->x[i*(dd->nr)+ir] *= geom;
@@ -227,7 +227,7 @@ void SimulationGenerator::ConstructEquation_j_tot_consistent(
 
 		// Need to convert to j_|| first?
 		if (prof_type == OptionConstants::CURRENT_PROFILE_TYPE_J_DOT_GRADPHI) {
-			// Conversion from <j . grad phi>  -->  j_||
+			// Convert <j_parallel . grad phi> to DREAM's j_parallel at B=Bmin.
 			const len_t nr = rGrid->GetNr();
 			const real_t *GR0 = rGrid->GetBTorG();
 			const real_t *R02OverR2 = rGrid->GetFSA_1OverR2();
@@ -241,7 +241,7 @@ void SimulationGenerator::ConstructEquation_j_tot_consistent(
 				);
 
 			for (len_t ir = 0; ir < nr; ir++)
-				johm_init[ir] *= Bmin[ir] * R0*R0*R0 / (GR0[ir] * R02OverR2[ir]);
+				johm_init[ir] *= Bmin[ir] * R0 / (GR0[ir] * R02OverR2[ir]);
 
 		} else if (prof_type == OptionConstants::CURRENT_PROFILE_TYPE_JTOR_OVER_R) {
 			// Conversion from <j . B> / <B . grad phi>  -->  j_||


### PR DESCRIPTION
## Summary

Use one power of `R0` when converting prescribed and initial `J_DOT_GRADPHI` profiles to DREAM's parallel-current amplitude at `B=Bmin`.

## Normalization being checked

DREAM's radial current unknown is

```math
j_{\mathrm{DREAM}}
= \frac{j_\parallel}{B/B_{\min}}
= B_{\min}\frac{j_\parallel}{B}.
```

For a parallel current,

```math
\left\langle \boldsymbol{j}_\parallel\cdot\nabla\phi\right\rangle
= \frac{j_{\mathrm{DREAM}}}{B_{\min}}
  \left\langle \boldsymbol{B}\cdot\nabla\phi\right\rangle,
```

so

```math
j_{\mathrm{DREAM}}
= \left\langle \boldsymbol{j}_\parallel\cdot\nabla\phi\right\rangle
  \frac{B_{\min}}
  {\left\langle \boldsymbol{B}\cdot\nabla\phi\right\rangle}.
```

For axisymmetric geometry,

```math
\left\langle \boldsymbol{B}\cdot\nabla\phi\right\rangle
= G\left\langle \frac{1}{R^2}\right\rangle.
```

The radial grid stores

```math
\mathrm{GR0}=\frac{G}{R_0},
\qquad
\mathrm{FSA\_R02OverR2}
=R_0^2\left\langle\frac{1}{R^2}\right\rangle.
```

Under these definitions,

```math
\left\langle \boldsymbol{B}\cdot\nabla\phi\right\rangle
= \frac{\mathrm{GR0}\,\mathrm{FSA\_R02OverR2}}{R_0},
```

and the conversion becomes

```math
j_{\mathrm{DREAM}}
= \left\langle \boldsymbol{j}_\parallel\cdot\nabla\phi\right\rangle
  \frac{B_{\min}R_0}
  {\mathrm{GR0}\,\mathrm{FSA\_R02OverR2}}.
```

The prescribed and initial-current paths currently use `R0^3`. This change uses `R0` in both paths so that the conversion follows the normalization of the stored geometry quantities.

## Validation

- `git diff --check` — exit 0
- `cmake --build build -j 10` — exit 0 with Apple Clang 17 and OpenMPI
- `tests/physics/runtests.py amperefaraday` — exit 0
- `build/tests/cxx/dreamtests all` — exit 0, 13 of 13 tests completed successfully
- `tests/physics/runtests.py all` — exit 255 with the same 16 low-field avalanche reference mismatches as `upstream/master`
- `./testDREAM.sh` — exit 1 before building on macOS because the script reads `/proc/cpuinfo`; the same baseline failure occurs on `upstream/master`

## Scope/non-goals

This changes only the two `J_DOT_GRADPHI` conversion factors and their nearby comments. It does not change `JTOR_OVER_R`, `Ip0` normalization, Ampère/Faraday equations, conductivity models, or tests.

## Issue reference

No issue.
