### PR TITLE
Fixed bug that resulted in seg fault for Kiramov BC

### DIFF
--- a/include/DREAM/Equations/Fluid/KiramovBoundaryHeatTransport.hpp
+++ b/include/DREAM/Equations/Fluid/KiramovBoundaryHeatTransport.hpp
@@ -52,7 +52,7 @@ namespace DREAM {
             }
 
             ~KiramovBoundaryHeatTransportBC(){
-                delete [] this->transportOperator;
+                delete this->transportOperator;
             }
 
     };


### PR DESCRIPTION
When I ran a simulation with the Kiramov BC on master, I had a segmentation fault due to how the transportOperator-object was deleted. This fixed it