### PR TITLE
Release stellarator geometry allocations on rebuild and destruction

### DIFF
--- a/fvm/Grid/Stellarator/RadialGridGeneratorStellarator.cpp
+++ b/fvm/Grid/Stellarator/RadialGridGeneratorStellarator.cpp
@@ -75,6 +75,8 @@ void RadialGridGeneratorStellarator::RebuildJacobians(RadialGridStellarator *rGr
     );
     delete [] phi_Bmin;
     delete [] phi_Bmax;
+    delete [] phi_Bmin_f;
+    delete [] phi_Bmax_f;
 }
 
 // The remaining functions are related to determining theta_Bmin and theta_Bmax

--- a/fvm/Grid/Stellarator/RadialGridStellarator.cpp
+++ b/fvm/Grid/Stellarator/RadialGridStellarator.cpp
@@ -219,6 +219,7 @@ void RadialGridStellarator::RebuildFluxSurfaceAveragedQuantities(){
             GSL_func.params = &params;
             real_t epsabs = 0, epsrel = 1e-4, lim = gsl_adaptive->limit, error;
             gsl_integration_qag(&GSL_func, a, b, epsabs, epsrel, lim, GSL_INTEG_GAUSS41, gsl_adaptive, &psiExtraAtWall, &error);
+            gsl_integration_workspace_free(gsl_adaptive);
         } else 
             psiExtraAtWall = 0.;
     } else {
@@ -349,6 +350,7 @@ void RadialGridStellarator::DeallocateFSAvg(){
     if (this->FSA_BdotGradphi == nullptr)
         return;
 
+    // RadialGridStellarator owns all arrays installed by InitializeFSAvg().
     delete [] this->FSA_B;
     this->FSA_B = nullptr;
     delete [] this->FSA_B_f;
@@ -359,12 +361,24 @@ void RadialGridStellarator::DeallocateFSAvg(){
     this->FSA_B2_f = nullptr;
     delete [] this->effectivePassingFraction;
     this->effectivePassingFraction = nullptr;
+    delete [] this->effectivePassingFraction_f;
+    this->effectivePassingFraction_f = nullptr;
+    delete [] this->FSA_1OverB;
+    this->FSA_1OverB = nullptr;
+    delete [] this->FSA_1OverB_f;
+    this->FSA_1OverB_f = nullptr;
 
     delete [] this->FSA_BdotGradphi;
+    this->FSA_BdotGradphi = nullptr;
     delete [] this->FSA_BdotGradphi_f;
+    this->FSA_BdotGradphi_f = nullptr;
     delete [] this->FSA_gttOverJ2;
+    this->FSA_gttOverJ2 = nullptr;
     delete [] this->FSA_gttOverJ2_f;
+    this->FSA_gttOverJ2_f = nullptr;
     delete [] this->FSA_gtpOverJ2;
+    this->FSA_gtpOverJ2 = nullptr;
     delete [] this->FSA_gtpOverJ2_f;
+    this->FSA_gtpOverJ2_f = nullptr;
 }
 


### PR DESCRIPTION
## Summary

- Release the radial-face magnetic-extremum arrays after rebuilding the Jacobians.
- Complete cleanup and pointer nulling for arrays installed by `InitializeFSAvg()`.
- Free the local GSL integration workspace after the wall integral.

## Behavior being checked

These allocations are owned by the functions or object that create and install them. Pairing each allocation with cleanup prevents storage from being retained across stellarator geometry rebuilds or destruction; it does not alter the computed geometry.

## Validation

- On macOS: configured and built DREAM, ran all 13 C++ test groups, compiled `py/DREAM`, and ran a numerical stellarator case successfully.
- Apple `leaks` comparison on the same case: 513 allocations / 134688 bytes reported before and 505 allocations / 134448 bytes after. Other existing leak families remain.
- On an independent Linux computer from a fresh `upstream/stellarator` clone: built DREAM, ran the numerical stellarator case, and ran `./testDREAM.sh` successfully, including all C++ and physics/Python tests.
- Linux AddressSanitizer comparison on the same case: 927 allocations / 106476 bytes reported before and 919 allocations / 106332 bytes after. No new sanitizer stack was introduced; other existing leak families remain.

## Scope/non-goals

This PR does not change quadrature, wall equations, extrapolation, or the ownership architecture.

## Issue reference

No linked issue. Searches for `stellarator memory leak`, `RebuildFluxSurfaceAveragedQuantities`, and `effectivePassingFraction_f` found no existing issue or PR.
