### PR TITLE
Fix angle-resolution setter names in the stellarator frontend

### DIFF
--- a/py/DREAM/Settings/RadialGrid.py
+++ b/py/DREAM/Settings/RadialGrid.py
@@ -231,11 +231,11 @@ class RadialGrid(PrescribedScalarParameter):
     def setNphi(self, nphi):
         """
         (Analytic toroidal, numerical and stellarator)
-        Set the number of grid points to use for the poloidal grid on which bounce
+        Set the number of grid points to use for the toroidal grid on which bounce
         averages are calculated.
         """
         if nphi <= 0:
-            raise DREAMException("RadialGrid: Invalid value assigned to 'ntheta': {}".format(ntheta))
+            raise DREAMException("RadialGrid: Invalid value assigned to 'nphi': {}".format(nphi))
 
         self.nphi = nphi
 
@@ -249,7 +249,7 @@ class RadialGrid(PrescribedScalarParameter):
         if ntheta <= 0:
             raise DREAMException(f"RadialGrid: Invalid value assigned to 'ntheta_out': {ntheta}.")
 
-        self.ntheta_out = ntheta_out
+        self.ntheta_out = ntheta
 
 
     def setShapeParameter(self, name, data, r=0.0):


### PR DESCRIPTION
## Summary

Fix two undefined variable names in the stellarator angle-resolution setters.

## Behavior being checked

- `setNphi()` now reports invalid `nphi` values and describes the toroidal grid.
- `setNthetaOut()` now assigns its `ntheta` argument to `ntheta_out`.

This avoids `NameError` for invalid `setNphi()` input and valid `setNthetaOut()` input.

## Validation

- `python -m compileall -q py/DREAM` — exit 0
- direct valid/invalid setter smoke — exit 0
- `git diff --check` — exit 0
- C++ tests — exit 0, 13 of 13 tests completed successfully
- the full stellarator physics suite retains its pre-existing NumPy scalar-conversion failures

## Scope/non-goals

No settings-schema, default-resolution, geometry, or C++ changes.

## Issue reference

No issue; duplicate searches for `setNphi` and `setNthetaOut` returned no matches.
