### PR TITLE
Fix T_cold.plotEnergyBalance(log=True)

### DIFF
--- a/py/DREAM/Output/Temperature.py
+++ b/py/DREAM/Output/Temperature.py
@@ -29,7 +29,7 @@ class Temperature(FluidQuantity):
             q = self.output.other.fluid[o]
 
             if integrate:
-                ax = q.plotIntegral(ax=ax, show=show)
+                ax = q.plotIntegral(ax=ax, show=show, log=log)
             else:
                 ax = q.plot(r=r, t=t, ax=ax, show=False, log=log)
 


### PR DESCRIPTION
Previously, the log argument was not passed to plotIntegral(), so that the plot did not render as expected. This pull request fixes this bug.