### PR TITLE
Clamp BOverBmin value in KnockOnUtilities.cpp

### DIFF
--- a/src/Equations/KnockOnUtilities.cpp
+++ b/src/Equations/KnockOnUtilities.cpp
@@ -213,6 +213,8 @@ bool KnockOnUtilities::CheckIfReachableAndSetGeometricQuantities(
         ir, theta, B_, Jacobian, ROverR0_, NablaR2_, FVM::FLUXGRIDTYPE_DISTRIBUTION
     );
     BOverBmin = B_ / Bmin;
+    // Clamp BOverBmin to avoid issues with numerical geometry
+    std::max(BOverBmin, 1.0);    
     xi0Cutoff = sqrt(1 - 1 / BOverBmin);
 
     if (xi0Cutoff >= fabs(xi01)) {

--- a/src/Equations/KnockOnUtilities.cpp
+++ b/src/Equations/KnockOnUtilities.cpp
@@ -214,7 +214,7 @@ bool KnockOnUtilities::CheckIfReachableAndSetGeometricQuantities(
     );
     BOverBmin = B_ / Bmin;
     // Clamp BOverBmin to avoid issues with numerical geometry
-    std::max(BOverBmin, 1.0);    
+    BOverBmin = std::max(BOverBmin, 1.0);
     xi0Cutoff = sqrt(1 - 1 / BOverBmin);
 
     if (xi0Cutoff >= fabs(xi01)) {


### PR DESCRIPTION
Clamp BOverBmin to avoid issues with numerical geometry where one can get B/Bmin ~ (1 - epsilon), making the sqrt() argument negative, and causing a crash.

Now the fix is at the correct place:
```cxx
    BOverBmin = B_ / Bmin;
    // Clamp BOverBmin to avoid issues with numerical geometry
    BOverBmin = std::max(BOverBmin, 1.0);
    xi0Cutoff = sqrt(1 - 1 / BOverBmin);
```