### PR TITLE
Change trapz -> trapezoid

### DIFF
--- a/py/DREAM/Output/ElectricField.py
+++ b/py/DREAM/Output/ElectricField.py
@@ -76,7 +76,7 @@ class ElectricField(FluidQuantity):
         :param int t: Index of time to calculate transferred momentum until.
         """
         if np.isscalar(t):
-            p = np.trapz(self[fromt:t], self.grid.t[fromt:t], axis=0)
+            p = np.trapezoid(self[fromt:t], self.grid.t[fromt:t], axis=0)
         else:
             p = []
             t = np.asarray(t)
@@ -85,7 +85,7 @@ class ElectricField(FluidQuantity):
                 raise OutputException("Unrecognized dimensions of time index: {}.".format(t.ndim))
 
             for time in t:
-                p.append(np.trapz(self[fromt:time], self.grid.t[fromt:time], axis=0))
+                p.append(np.trapezoid(self[fromt:time], self.grid.t[fromt:time], axis=0))
 
             p = np.array(p)
 

--- a/py/DREAM/Output/ElectricField.py
+++ b/py/DREAM/Output/ElectricField.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import scipy.constants
+from packaging import version
 
 from . FluidQuantity import FluidQuantity
 from . OutputException import OutputException
@@ -76,7 +77,10 @@ class ElectricField(FluidQuantity):
         :param int t: Index of time to calculate transferred momentum until.
         """
         if np.isscalar(t):
-            p = np.trapezoid(self[fromt:t], self.grid.t[fromt:t], axis=0)
+            if version.parse(np.__version__) >= version.parse('2.0.0'):
+                p = np.trapezoid(self[fromt:t], self.grid.t[fromt:t], axis=0)
+            else:
+                p = np.trapz(self[fromt:t], self.grid.t[fromt:t], axis=0)
         else:
             p = []
             t = np.asarray(t)
@@ -85,7 +89,10 @@ class ElectricField(FluidQuantity):
                 raise OutputException("Unrecognized dimensions of time index: {}.".format(t.ndim))
 
             for time in t:
-                p.append(np.trapezoid(self[fromt:time], self.grid.t[fromt:time], axis=0))
+                if version.parse(np.__version__) >= version.parse('2.0.0'):
+                    p.append(np.trapezoid(self[fromt:time], self.grid.t[fromt:time], axis=0))
+                else:
+                    p.append(np.trapz(self[fromt:time], self.grid.t[fromt:time], axis=0))
 
             p = np.array(p)
 


### PR DESCRIPTION
Add support for the newer ``numpy.trapezoid`` function. This function was added in numpy 2.0.0, while ``trapz`` was at the same time deprecated. The ``trapz`` function was ultimately removed in numpy 2.4.0. This fix ensures that trapezoidal integration works across all versions of numpy.